### PR TITLE
Fix #27, Add library support to application checksum computing function.

### DIFF
--- a/docs/cs_FunctionalRequirements.csv
+++ b/docs/cs_FunctionalRequirements.csv
@@ -63,26 +63,26 @@ a) Generate an event message containing the baseline CRC
 b) Set the Recompute In Progress Flag to FALSE",Gives the ground indication not only that the CRC baseline was calculated but what the value is
 CS3009.2,CS3009.2,"If CS is already processing a Recompute CRC command or a One Shot CRC command, CS shall reject the command.",Only able to process one recompute one at a time
 CS3010,CS3010,"Upon receipt of a Report cFE code segment CRC command, CS shall send an event message containing the baseline cFE code segment CRC.",Provides the ability to view the cFE code segment baseline CRC
-CS4000,CS4000,"Checksum shall calculate CRCs for each Table-Defined Application's code segment and compare them against the corresponding Application's baseline code segment CRC if:
+CS4000,CS4000,"Checksum shall calculate CRCs for each Table-Defined Application or Library's code segment and compare them against the corresponding Application's baseline code segment CRC if:
 a)       Checksumming (as a whole) is Enabled
 b)       App code segment checksumming is Enabled
-c)       Checksumming of the individual Application Code Segment is Enabled",Need to verify each Application’s code segment. Note that CS depends on ES to provide the information as to which applications are running
-CS4000.1,CS4000.1,"If the Application's code segment CRC is not equal to the corresponding  Application's baseline code segment CRC, CS shall increment the Application Code Segment CRC Miscompare Counter and send an event message.","In practice, when a new application is being loaded, checksumming of Application code segments should be disabled prior to the load and then enabled after the load."
-CS4000.2,CS4000.2,"If the table-defined Application code segment is invalid, CS shall send an event message and skip that Application code segment.",This may be a result of an invalid Application code segment table or a deleted application.
-CS4001,CS4001,"Upon receipt of a Enable Application checksumming command, CS shall enable checksumming of all Application Code segments.",Enable checksumming of all of the Application code segments defined in the table
-CS4002,CS4002,"Upon receipt of a Disable Application checksumming command, CS shall Disable checksumming of all Application Code segments.",Disable checksumming of all of the Application code segments defined in the table
-CS4003,CS4003,"Upon receipt of a Enable Application code segment command, CS shall enable checksumming of the command-specified Application.",Enable checksumming of a particular Application code segment
-CS4004,CS4004,"Upon receipt of a Disable Application code segment command, CS shall Disable checksumming of the command-specified Application.",Disable checksumming of a particular Application Code segment. This may be particularly useful when reloading an existing application.
+c)       Checksumming of the individual Application or Library Code Segment is Enabled",Need to verify each Application or Library’s code segment. Note that CS depends on ES to provide the information as to which applications are running
+CS4000.1,CS4000.1,"If the Application or Library's code segment CRC is not equal to the corresponding  Application or Library's baseline code segment CRC, CS shall increment the Application Code Segment CRC Miscompare Counter and send an event message.","In practice, when a new application or library is being loaded, checksumming of Application or Library code segments should be disabled prior to the load and then enabled after the load."
+CS4000.2,CS4000.2,"If the table-defined Application or Library code segment is invalid, CS shall send an event message and skip that Application or Library code segment.",This may be a result of an invalid Application or Library code segment table or a deleted application.
+CS4001,CS4001,"Upon receipt of a Enable Application checksumming command, CS shall enable checksumming of all Application and Library Code segments.",Enable checksumming of all of the Application and Library code segments defined in the table
+CS4002,CS4002,"Upon receipt of a Disable Application checksumming command, CS shall Disable checksumming of all Application and Library Code segments.",Disable checksumming of all of the Application and Library code segments defined in the table
+CS4003,CS4003,"Upon receipt of a Enable Application code segment command, CS shall enable checksumming of the command-specified Application or Library.",Enable checksumming of a particular Application or Library code segment
+CS4004,CS4004,"Upon receipt of a Disable Application code segment command, CS shall Disable checksumming of the command-specified Application or Library.",Disable checksumming of a particular Application or Library Code segment. This may be particularly useful when reloading an existing application.
 CS4005,CS4005,"Upon receipt of a Recompute Application Code Segment CRC command, CS shall:
-a) Recompute the baseline CRC for the Application
-b) Set the Recompute In Progress Flag to TRUE",Would be used after an Application code segment is updated in order to regenerate the baseline
+a) Recompute the baseline CRC for the Application or Library
+b) Set the Recompute In Progress Flag to TRUE",Would be used after an Application or Library code segment is updated in order to regenerate the baseline
 CS4005.1,CS4005.1,"Once the baseline CRC is computed, CS shall:
 a) Generate an event message containing the baseline CRC
 b) Set the Recompute In Progress Flag to FALSE",Gives the ground indication not only that the CRC baseline was calculated but what the value is.
 CS4005.2,CS4005.2,"If CS is already processing a Recompute CRC command or a One Shot CRC command, CS shall reject the command.",Can only support one recompute CRC at a time
-CS4006,CS4006,"Upon receipt of a Report Application code segment CRC command, CS shall send an event message containing the baseline Application code segment CRC",Provides the ground with the baseline being used.
-CS4007,CS4007,"If the command-specified Application is invalid (for any Application Code Segment command where the Application is a command argument, CS shall reject the command and send an event message",Need to handle the case where an invalid Application is specified for any of the Application code segment commands
-CS4008,CS4008,CS shall provide the ability to dump the baseline CRCs and status for the Application code segment memory segments via a dump-only table,Need the ability to get all of the application code segment checksums. Easiest to use the cFE Table services dump-only table feature
+CS4006,CS4006,"Upon receipt of a Report Application code segment CRC command, CS shall send an event message containing the baseline Application or Library code segment CRC",Provides the ground with the baseline being used.
+CS4007,CS4007,"If the command-specified Application or Library is invalid (for any Application Code Segment command where the Application/Library is a command argument, CS shall reject the command and send an event message",Need to handle the case where an invalid Application or Library is specified for any of the Application code segment commands
+CS4008,CS4008,CS shall provide the ability to dump the baseline CRCs and status for the Application or Library code segment memory segments via a dump-only table,Need the ability to get all of the application code segment checksums. Easiest to use the cFE Table services dump-only table feature
 CS5000,CS5000,"Checksum shall calculate CRCs for each Table-Defined Table and compare them against the corresponding Table's baseline CRC if:
 a)       Checksumming (as a whole) is Enabled
 b)       Table checksumming is Enabled
@@ -186,7 +186,7 @@ a)       enabled
 b)       disabled
 c)       empty",Table validation includes verifying that the table contains valid intial states.
 CS9004,CS9004,"Upon a cFE Power On Reset, if the Non-Volatile <PLATFORM_DEFINED> Power-On Initialization state is set to Enabled, CS shall compute the baseline CRC for the total of all of non-volatile segments.",Need to have a checksum for the entire image. Note that the CRCs for each of the non-volatile segments specified in the table are added together to arrive at this number.
-CS9005,CS9005,"Upon a cFE Power On Reset, if the Application <PLATFORM_DEFINED> Power-On Initialization state is set to Enabled, CS shall compute baseline CRCs for the Application code segments region based on the corresponding table definition for up to a <PLATFORM_DEFINED> Applications",Need to compute baselines for the Applications specified in the table. The platform-defined value could be equal to the max number of apps defined by cFE ES but could be less
+CS9005,CS9005,"Upon a cFE Power On Reset, if the Application <PLATFORM_DEFINED> Power-On Initialization state is set to Enabled, CS shall compute baseline CRCs for the Application or Library code segments region based on the corresponding table definition for up to a <PLATFORM_DEFINED> Applications and Libraries",Need to compute baselines for the Applications and Libraries specified in the table. The platform-defined value could be equal to the max number of apps defined by cFE ES but could be less
 CS9005.1,CS9005.1,"CS shall send an event message and disable Application code segment Checksumming, if the state is not one of the following:
 a)       enabled
 b)       disabled

--- a/unit-test/cs_compute_tests.c
+++ b/unit-test/cs_compute_tests.c
@@ -69,25 +69,26 @@ void CS_COMPUTE_TEST_CFE_TBL_ShareHandler(void *UserObj, UT_EntryKey_t FuncKey, 
     *TblHandlePtr = 99;
 }
 
-void CS_COMPUTE_TEST_CFE_ES_GetAppInfoHandler1(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void CS_COMPUTE_TEST_CFE_ES_GetModuleInfoHandler1(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
-    CFE_ES_AppInfo_t *AppInfo = (CFE_ES_AppInfo_t *)UT_Hook_GetArgValueByName(Context, "AppInfo", CFE_ES_AppInfo_t *);
+    CFE_ES_AppInfo_t *AppInfo =
+        (CFE_ES_AppInfo_t *)UT_Hook_GetArgValueByName(Context, "ModuleInfo", CFE_ES_AppInfo_t *);
 
     AppInfo->CodeSize          = 5;
     AppInfo->CodeAddress       = 1;
     AppInfo->AddressesAreValid = true;
 }
 
-void CS_COMPUTE_TEST_CFE_ES_GetAppInfoHandler2(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+void CS_COMPUTE_TEST_CFE_ES_GetModuleInfoHandler2(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
-    CFE_ES_AppInfo_t *AppInfo = (CFE_ES_AppInfo_t *)UT_Hook_GetArgValueByName(Context, "AppInfo", CFE_ES_AppInfo_t *);
+    CFE_ES_AppInfo_t *AppInfo =
+        (CFE_ES_AppInfo_t *)UT_Hook_GetArgValueByName(Context, "ModuleInfo", CFE_ES_AppInfo_t *);
 
     AppInfo->AddressesAreValid = false;
 }
 
 void CS_ComputeEepromMemory_Test_Nominal(void)
 {
-    int32                             Result;
     CS_Res_EepromMemory_Table_Entry_t ResultsEntry;
     uint32                            ComputedCSValue = 0;
     bool                              DoneWithEntry   = false;
@@ -105,23 +106,17 @@ void CS_ComputeEepromMemory_Test_Nominal(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_CalculateCRC), 1);
 
     /* Execute the function being tested */
-    Result = CS_ComputeEepromMemory(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeEepromMemory(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CFE_SUCCESS);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == true, "DoneWithEntry == true");
+    UtAssert_BOOL_TRUE(DoneWithEntry);
 
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
 } /* end CS_ComputeEepromMemory_Test_Nominal */
 
 void CS_ComputeEepromMemory_Test_Error(void)
 {
-    int32                             Result;
     CS_Res_EepromMemory_Table_Entry_t ResultsEntry;
     uint32                            ComputedCSValue = 0;
     bool                              DoneWithEntry   = false;
@@ -139,23 +134,17 @@ void CS_ComputeEepromMemory_Test_Error(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_CalculateCRC), 1);
 
     /* Execute the function being tested */
-    Result = CS_ComputeEepromMemory(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeEepromMemory(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CS_ERROR);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == true, "DoneWithEntry == true");
+    UtAssert_BOOL_TRUE(DoneWithEntry);
 
-    UtAssert_True(Result == CS_ERROR, "Result == CS_ERROR");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
 } /* end CS_ComputeEepromMemory_Test_Error */
 
 void CS_ComputeEepromMemory_Test_FirstTimeThrough(void)
 {
-    int32                             Result;
     CS_Res_EepromMemory_Table_Entry_t ResultsEntry;
     uint32                            ComputedCSValue = 0;
     bool                              DoneWithEntry   = false;
@@ -171,29 +160,23 @@ void CS_ComputeEepromMemory_Test_FirstTimeThrough(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CalculateCRC), 1, 1);
 
     /* Execute the function being tested */
-    Result = CS_ComputeEepromMemory(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeEepromMemory(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CFE_SUCCESS);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == true, "DoneWithEntry == true");
+    UtAssert_BOOL_TRUE(DoneWithEntry);
 
-    UtAssert_True(ResultsEntry.ComputedYet == true, "ResultsEntry.ComputedYet == true");
-    UtAssert_True(ResultsEntry.ComparisonValue == 1, "ResultsEntry.ComparisonValue == 1");
-    UtAssert_True(ComputedCSValue == 1, "ComputedCSValue == 1");
-    UtAssert_True(ResultsEntry.ByteOffset == 0, "ResultsEntry.ByteOffset == 0");
-    UtAssert_True(ResultsEntry.TempChecksumValue == 0, "ResultsEntry.TempChecksumValue == 0");
+    UtAssert_BOOL_TRUE(ResultsEntry.ComputedYet);
+    UtAssert_UINT32_EQ(ResultsEntry.ComparisonValue, 1);
+    UtAssert_UINT32_EQ(ComputedCSValue, 1);
+    UtAssert_UINT32_EQ(ResultsEntry.ByteOffset, 0);
+    UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
 } /* end CS_ComputeEepromMemory_Test_FirstTimeThrough */
 
 void CS_ComputeEepromMemory_Test_NotFinished(void)
 {
-    int32                             Result;
     CS_Res_EepromMemory_Table_Entry_t ResultsEntry;
     uint32                            ComputedCSValue = 0;
     bool                              DoneWithEntry   = false;
@@ -209,28 +192,21 @@ void CS_ComputeEepromMemory_Test_NotFinished(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CalculateCRC), 1, 1);
 
     /* Execute the function being tested */
-    Result = CS_ComputeEepromMemory(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeEepromMemory(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CFE_SUCCESS);
 
     /* Verify results */
-    UtAssert_True(ResultsEntry.ByteOffset == 1, "ResultsEntry.ByteOffset == 1");
-    UtAssert_True(ResultsEntry.TempChecksumValue == 1, "ResultsEntry.TempChecksumValue == 1");
+    UtAssert_UINT32_EQ(ResultsEntry.ByteOffset, 1);
+    UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 1);
 
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
 } /* end CS_ComputeEepromMemory_Test_NotFinished */
 
 void CS_ComputeTables_Test_TableNeverLoaded(void)
 {
-    int32                       Result;
     CS_Res_Tables_Table_Entry_t ResultsEntry;
     uint32                      ComputedCSValue = 0;
     bool                        DoneWithEntry   = true;
-    int32                       strCmpResult;
     char                        ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&ResultsEntry, 0, sizeof(ResultsEntry));
@@ -246,34 +222,26 @@ void CS_ComputeTables_Test_TableNeverLoaded(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_ERR_NEVER_LOADED);
 
     /* Execute the function being tested */
-    Result = CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CS_ERR_NOT_FOUND);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == false, "DoneWithEntry == false");
-
-    UtAssert_True(Result == CS_ERR_NOT_FOUND, "Result == CS_ERR_NOT_FOUND");
+    UtAssert_BOOL_FALSE(DoneWithEntry);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_COMPUTE_TABLES_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_ComputeTables_Test_TableNeverLoaded */
 
 void CS_ComputeTables_Test_TableUnregisteredAndNeverLoaded(void)
 {
-    int32                       Result;
     CS_Res_Tables_Table_Entry_t ResultsEntry;
     uint32                      ComputedCSValue = 0;
     bool                        DoneWithEntry   = true;
-    int32                       strCmpResult;
     char                        ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&ResultsEntry, 0, sizeof(ResultsEntry));
@@ -295,38 +263,30 @@ void CS_ComputeTables_Test_TableUnregisteredAndNeverLoaded(void)
     UT_SetDeferredRetcode(UT_KEY(CS_AttemptTableReshare), 1, -1);
 
     /* Execute the function being tested */
-    Result = CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CS_ERR_NOT_FOUND);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == false, "DoneWithEntry == false");
+    UtAssert_BOOL_FALSE(DoneWithEntry);
 
-    UtAssert_True(ResultsEntry.ComparisonValue == 0, "ResultsEntry.ComparisonValue == 0");
-    UtAssert_True(ResultsEntry.StartAddress == 0, "ResultsEntry.StartAddress == 0");
-    UtAssert_True(ResultsEntry.NumBytesToChecksum == 0, "ResultsEntry.NumBytesToChecksum == 0");
-
-    UtAssert_True(Result == CS_ERR_NOT_FOUND, "Result == CS_ERR_NOT_FOUND");
+    UtAssert_UINT32_EQ(ResultsEntry.ComparisonValue, 0);
+    UtAssert_UINT32_EQ(ResultsEntry.StartAddress, 0);
+    UtAssert_UINT32_EQ(ResultsEntry.NumBytesToChecksum, 0);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_COMPUTE_TABLES_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_ComputeTables_Test_TableUnregisteredAndNeverLoaded */
 
 void CS_ComputeTables_Test_ResultShareNotSuccess(void)
 {
-    int32                       Result;
     CS_Res_Tables_Table_Entry_t ResultsEntry;
     uint32                      ComputedCSValue = 0;
     bool                        DoneWithEntry   = true;
-    int32                       strCmpResult;
     char                        ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&ResultsEntry, 0, sizeof(ResultsEntry));
@@ -349,33 +309,25 @@ void CS_ComputeTables_Test_ResultShareNotSuccess(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_GetAddress), 1, CFE_TBL_ERR_UNREGISTERED);
 
     /* Execute the function being tested */
-    Result = CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CS_ERR_NOT_FOUND);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == false, "DoneWithEntry == false");
+    UtAssert_BOOL_FALSE(DoneWithEntry);
 
-    UtAssert_True(ResultsEntry.TblHandle == CFE_TBL_BAD_TABLE_HANDLE,
-                  "ResultsEntry.TblHandle == CFE_TBL_BAD_TABLE_HANDLE");
-
-    UtAssert_True(Result == CS_ERR_NOT_FOUND, "Result == CS_ERR_NOT_FOUND");
+    UtAssert_INT32_EQ(ResultsEntry.TblHandle, CFE_TBL_BAD_TABLE_HANDLE);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_COMPUTE_TABLES_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_ComputeTables_Test_ResultShareNotSuccess */
 
 void CS_ComputeTables_Test_TblInfoUpdated(void)
 {
-    int32                       Result;
     CS_Res_Tables_Table_Entry_t ResultsEntry;
     uint32                      ComputedCSValue = 0;
     bool                        DoneWithEntry   = true;
@@ -398,31 +350,25 @@ void CS_ComputeTables_Test_TblInfoUpdated(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_TBL_INFO_UPDATED);
 
     /* Execute the function being tested */
-    Result = CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CFE_SUCCESS);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == false, "DoneWithEntry == false");
+    UtAssert_BOOL_FALSE(DoneWithEntry);
 
-    UtAssert_True(ResultsEntry.NumBytesToChecksum == 5, "ResultsEntry.NumBytesToChecksum == 5");
-    UtAssert_True(ResultsEntry.StartAddress == 0, "ResultsEntry.StartAddress == 0");
-    UtAssert_True(ComputedCSValue == 0, "ComputedCSValue == 0");
-    UtAssert_True(ResultsEntry.ComputedYet == false, "ResultsEntry.ComputedYet == false");
-    UtAssert_True(ResultsEntry.ComparisonValue == 0, "ResultsEntry.ComparisonValue == 0");
-    UtAssert_True(ResultsEntry.ByteOffset == 0, "ResultsEntry.ByteOffset == 0");
-    UtAssert_True(ResultsEntry.TempChecksumValue == 0, "ResultsEntry.TempChecksumValue == 0");
+    UtAssert_UINT32_EQ(ResultsEntry.NumBytesToChecksum, 5);
+    UtAssert_UINT32_EQ(ResultsEntry.StartAddress, 0);
+    UtAssert_UINT32_EQ(ComputedCSValue, 0);
+    UtAssert_BOOL_FALSE(ResultsEntry.ComputedYet);
+    UtAssert_UINT32_EQ(ResultsEntry.ComparisonValue, 0);
+    UtAssert_UINT32_EQ(ResultsEntry.ByteOffset, 0);
+    UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
 } /* end CS_ComputeTables_Test_TblInfoUpdated */
 
 void CS_ComputeTables_Test_GetInfoResult(void)
 {
-    int32                       Result;
     CS_Res_Tables_Table_Entry_t ResultsEntry;
     uint32                      ComputedCSValue = 0;
     bool                        DoneWithEntry   = true;
@@ -446,31 +392,25 @@ void CS_ComputeTables_Test_GetInfoResult(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), CFE_TBL_INFO_UPDATED);
 
     /* Execute the function being tested */
-    Result = CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CFE_SUCCESS);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == false, "DoneWithEntry == false");
+    UtAssert_BOOL_FALSE(DoneWithEntry);
 
-    UtAssert_True(ResultsEntry.NumBytesToChecksum == 0, "ResultsEntry.NumBytesToChecksum == 0");
-    UtAssert_True(ResultsEntry.StartAddress == 0, "ResultsEntry.StartAddress == 0");
-    UtAssert_True(ComputedCSValue == 0, "ComputedCSValue == 0");
-    UtAssert_True(ResultsEntry.ComputedYet == false, "ResultsEntry.ComputedYet == false");
-    UtAssert_True(ResultsEntry.ComparisonValue == 0, "ResultsEntry.ComparisonValue == 0");
-    UtAssert_True(ResultsEntry.ByteOffset == 0, "ResultsEntry.ByteOffset == 0");
-    UtAssert_True(ResultsEntry.TempChecksumValue == 0, "ResultsEntry.TempChecksumValue == 0");
+    UtAssert_UINT32_EQ(ResultsEntry.NumBytesToChecksum, 0);
+    UtAssert_UINT32_EQ(ResultsEntry.StartAddress, 0);
+    UtAssert_UINT32_EQ(ComputedCSValue, 0);
+    UtAssert_BOOL_FALSE(ResultsEntry.ComputedYet);
+    UtAssert_UINT32_EQ(ResultsEntry.ComparisonValue, 0);
+    UtAssert_UINT32_EQ(ResultsEntry.ByteOffset, 0);
+    UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
 } /* end CS_ComputeTables_Test_GetInfoResult */
 
 void CS_ComputeTables_Test_CSError(void)
 {
-    int32                       Result;
     CS_Res_Tables_Table_Entry_t ResultsEntry;
     uint32                      ComputedCSValue = 0;
     bool                        DoneWithEntry   = false;
@@ -500,29 +440,23 @@ void CS_ComputeTables_Test_CSError(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CalculateCRC), 1, 2);
 
     /* Execute the function being tested */
-    Result = CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CS_ERROR);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == true, "DoneWithEntry == true");
+    UtAssert_BOOL_TRUE(DoneWithEntry);
 
-    UtAssert_True(ResultsEntry.NumBytesToChecksum == 5, "ResultsEntry.NumBytesToChecksum == 5");
-    UtAssert_True(ResultsEntry.StartAddress == 0, "ResultsEntry.StartAddress == 0");
-    UtAssert_True(ComputedCSValue == 2, "ComputedCSValue == 2");
-    UtAssert_True(ResultsEntry.ByteOffset == 0, "ResultsEntry.ByteOffset == 0");
-    UtAssert_True(ResultsEntry.TempChecksumValue == 0, "ResultsEntry.TempChecksumValue == 0");
+    UtAssert_UINT32_EQ(ResultsEntry.NumBytesToChecksum, 5);
+    UtAssert_UINT32_EQ(ResultsEntry.StartAddress, 0);
+    UtAssert_UINT32_EQ(ComputedCSValue, 2);
+    UtAssert_UINT32_EQ(ResultsEntry.ByteOffset, 0);
+    UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
-    UtAssert_True(Result == CS_ERROR, "Result == CS_ERROR");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
 } /* end CS_ComputeTables_Test_CSError */
 
 void CS_ComputeTables_Test_NominalBadTableHandle(void)
 {
-    int32                       Result;
     CS_Res_Tables_Table_Entry_t ResultsEntry;
     uint32                      ComputedCSValue = 0;
     bool                        DoneWithEntry   = false;
@@ -555,31 +489,25 @@ void CS_ComputeTables_Test_NominalBadTableHandle(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CalculateCRC), 1, 2);
 
     /* Execute the function being tested */
-    Result = CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CFE_SUCCESS);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == true, "DoneWithEntry == true");
+    UtAssert_BOOL_TRUE(DoneWithEntry);
 
-    UtAssert_True(ResultsEntry.TblHandle == 99, "ResultsEntry.TblHandle == 99");
+    UtAssert_INT32_EQ(ResultsEntry.TblHandle, 99);
 
-    UtAssert_True(ResultsEntry.NumBytesToChecksum == 5, "ResultsEntry.NumBytesToChecksum == 5");
-    UtAssert_True(ResultsEntry.StartAddress == 0, "ResultsEntry.StartAddress == 0");
-    UtAssert_True(ComputedCSValue == 2, "ComputedCSValue == 2");
-    UtAssert_True(ResultsEntry.ByteOffset == 0, "ResultsEntry.ByteOffset == 0");
-    UtAssert_True(ResultsEntry.TempChecksumValue == 0, "ResultsEntry.TempChecksumValue == 0");
+    UtAssert_UINT32_EQ(ResultsEntry.NumBytesToChecksum, 5);
+    UtAssert_UINT32_EQ(ResultsEntry.StartAddress, 0);
+    UtAssert_UINT32_EQ(ComputedCSValue, 2);
+    UtAssert_UINT32_EQ(ResultsEntry.ByteOffset, 0);
+    UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
 } /* end CS_ComputeTables_Test_NominalBadTableHandle */
 
 void CS_ComputeTables_Test_FirstTimeThrough(void)
 {
-    int32                       Result;
     CS_Res_Tables_Table_Entry_t ResultsEntry;
     uint32                      ComputedCSValue = 0;
     bool                        DoneWithEntry   = false;
@@ -612,35 +540,29 @@ void CS_ComputeTables_Test_FirstTimeThrough(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CalculateCRC), 1, 3);
 
     /* Execute the function being tested */
-    Result = CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CFE_SUCCESS);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == true, "DoneWithEntry == true");
+    UtAssert_BOOL_TRUE(DoneWithEntry);
 
-    UtAssert_True(ResultsEntry.TblHandle == 99, "ResultsEntry.TblHandle == 99");
+    UtAssert_INT32_EQ(ResultsEntry.TblHandle, 99);
 
-    UtAssert_True(ResultsEntry.NumBytesToChecksum == 5, "ResultsEntry.NumBytesToChecksum == 5");
-    UtAssert_True(ResultsEntry.StartAddress == 0, "ResultsEntry.StartAddress == 0");
+    UtAssert_UINT32_EQ(ResultsEntry.NumBytesToChecksum, 5);
+    UtAssert_UINT32_EQ(ResultsEntry.StartAddress, 0);
 
-    UtAssert_True(ResultsEntry.ComputedYet == true, "ResultsEntry.ComputedYet == true");
-    UtAssert_True(ResultsEntry.ComparisonValue == 3, "ResultsEntry.ComparisonValue == 3");
+    UtAssert_BOOL_TRUE(ResultsEntry.ComputedYet);
+    UtAssert_UINT32_EQ(ResultsEntry.ComparisonValue, 3);
 
-    UtAssert_True(ComputedCSValue == 3, "ComputedCSValue == 3");
-    UtAssert_True(ResultsEntry.ByteOffset == 0, "ResultsEntry.ByteOffset == 0");
-    UtAssert_True(ResultsEntry.TempChecksumValue == 0, "ResultsEntry.TempChecksumValue == 0");
+    UtAssert_UINT32_EQ(ComputedCSValue, 3);
+    UtAssert_UINT32_EQ(ResultsEntry.ByteOffset, 0);
+    UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
 } /* end CS_ComputeTables_Test_FirstTimeThrough */
 
 void CS_ComputeTables_Test_EntryNotFinished(void)
 {
-    int32                       Result;
     CS_Res_Tables_Table_Entry_t ResultsEntry;
     uint32                      ComputedCSValue = 0;
     bool                        DoneWithEntry   = true;
@@ -673,37 +595,30 @@ void CS_ComputeTables_Test_EntryNotFinished(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CalculateCRC), 1, 3);
 
     /* Execute the function being tested */
-    Result = CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CFE_SUCCESS);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == false, "DoneWithEntry == false");
+    UtAssert_BOOL_FALSE(DoneWithEntry);
 
-    UtAssert_True(ResultsEntry.TblHandle == 99, "ResultsEntry.TblHandle == 99");
+    UtAssert_INT32_EQ(ResultsEntry.TblHandle, 99);
 
-    UtAssert_True(ResultsEntry.NumBytesToChecksum == 5, "ResultsEntry.NumBytesToChecksum == 5");
-    UtAssert_True(ResultsEntry.StartAddress == 0, "ResultsEntry.StartAddress == 0");
+    UtAssert_UINT32_EQ(ResultsEntry.NumBytesToChecksum, 5);
+    UtAssert_UINT32_EQ(ResultsEntry.StartAddress, 0);
 
-    UtAssert_True(ResultsEntry.ByteOffset == 3, "ResultsEntry.ByteOffset == 3");
-    UtAssert_True(ResultsEntry.TempChecksumValue == 3, "ResultsEntry.TempChecksumValue == 3");
-    UtAssert_True(ComputedCSValue == 3, "ComputedCSValue == 3");
+    UtAssert_UINT32_EQ(ComputedCSValue, 3);
+    UtAssert_UINT32_EQ(ResultsEntry.ByteOffset, 3);
+    UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 3);
 
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
 } /* end CS_ComputeTables_Test_EntryNotFinished */
 
 void CS_ComputeTables_Test_ComputeTablesReleaseError(void)
 {
-    int32                       Result;
     CS_Res_Tables_Table_Entry_t ResultsEntry;
     uint32                      ComputedCSValue = 0;
     bool                        DoneWithEntry   = true;
     CFE_TBL_Info_t              TblInfo;
-    int32                       strCmpResult;
     char                        ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&ResultsEntry, 0, sizeof(ResultsEntry));
@@ -741,44 +656,36 @@ void CS_ComputeTables_Test_ComputeTablesReleaseError(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_TBL_ReleaseAddress), 1, -1);
 
     /* Execute the function being tested */
-    Result = CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CFE_SUCCESS);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == false, "DoneWithEntry == false");
+    UtAssert_BOOL_FALSE(DoneWithEntry);
 
-    UtAssert_True(ResultsEntry.TblHandle == 99, "ResultsEntry.TblHandle == 99");
+    UtAssert_INT32_EQ(ResultsEntry.TblHandle, 99);
 
-    UtAssert_True(ResultsEntry.NumBytesToChecksum == 5, "ResultsEntry.NumBytesToChecksum == 5");
-    UtAssert_True(ResultsEntry.StartAddress == 0, "ResultsEntry.StartAddress == 0");
+    UtAssert_UINT32_EQ(ResultsEntry.NumBytesToChecksum, 5);
+    UtAssert_UINT32_EQ(ResultsEntry.StartAddress, 0);
 
-    UtAssert_True(ResultsEntry.ByteOffset == 3, "ResultsEntry.ByteOffset == 3");
-    UtAssert_True(ResultsEntry.TempChecksumValue == 3, "ResultsEntry.TempChecksumValue == 3");
-    UtAssert_True(ComputedCSValue == 3, "ComputedCSValue == 3");
-
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
+    UtAssert_UINT32_EQ(ResultsEntry.ByteOffset, 3);
+    UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 3);
+    UtAssert_UINT32_EQ(ComputedCSValue, 3);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_COMPUTE_TABLES_RELEASE_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_ComputeTables_Test_ComputeTablesReleaseError */
 
 void CS_ComputeTables_Test_ComputeTablesError(void)
 {
-    int32                       Result;
     CS_Res_Tables_Table_Entry_t ResultsEntry;
     uint32                      ComputedCSValue = 0;
     bool                        DoneWithEntry   = true;
     CFE_TBL_Info_t              TblInfo;
-    int32                       strCmpResult;
     char                        ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&ResultsEntry, 0, sizeof(ResultsEntry));
@@ -803,30 +710,23 @@ void CS_ComputeTables_Test_ComputeTablesError(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), -1);
 
     /* Execute the function being tested */
-    Result = CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeTables(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CS_ERR_NOT_FOUND);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == false, "DoneWithEntry == false");
-
-    UtAssert_True(Result == CS_ERR_NOT_FOUND, "Result == CS_ERR_NOT_FOUND");
+    UtAssert_BOOL_FALSE(DoneWithEntry);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_COMPUTE_TABLES_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_ComputeTables_Test_ComputeTablesError */
 
-void CS_ComputeApp_Test_Nominal(void)
+void CS_ComputeApp_Test_NominalApp(void)
 {
-    int32                    Result;
     CS_Res_App_Table_Entry_t ResultsEntry;
     uint32                   ComputedCSValue = 0;
     bool                     DoneWithEntry   = false;
@@ -841,122 +741,145 @@ void CS_ComputeApp_Test_Nominal(void)
 
     /* Sets AppInfo.CodeSize = 5, sets AppInfo.CodeAddress = 1, AppInfo.AddressesAreValid = true, and returns
      * CFE_SUCCESS */
-    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetAppInfo), CS_COMPUTE_TEST_CFE_ES_GetAppInfoHandler1, NULL);
+    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetModuleInfo), CS_COMPUTE_TEST_CFE_ES_GetModuleInfoHandler1, NULL);
 
     /* Set to fail condition "NewChecksumValue != ResultsEntry -> ComparisonValue" */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CalculateCRC), 1, 2);
 
     /* Execute the function being tested */
-    Result = CS_ComputeApp(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeApp(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CFE_SUCCESS);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == true, "DoneWithEntry == true");
+    UtAssert_BOOL_TRUE(DoneWithEntry);
 
-    UtAssert_True(ResultsEntry.NumBytesToChecksum == 5, "ResultsEntry.NumBytesToChecksum == 5");
-    UtAssert_True(ResultsEntry.StartAddress == 1, "ResultsEntry.StartAddress == 1");
+    UtAssert_UINT32_EQ(ResultsEntry.NumBytesToChecksum, 5);
+    UtAssert_UINT32_EQ(ResultsEntry.StartAddress, 1);
 
-    UtAssert_True(ComputedCSValue == 2, "ComputedCSValue == 2");
-    UtAssert_True(ResultsEntry.ByteOffset == 0, "ResultsEntry.ByteOffset == 0");
-    UtAssert_True(ResultsEntry.TempChecksumValue == 0, "ResultsEntry.TempChecksumValue == 0");
+    UtAssert_UINT32_EQ(ComputedCSValue, 2);
+    UtAssert_UINT32_EQ(ResultsEntry.ByteOffset, 0);
+    UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
+} /* end CS_ComputeApp_Test_NominalApp */
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
-
-} /* end CS_ComputeApp_Test_Nominal */
-
-void CS_ComputeApp_Test_GetAppIDByNameError(void)
+void CS_ComputeApp_Test_NominalLib(void)
 {
-    int32                    Result;
+    CS_Res_App_Table_Entry_t ResultsEntry;
+    uint32                   ComputedCSValue = 0;
+    bool                     DoneWithEntry   = false;
+
+    memset(&ResultsEntry, 0, sizeof(ResultsEntry));
+
+    CS_AppData.MaxBytesPerCycle = 5;
+
+    ResultsEntry.ComputedYet = true;
+
+    ResultsEntry.ComparisonValue = 2;
+
+    /* Set to generate error CS_COMPUTE_APP_ERR_EID */
+    UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppIDByName), 1, CFE_ES_ERR_NAME_NOT_FOUND);
+
+    /* Sets AppInfo.CodeSize = 5, sets AppInfo.CodeAddress = 1, AppInfo.AddressesAreValid = true, and returns
+     * CFE_SUCCESS */
+    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetModuleInfo), CS_COMPUTE_TEST_CFE_ES_GetModuleInfoHandler1, NULL);
+
+    /* Set to fail condition "NewChecksumValue != ResultsEntry -> ComparisonValue" */
+    UT_SetDeferredRetcode(UT_KEY(CFE_ES_CalculateCRC), 1, 2);
+
+    /* Execute the function being tested */
+    UtAssert_UINT32_EQ(CS_ComputeApp(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CFE_SUCCESS);
+
+    /* Verify results */
+    UtAssert_BOOL_TRUE(DoneWithEntry);
+
+    UtAssert_UINT32_EQ(ResultsEntry.NumBytesToChecksum, 5);
+    UtAssert_UINT32_EQ(ResultsEntry.StartAddress, 1);
+
+    UtAssert_UINT32_EQ(ComputedCSValue, 2);
+    UtAssert_UINT32_EQ(ResultsEntry.ByteOffset, 0);
+    UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
+
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
+
+} /* end CS_ComputeApp_Test_NominalLib */
+
+void CS_ComputeApp_Test_GetAppAndLibIDByNameError(void)
+{
     CS_Res_App_Table_Entry_t ResultsEntry;
     uint32                   ComputedCSValue = 0;
     bool                     DoneWithEntry   = true;
-    int32                    strCmpResult;
     char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&ResultsEntry, 0, sizeof(ResultsEntry));
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CS Apps: Problems getting app %%s info, GetAppID: 0x%%08X, GetAppInfo: 0x%%08X, AddressValid: %%d");
+    snprintf(
+        ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
+        "CS Apps: Problems getting module %%s info, GetResourceID: 0x%%08X, GetModuleInfo: 0x%%08X, AddressValid: %%d");
 
     strncpy(ResultsEntry.Name, "name", 10);
 
     /* Set to generate error CS_COMPUTE_APP_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppIDByName), 1, -1);
 
+    /* Set to generate error CS_COMPUTE_APP_ERR_EID */
+    UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetLibIDByName), 1, -1);
+
     /* Execute the function being tested */
-    Result = CS_ComputeApp(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeApp(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CS_ERR_NOT_FOUND);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == false, "DoneWithEntry == false");
-
-    UtAssert_True(Result == CS_ERR_NOT_FOUND, "Result == CS_ERR_NOT_FOUND");
+    UtAssert_BOOL_FALSE(DoneWithEntry);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_COMPUTE_APP_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
+} /* end CS_ComputeApp_Test_GetAppAndLibIDByNameError */
 
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-
-} /* end CS_ComputeApp_Test_GetAppIDByNameError */
-
-void CS_ComputeApp_Test_GetAppInfoError(void)
+void CS_ComputeApp_Test_GetModuleInfoError(void)
 {
-    int32                    Result;
     CS_Res_App_Table_Entry_t ResultsEntry;
     uint32                   ComputedCSValue = 0;
     bool                     DoneWithEntry   = true;
-    int32                    strCmpResult;
     char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&ResultsEntry, 0, sizeof(ResultsEntry));
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CS Apps: Problems getting app %%s info, GetAppID: 0x%%08X, GetAppInfo: 0x%%08X, AddressValid: %%d");
+    snprintf(
+        ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
+        "CS Apps: Problems getting module %%s info, GetResourceID: 0x%%08X, GetModuleInfo: 0x%%08X, AddressValid: %%d");
 
     strncpy(ResultsEntry.Name, "name", 10);
 
     /* Set to generate error CS_COMPUTE_APP_ERR_EID */
-    UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppInfo), 1, -1);
+    UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetModuleInfo), 1, -1);
 
     /* Execute the function being tested */
-    Result = CS_ComputeApp(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeApp(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CS_ERR_NOT_FOUND);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == false, "DoneWithEntry == false");
-
-    UtAssert_True(Result == CS_ERR_NOT_FOUND, "Result == CS_ERR_NOT_FOUND");
+    UtAssert_BOOL_FALSE(DoneWithEntry);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_COMPUTE_APP_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
-
-} /* end CS_ComputeApp_Test_GetAppInfoError */
+} /* end CS_ComputeApp_Test_GetModuleInfoError */
 
 void CS_ComputeApp_Test_ComputeAppPlatformError(void)
 {
-    int32                    Result;
     CS_Res_App_Table_Entry_t ResultsEntry;
     uint32                   ComputedCSValue = 0;
     bool                     DoneWithEntry   = true;
-    int32                    strCmpResult;
     char                     ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&ResultsEntry, 0, sizeof(ResultsEntry));
@@ -964,48 +887,39 @@ void CS_ComputeApp_Test_ComputeAppPlatformError(void)
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS cannot get a valid address for %%s, due to the platform");
 
-    snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CS Apps: Problems getting app %%s info, GetAppID: 0x%%08X, GetAppInfo: 0x%%08X, AddressValid: %%d");
+    snprintf(
+        ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
+        "CS Apps: Problems getting module %%s info, GetResourceID: 0x%%08X, GetModuleInfo: 0x%%08X, AddressValid: %%d");
 
     strncpy(ResultsEntry.Name, "name", 10);
 
     /* Sets AppInfo.AddressesAreValid = false and returns CFE_SUCCESS */
-    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetAppInfo), CS_COMPUTE_TEST_CFE_ES_GetAppInfoHandler2, NULL);
+    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetModuleInfo), CS_COMPUTE_TEST_CFE_ES_GetModuleInfoHandler2, NULL);
 
     /* Execute the function being tested */
-    Result = CS_ComputeApp(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeApp(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CS_ERR_NOT_FOUND);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == false, "DoneWithEntry == false");
-
-    UtAssert_True(Result == CS_ERR_NOT_FOUND, "Result == CS_ERR_NOT_FOUND");
+    UtAssert_BOOL_FALSE(DoneWithEntry);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_COMPUTE_APP_PLATFORM_DBG_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
 
-    strCmpResult =
-        strncmp(ExpectedEventString[0], context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
-
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_COMPUTE_APP_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
 
-    strCmpResult =
-        strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[1].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
 
 } /* end CS_ComputeApp_Test_ComputeAppPlatformError */
 
 void CS_ComputeApp_Test_DifferFromSavedValue(void)
 {
-    int32                    Result;
     CS_Res_App_Table_Entry_t ResultsEntry;
     uint32                   ComputedCSValue = 0;
     bool                     DoneWithEntry   = false;
@@ -1020,32 +934,26 @@ void CS_ComputeApp_Test_DifferFromSavedValue(void)
 
     /* Sets AppInfo.CodeSize = 5, sets AppInfo.CodeAddress = 1, AppInfo.AddressesAreValid = true, and returns
      * CFE_SUCCESS */
-    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetAppInfo), CS_COMPUTE_TEST_CFE_ES_GetAppInfoHandler1, NULL);
+    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetModuleInfo), CS_COMPUTE_TEST_CFE_ES_GetModuleInfoHandler1, NULL);
 
     /* Set to fail condition "NewChecksumValue != ResultsEntry -> ComparisonValue" */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CalculateCRC), 1, 2);
 
     /* Execute the function being tested */
-    Result = CS_ComputeApp(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeApp(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CS_ERROR);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == true, "DoneWithEntry == true");
+    UtAssert_BOOL_TRUE(DoneWithEntry);
 
-    UtAssert_True(ResultsEntry.NumBytesToChecksum == 5, "ResultsEntry.NumBytesToChecksum == 5");
-    UtAssert_True(ResultsEntry.StartAddress == 1, "ResultsEntry.StartAddress == 1");
+    UtAssert_UINT32_EQ(ResultsEntry.NumBytesToChecksum, 5);
+    UtAssert_UINT32_EQ(ResultsEntry.StartAddress, 1);
 
-    UtAssert_True(Result == CS_ERROR, "Result == CS_ERROR");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
 } /* end CS_ComputeApp_Test_DifferFromSavedValue */
 
 void CS_ComputeApp_Test_FirstTimeThrough(void)
 {
-    int32                    Result;
     CS_Res_App_Table_Entry_t ResultsEntry;
     uint32                   ComputedCSValue = 0;
     bool                     DoneWithEntry   = false;
@@ -1060,39 +968,33 @@ void CS_ComputeApp_Test_FirstTimeThrough(void)
 
     /* Sets AppInfo.CodeSize = 5, sets AppInfo.CodeAddress = 1, AppInfo.AddressesAreValid = true, and returns
      * CFE_SUCCESS */
-    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetAppInfo), CS_COMPUTE_TEST_CFE_ES_GetAppInfoHandler1, NULL);
+    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetModuleInfo), CS_COMPUTE_TEST_CFE_ES_GetModuleInfoHandler1, NULL);
 
     /* Set to fail condition "NewChecksumValue != ResultsEntry -> ComparisonValue" */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CalculateCRC), 1, 2);
 
     /* Execute the function being tested */
-    Result = CS_ComputeApp(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeApp(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CFE_SUCCESS);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == true, "DoneWithEntry == true");
+    UtAssert_BOOL_TRUE(DoneWithEntry);
 
-    UtAssert_True(ResultsEntry.NumBytesToChecksum == 5, "ResultsEntry.NumBytesToChecksum == 5");
-    UtAssert_True(ResultsEntry.StartAddress == 1, "ResultsEntry.StartAddress == 1");
+    UtAssert_UINT32_EQ(ResultsEntry.NumBytesToChecksum, 5);
+    UtAssert_UINT32_EQ(ResultsEntry.StartAddress, 1);
 
-    UtAssert_True(ResultsEntry.ComputedYet == true, "ResultsEntry.ComputedYet == true");
-    UtAssert_True(ResultsEntry.ComparisonValue == 2, "ResultsEntry.ComparisonValue == 2");
+    UtAssert_BOOL_TRUE(ResultsEntry.ComputedYet);
+    UtAssert_UINT32_EQ(ResultsEntry.ComparisonValue, 2);
 
-    UtAssert_True(ComputedCSValue == 2, "ComputedCSValue == 2");
-    UtAssert_True(ResultsEntry.ByteOffset == 0, "ResultsEntry.ByteOffset == 0");
-    UtAssert_True(ResultsEntry.TempChecksumValue == 0, "ResultsEntry.TempChecksumValue == 0");
+    UtAssert_UINT32_EQ(ComputedCSValue, 2);
+    UtAssert_UINT32_EQ(ResultsEntry.ByteOffset, 0);
+    UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
 } /* end CS_ComputeApp_Test_FirstTimeThrough */
 
 void CS_ComputeApp_Test_EntryNotFinished(void)
 {
-    int32                    Result;
     CS_Res_App_Table_Entry_t ResultsEntry;
     uint32                   ComputedCSValue = 0;
     bool                     DoneWithEntry   = true;
@@ -1109,7 +1011,7 @@ void CS_ComputeApp_Test_EntryNotFinished(void)
 
     /* Sets AppInfo.CodeSize = 5, sets AppInfo.CodeAddress = 1, AppInfo.AddressesAreValid = true, and returns
      * CFE_SUCCESS */
-    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetAppInfo), CS_COMPUTE_TEST_CFE_ES_GetAppInfoHandler1, NULL);
+    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetModuleInfo), CS_COMPUTE_TEST_CFE_ES_GetModuleInfoHandler1, NULL);
 
     TblInfo.Size = 5;
 
@@ -1121,23 +1023,18 @@ void CS_ComputeApp_Test_EntryNotFinished(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CalculateCRC), 1, 2);
 
     /* Execute the function being tested */
-    Result = CS_ComputeApp(&ResultsEntry, &ComputedCSValue, &DoneWithEntry);
+    UtAssert_UINT32_EQ(CS_ComputeApp(&ResultsEntry, &ComputedCSValue, &DoneWithEntry), CFE_SUCCESS);
 
     /* Verify results */
-    UtAssert_True(DoneWithEntry == false, "DoneWithEntry == false");
+    UtAssert_BOOL_FALSE(DoneWithEntry);
 
-    UtAssert_True(ResultsEntry.StartAddress == 1, "ResultsEntry.StartAddress == 1");
+    UtAssert_UINT32_EQ(ResultsEntry.StartAddress, 1);
 
-    UtAssert_True(ResultsEntry.ByteOffset == 3, "ResultsEntry.ByteOffset == 3");
-    UtAssert_True(ResultsEntry.TempChecksumValue == 2, "ResultsEntry.TempChecksumValue == 2");
-    UtAssert_True(ComputedCSValue == 2, "ComputedCSValue == 2");
+    UtAssert_UINT32_EQ(ResultsEntry.ByteOffset, 3);
+    UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 2);
+    UtAssert_UINT32_EQ(ComputedCSValue, 2);
 
-    UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 
 } /* end CS_ComputeApp_Test_EntryNotFinished */
 
@@ -1145,7 +1042,6 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTable(void)
 {
     CS_Res_EepromMemory_Table_Entry_t RecomputeEepromMemoryEntry;
     CS_Def_EepromMemory_Table_Entry_t DefEepromTbl[10];
-    int32                             strCmpResult;
     char                              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&RecomputeEepromMemoryEntry, 0, sizeof(RecomputeEepromMemoryEntry));
@@ -1179,30 +1075,21 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTable(void)
     CS_RecomputeEepromMemoryChildTask();
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue == 0,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue == 0");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset == 0,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset == 0");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet == true,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet == true");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->State == 99,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->State == 99");
-    UtAssert_True(CS_AppData.DefEepromTblPtr[CS_AppData.ChildTaskEntryID].State == 1,
-                  "CS_AppData.DefEepromTblPtr[CS_AppData.ChildTaskEntryID].State == 1");
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue, 0);
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset, 0);
+    UtAssert_BOOL_TRUE(CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet);
+    UtAssert_UINT16_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->State, 99);
+    UtAssert_UINT16_EQ(CS_AppData.DefEepromTblPtr[CS_AppData.ChildTaskEntryID].State, 1);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_FINISH_EEPROM_MEMORY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_RecomputeEepromMemoryChildTask_Test_EEPROMTable */
 
@@ -1210,7 +1097,6 @@ void CS_RecomputeEepromMemoryChildTask_Test_MemoryTable(void)
 {
     CS_Res_EepromMemory_Table_Entry_t RecomputeEepromMemoryEntry;
     CS_Def_EepromMemory_Table_Entry_t DefMemoryTbl[10];
-    int32                             strCmpResult;
     char                              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&RecomputeEepromMemoryEntry, 0, sizeof(RecomputeEepromMemoryEntry));
@@ -1244,30 +1130,21 @@ void CS_RecomputeEepromMemoryChildTask_Test_MemoryTable(void)
     CS_RecomputeEepromMemoryChildTask();
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue == 0,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue == 0");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset == 0,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset == 0");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet == true,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet == true");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->State == 99,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->State == 99");
-    UtAssert_True(CS_AppData.DefMemoryTblPtr[CS_AppData.ChildTaskEntryID].State == 1,
-                  "CS_AppData.DefMemoryTblPtr[CS_AppData.ChildTaskEntryID].State == 1");
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue, 0);
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset, 0);
+    UtAssert_BOOL_TRUE(CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet);
+    UtAssert_UINT16_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->State, 99);
+    UtAssert_UINT16_EQ(CS_AppData.DefMemoryTblPtr[CS_AppData.ChildTaskEntryID].State, 1);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_FINISH_EEPROM_MEMORY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_RecomputeEepromMemoryChildTask_Test_MemoryTable */
 
@@ -1275,7 +1152,6 @@ void CS_RecomputeEepromMemoryChildTask_Test_CFECore(void)
 {
     CS_Res_EepromMemory_Table_Entry_t RecomputeEepromMemoryEntry;
     CS_Def_EepromMemory_Table_Entry_t DefMemoryTbl[10];
-    int32                             strCmpResult;
     char                              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&RecomputeEepromMemoryEntry, 0, sizeof(RecomputeEepromMemoryEntry));
@@ -1309,32 +1185,23 @@ void CS_RecomputeEepromMemoryChildTask_Test_CFECore(void)
     CS_RecomputeEepromMemoryChildTask();
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue == 0,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue == 0");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset == 0,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset == 0");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet == true,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet == true");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->State == 99,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->State == 99");
-    UtAssert_True(CS_AppData.DefMemoryTblPtr[CS_AppData.ChildTaskEntryID].State == 1,
-                  "CS_AppData.DefMemoryTblPtr[CS_AppData.ChildTaskEntryID].State == 1");
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue, 0);
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset, 0);
+    UtAssert_BOOL_TRUE(CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet);
+    UtAssert_UINT16_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->State, 99);
+    UtAssert_UINT16_EQ(CS_AppData.DefMemoryTblPtr[CS_AppData.ChildTaskEntryID].State, 1);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_FINISH_EEPROM_MEMORY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.CfeCoreBaseline, 1);
 
-    UtAssert_True(CS_AppData.HkPacket.CfeCoreBaseline == 1, "CS_AppData.HkPacket.CfeCoreBaseline == 1");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_RecomputeEepromMemoryChildTask_Test_CFECore */
 
@@ -1342,7 +1209,6 @@ void CS_RecomputeEepromMemoryChildTask_Test_OSCore(void)
 {
     CS_Res_EepromMemory_Table_Entry_t RecomputeEepromMemoryEntry;
     CS_Def_EepromMemory_Table_Entry_t DefMemoryTbl[10];
-    int32                             strCmpResult;
     char                              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&RecomputeEepromMemoryEntry, 0, sizeof(RecomputeEepromMemoryEntry));
@@ -1376,32 +1242,23 @@ void CS_RecomputeEepromMemoryChildTask_Test_OSCore(void)
     CS_RecomputeEepromMemoryChildTask();
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue == 0,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue == 0");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset == 0,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset == 0");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet == true,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet == true");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->State == 99,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->State == 99");
-    UtAssert_True(CS_AppData.DefMemoryTblPtr[CS_AppData.ChildTaskEntryID].State == 1,
-                  "CS_AppData.DefMemoryTblPtr[CS_AppData.ChildTaskEntryID].State == 1");
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue, 0);
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset, 0);
+    UtAssert_BOOL_TRUE(CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet);
+    UtAssert_UINT16_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->State, 99);
+    UtAssert_UINT16_EQ(CS_AppData.DefMemoryTblPtr[CS_AppData.ChildTaskEntryID].State, 1);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_FINISH_EEPROM_MEMORY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.OSBaseline, 1);
 
-    UtAssert_True(CS_AppData.HkPacket.OSBaseline == 1, "CS_AppData.HkPacket.OSBaseline == 1");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_RecomputeEepromMemoryChildTask_Test_OSCore */
 
@@ -1409,7 +1266,6 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableEntryId(void)
 {
     CS_Res_EepromMemory_Table_Entry_t RecomputeEepromMemoryEntry;
     CS_Def_EepromMemory_Table_Entry_t DefEepromTbl[10];
-    int32                             strCmpResult;
     char                              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&RecomputeEepromMemoryEntry, 0, sizeof(RecomputeEepromMemoryEntry));
@@ -1443,28 +1299,20 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableEntryId(void)
     CS_RecomputeEepromMemoryChildTask();
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue == 0,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue == 0");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset == 0,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset == 0");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet == true,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet == true");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->State == 99,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->State == 99");
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue, 0);
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset, 0);
+    UtAssert_BOOL_TRUE(CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet);
+    UtAssert_UINT16_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->State, 99);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_FINISH_EEPROM_MEMORY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableEntryId */
 
@@ -1472,7 +1320,6 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableStartAddress(void)
 {
     CS_Res_EepromMemory_Table_Entry_t RecomputeEepromMemoryEntry;
     CS_Def_EepromMemory_Table_Entry_t DefEepromTbl[10];
-    int32                             strCmpResult;
     char                              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&RecomputeEepromMemoryEntry, 0, sizeof(RecomputeEepromMemoryEntry));
@@ -1506,30 +1353,21 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableStartAddress(void)
     CS_RecomputeEepromMemoryChildTask();
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue == 0,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue == 0");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset == 0,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset == 0");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet == true,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet == true");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->State == 99,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->State == 99");
-    UtAssert_True(CS_AppData.DefEepromTblPtr[CS_AppData.ChildTaskEntryID].State == 1,
-                  "CS_AppData.DefEepromTblPtr[CS_AppData.ChildTaskEntryID].State == 1");
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue, 0);
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset, 0);
+    UtAssert_BOOL_TRUE(CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet);
+    UtAssert_UINT16_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->State, 99);
+    UtAssert_UINT16_EQ(CS_AppData.DefEepromTblPtr[CS_AppData.ChildTaskEntryID].State, 1);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_FINISH_EEPROM_MEMORY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableStartAddress */
 
@@ -1537,7 +1375,6 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableState(void)
 {
     CS_Res_EepromMemory_Table_Entry_t RecomputeEepromMemoryEntry;
     CS_Def_EepromMemory_Table_Entry_t DefEepromTbl[10];
-    int32                             strCmpResult;
     char                              ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&RecomputeEepromMemoryEntry, 0, sizeof(RecomputeEepromMemoryEntry));
@@ -1571,30 +1408,21 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableState(void)
     CS_RecomputeEepromMemoryChildTask();
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue == 0,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue == 0");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset == 0,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset == 0");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet == true,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet == true");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr->State == 99,
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr->State == 99");
-    UtAssert_True(CS_AppData.DefEepromTblPtr[CS_AppData.ChildTaskEntryID].State == CS_STATE_EMPTY,
-                  "CS_AppData.DefEepromTblPtr[CS_AppData.ChildTaskEntryID].State == CS_STATE_EMPTY");
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue, 0);
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset, 0);
+    UtAssert_BOOL_TRUE(CS_AppData.RecomputeEepromMemoryEntryPtr->ComputedYet);
+    UtAssert_UINT16_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->State, 99);
+    UtAssert_UINT16_EQ(CS_AppData.DefEepromTblPtr[CS_AppData.ChildTaskEntryID].State, CS_STATE_EMPTY);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_FINISH_EEPROM_MEMORY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableState */
 
@@ -1602,7 +1430,6 @@ void CS_RecomputeAppChildTask_Test_Nominal(void)
 {
     CS_Res_App_Table_Entry_t RecomputeAppEntry;
     CS_Def_App_Table_Entry_t DefAppTbl[10];
-    int32                    strCmpResult;
     char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&RecomputeAppEntry, 0, sizeof(RecomputeAppEntry));
@@ -1633,34 +1460,27 @@ void CS_RecomputeAppChildTask_Test_Nominal(void)
 
     /* Sets AppInfo.CodeSize = 5, sets AppInfo.CodeAddress = 1, AppInfo.AddressesAreValid = true, and returns
      * CFE_SUCCESS */
-    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetAppInfo), CS_COMPUTE_TEST_CFE_ES_GetAppInfoHandler1, NULL);
+    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetModuleInfo), CS_COMPUTE_TEST_CFE_ES_GetModuleInfoHandler1, NULL);
 
     /* Execute the function being tested */
     CS_RecomputeAppChildTask();
 
     /* Verify results */
-    UtAssert_True(CS_AppData.RecomputeAppEntryPtr->State == 99, "CS_AppData.RecomputeAppEntryPtr->State == 99");
-    UtAssert_True(CS_AppData.DefAppTblPtr[CS_AppData.ChildTaskEntryID].State == 1,
-                  "CS_AppData.DefAppTblPtr[CS_AppData.ChildTaskEntryID].State == 1");
-    UtAssert_True(CS_AppData.RecomputeAppEntryPtr->TempChecksumValue == 0,
-                  "CS_AppData.RecomputeAppEntryPtr->TempChecksumValue == 0");
-    UtAssert_True(CS_AppData.RecomputeAppEntryPtr->ByteOffset == 0, "CS_AppData.RecomputeAppEntryPtr->ByteOffset == 0");
-    UtAssert_True(CS_AppData.RecomputeAppEntryPtr->ComputedYet == true,
-                  "CS_AppData.RecomputeAppEntryPtr->ComputedYet == true");
+    UtAssert_UINT16_EQ(CS_AppData.RecomputeAppEntryPtr->State, 99);
+    UtAssert_UINT16_EQ(CS_AppData.DefAppTblPtr[CS_AppData.ChildTaskEntryID].State, 1);
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeAppEntryPtr->TempChecksumValue, 0);
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeAppEntryPtr->ByteOffset, 0);
+    UtAssert_BOOL_TRUE(CS_AppData.RecomputeAppEntryPtr->ComputedYet);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_FINISH_APP_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_RecomputeAppChildTask_Test_Nominal */
 
@@ -1689,10 +1509,11 @@ void CS_RecomputeAppChildTask_Test_CouldNotGetAddress(void)
 
     /* Set to cause CS_ComputeApp to return CS_ERR_NOT_FOUND */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppIDByName), 1, -1);
+    UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetLibIDByName), 1, -1);
 
     /* Sets AppInfo.CodeSize = 5, sets AppInfo.CodeAddress = 1, AppInfo.AddressesAreValid = true, and returns
      * CFE_SUCCESS */
-    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetAppInfo), CS_COMPUTE_TEST_CFE_ES_GetAppInfoHandler1, NULL);
+    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetModuleInfo), CS_COMPUTE_TEST_CFE_ES_GetModuleInfoHandler1, NULL);
 
     /* Execute the function being tested */
     CS_RecomputeAppChildTask();
@@ -1718,7 +1539,6 @@ void CS_RecomputeAppChildTask_Test_DefEntryId(void)
 {
     CS_Res_App_Table_Entry_t RecomputeAppEntry;
     CS_Def_App_Table_Entry_t DefAppTbl[10];
-    int32                    strCmpResult;
     char                     ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&RecomputeAppEntry, 0, sizeof(RecomputeAppEntry));
@@ -1748,7 +1568,7 @@ void CS_RecomputeAppChildTask_Test_DefEntryId(void)
 
     /* Sets AppInfo.CodeSize = 5, sets AppInfo.CodeAddress = 1, AppInfo.AddressesAreValid = true, and returns
      * CFE_SUCCESS */
-    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetAppInfo), CS_COMPUTE_TEST_CFE_ES_GetAppInfoHandler1, NULL);
+    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetAppInfo), CS_COMPUTE_TEST_CFE_ES_GetModuleInfoHandler1, NULL);
 
     /* Execute the function being tested */
     CS_RecomputeAppChildTask();
@@ -1763,16 +1583,12 @@ void CS_RecomputeAppChildTask_Test_DefEntryId(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_FINISH_APP_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_RecomputeAppChildTask_Test_DefEntryId */
 
@@ -1781,7 +1597,6 @@ void CS_RecomputeTablesChildTask_Test_Nominal(void)
     CS_Res_Tables_Table_Entry_t RecomputeTablesEntry;
     CS_Def_Tables_Table_Entry_t DefTablesTbl[10];
     CFE_TBL_Info_t              TblInfo;
-    int32                       strCmpResult;
     char                        ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&RecomputeTablesEntry, 0, sizeof(RecomputeTablesEntry));
@@ -1835,29 +1650,21 @@ void CS_RecomputeTablesChildTask_Test_Nominal(void)
     CS_RecomputeTablesChildTask();
 
     /* Verify results */
-    UtAssert_True(CS_AppData.RecomputeTablesEntryPtr->State == 99, "CS_AppData.RecomputeTablesEntryPtr->State == 99");
-    UtAssert_True(CS_AppData.DefTablesTblPtr[CS_AppData.ChildTaskEntryID].State == 1,
-                  "CS_AppData.DefTablesTblPtr[CS_AppData.ChildTaskEntryID].State == 1");
-    UtAssert_True(CS_AppData.RecomputeTablesEntryPtr->TempChecksumValue == 0,
-                  "CS_AppData.RecomputeTablesEntryPtr->TempChecksumValue == 0");
-    UtAssert_True(CS_AppData.RecomputeTablesEntryPtr->ByteOffset == 0,
-                  "CS_AppData.RecomputeTablesEntryPtr->ByteOffset == 0");
-    UtAssert_True(CS_AppData.RecomputeTablesEntryPtr->ComputedYet == true,
-                  "CS_AppData.RecomputeTablesEntryPtr->ComputedYet == true");
+    UtAssert_UINT16_EQ(CS_AppData.RecomputeTablesEntryPtr->State, 99);
+    UtAssert_UINT16_EQ(CS_AppData.DefTablesTblPtr[CS_AppData.ChildTaskEntryID].State, 1);
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeTablesEntryPtr->TempChecksumValue, 0);
+    UtAssert_UINT32_EQ(CS_AppData.RecomputeTablesEntryPtr->ByteOffset, 0);
+    UtAssert_BOOL_TRUE(CS_AppData.RecomputeTablesEntryPtr->ComputedYet);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_FINISH_TABLES_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.ChildTaskInUse == false");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_RecomputeTablesChildTask_Test_Nominal */
 
@@ -1914,7 +1721,6 @@ void CS_RecomputeTablesChildTask_Test_DefEntryId(void)
     CS_Res_Tables_Table_Entry_t RecomputeTablesEntry;
     CS_Def_Tables_Table_Entry_t DefTablesTbl[10];
     CFE_TBL_Info_t              TblInfo;
-    int32                       strCmpResult;
     char                        ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     memset(&RecomputeTablesEntry, 0, sizeof(RecomputeTablesEntry));
@@ -1976,23 +1782,18 @@ void CS_RecomputeTablesChildTask_Test_DefEntryId(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_FINISH_TABLES_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.ChildTaskInUse == false");
-
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_RecomputeTablesChildTask_Test_DefEntryId*/
 
 void CS_OneShotChildTask_Test_Nominal(void)
 {
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    char ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "OneShot checksum on Address: 0x%%08X, size %%d completed. Checksum =  0x%%08X");
@@ -2009,23 +1810,19 @@ void CS_OneShotChildTask_Test_Nominal(void)
     CS_OneShotChildTask();
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.LastOneShotChecksum == 1, "CS_AppData.HkPacket.LastOneShotChecksum == 1");
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.LastOneShotChecksum, 1);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ONESHOT_FINISHED_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
-    strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
+    UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
+                          CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == false, "CS_AppData.HkPacket.OneShotInProgress == false");
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.OneShotInProgress);
     UtAssert_BOOL_FALSE(CFE_RESOURCEID_TEST_DEFINED(CS_AppData.ChildTaskID));
 
-    call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
-
-    UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
-                  call_count_CFE_EVS_SendEvent);
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 
 } /* end CS_OneShotChildTask_Test_Nominal */
 
@@ -2061,11 +1858,12 @@ void UtTest_Setup(void)
     UtTest_Add(CS_ComputeTables_Test_ComputeTablesError, CS_Test_Setup, CS_Test_TearDown,
                "CS_ComputeTables_Test_ComputeTablesError");
 
-    UtTest_Add(CS_ComputeApp_Test_Nominal, CS_Test_Setup, CS_Test_TearDown, "CS_ComputeApp_Test_Nominal");
-    UtTest_Add(CS_ComputeApp_Test_GetAppIDByNameError, CS_Test_Setup, CS_Test_TearDown,
-               "CS_ComputeApp_Test_GetAppIDByNameError");
-    UtTest_Add(CS_ComputeApp_Test_GetAppInfoError, CS_Test_Setup, CS_Test_TearDown,
-               "CS_ComputeApp_Test_GetAppInfoError");
+    UtTest_Add(CS_ComputeApp_Test_NominalApp, CS_Test_Setup, CS_Test_TearDown, "CS_ComputeApp_Test_NominalApp");
+    UtTest_Add(CS_ComputeApp_Test_NominalLib, CS_Test_Setup, CS_Test_TearDown, "CS_ComputeApp_Test_NominalLib");
+    UtTest_Add(CS_ComputeApp_Test_GetAppAndLibIDByNameError, CS_Test_Setup, CS_Test_TearDown,
+               "CS_ComputeApp_Test_GetAppAndLibIDByNameError");
+    UtTest_Add(CS_ComputeApp_Test_GetModuleInfoError, CS_Test_Setup, CS_Test_TearDown,
+               "CS_ComputeApp_Test_GetModuleInfoError");
     UtTest_Add(CS_ComputeApp_Test_ComputeAppPlatformError, CS_Test_Setup, CS_Test_TearDown,
                "CS_ComputeApp_Test_ComputeAppPlatformError");
     UtTest_Add(CS_ComputeApp_Test_DifferFromSavedValue, CS_Test_Setup, CS_Test_TearDown,


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #27

**Testing performed**
CI

**Expected behavior changes**
CS_ComputeApp() will now scrub libraries in addition to apps when computing the checksum.

Unit test updates (all in cs_compute_tests.c):
- Separate nominal tests for checking an app vs. library
- Modified App ID name error test to use invalid App and Lib ID
- GetModuleInfo() error test case (instead of GetAppInfo())

**System(s) tested on**
CI