### PR TITLE
Fix #50, Remove redundant/inconsistent comments (/* end of function */, /* end if */ etc.) and clean up empty lines.

### DIFF
--- a/fsw/src/cs_app.c
+++ b/fsw/src/cs_app.c
@@ -218,7 +218,6 @@ void CS_AppMain(void)
 
     /* Let cFE kill the task (and child task) */
     CFE_ES_ExitApp(CS_AppData.RunStatus);
-
 } /* End of CS_AppMain () */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -250,7 +249,6 @@ int32 CS_AppInit(void)
 
     if (Result == CFE_SUCCESS)
     {
-
         /* Set up default tables in memory */
         CS_InitializeDefaultTables();
 
@@ -551,7 +549,6 @@ void CS_HousekeepingCmd(const CS_NoArgsCmd_t *CmdPtr)
     /* Verify the command packet length */
     if (ExpectedLength != ActualLength)
     {
-
         CFE_MSG_GetMsgId(&CmdPtr->CmdHeader.Msg, &MessageID);
         CFE_MSG_GetFcnCode(&CmdPtr->CmdHeader.Msg, &CommandCode);
 
@@ -662,7 +659,6 @@ int32 CS_CreateRestoreStatesFromCDS(void)
     }
 
     return Result;
-
 } /* End of CS_CreateCDS() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/cs_app.c
+++ b/fsw/src/cs_app.c
@@ -218,7 +218,7 @@ void CS_AppMain(void)
 
     /* Let cFE kill the task (and child task) */
     CFE_ES_ExitApp(CS_AppData.RunStatus);
-} /* End of CS_AppMain () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -293,7 +293,7 @@ int32 CS_AppInit(void)
                               CS_MAJOR_VERSION, CS_MINOR_VERSION, CS_REVISION, CS_MISSION_REV);
     }
     return Result;
-} /* End of CS_AppInit () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -335,7 +335,7 @@ int32 CS_AppPipe(const CFE_SB_Buffer_t *BufPtr)
     }
 
     return Result;
-} /* End of CS_AppPipe () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -563,7 +563,7 @@ void CS_HousekeepingCmd(const CS_NoArgsCmd_t *CmdPtr)
         CFE_SB_TimeStampMsg(&CS_AppData.HkPacket.TlmHeader.Msg);
         CFE_SB_TransmitMsg(&CS_AppData.HkPacket.TlmHeader.Msg, true);
     }
-} /* End of CS_HousekeepingCmd () */
+}
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
 
@@ -659,7 +659,7 @@ int32 CS_CreateRestoreStatesFromCDS(void)
     }
 
     return Result;
-} /* End of CS_CreateCDS() */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -704,9 +704,5 @@ void CS_UpdateCDS(void)
             CS_AppData.DataStoreHandle = CFE_ES_CDS_BAD_HANDLE;
         }
     }
-} /* End of CS_UpdateCDS() */
+}
 #endif /* #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true   ) */
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/src/cs_app.h
+++ b/fsw/src/cs_app.h
@@ -176,7 +176,6 @@ typedef struct
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
     CFE_ES_CDSHandle_t DataStoreHandle; /**< \brief Handle to critical data store created by CS */
 #endif
-
 } CS_AppData_t;
 
 /**************************************************************************

--- a/fsw/src/cs_app_cmds.c
+++ b/fsw/src/cs_app_cmds.c
@@ -65,7 +65,7 @@ void CS_DisableAppCmd(const CS_NoArgsCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdCounter++;
         }
     }
-} /* End of CS_DisableAppCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -92,7 +92,7 @@ void CS_EnableAppCmd(const CS_NoArgsCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdCounter++;
         }
     }
-} /* End of CS_EnableAppCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -136,7 +136,7 @@ void CS_ReportBaselineAppCmd(const CS_AppNameCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdErrCounter++;
         }
     }
-} /* End of CS_ReportBaselineAppCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -205,7 +205,7 @@ void CS_RecomputeBaselineAppCmd(const CS_AppNameCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdErrCounter++;
         }
     }
-} /* end CS_RecomputeBaselineAppCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -261,7 +261,7 @@ void CS_DisableNameAppCmd(const CS_AppNameCmd_t *CmdPtr)
             }
         } /* end InProgress if */
     }
-} /* End of CS_DisableNameAppCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -314,8 +314,4 @@ void CS_EnableNameAppCmd(const CS_AppNameCmd_t *CmdPtr)
             }
         } /* end InProgress if */
     }
-} /* End of CS_EnableNameAppCmd () */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/cs_app_cmds.c
+++ b/fsw/src/cs_app_cmds.c
@@ -52,10 +52,8 @@ void CS_DisableAppCmd(const CS_NoArgsCmd_t *CmdPtr)
     /* Verify command packet length */
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))
     {
-
         if (CS_CheckRecomputeOneshot() == false)
         {
-
             CS_AppData.HkPacket.AppCSState = CS_STATE_DISABLED;
             CS_ZeroAppTempValues();
 
@@ -82,10 +80,8 @@ void CS_EnableAppCmd(const CS_NoArgsCmd_t *CmdPtr)
     /* Verify command packet length */
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))
     {
-
         if (CS_CheckRecomputeOneshot() == false)
         {
-
             CS_AppData.HkPacket.AppCSState = CS_STATE_ENABLED;
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
@@ -235,7 +231,6 @@ void CS_DisableNameAppCmd(const CS_AppNameCmd_t *CmdPtr)
 
             if (CS_GetAppResTblEntryByName(&ResultsEntry, Name))
             {
-
                 ResultsEntry->State             = CS_STATE_DISABLED;
                 ResultsEntry->TempChecksumValue = 0;
                 ResultsEntry->ByteOffset        = 0;

--- a/fsw/src/cs_cmds.c
+++ b/fsw/src/cs_cmds.c
@@ -59,7 +59,7 @@ void CS_NoopCmd(const CS_NoArgsCmd_t *CmdPtr)
         CFE_EVS_SendEvent(CS_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op command. Version %d.%d.%d.%d",
                           CS_MAJOR_VERSION, CS_MINOR_VERSION, CS_REVISION, CS_MISSION_REV);
     }
-} /* End of CS_NoopCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -87,7 +87,7 @@ void CS_ResetCmd(const CS_NoArgsCmd_t *CmdPtr)
 
         CFE_EVS_SendEvent(CS_RESET_DBG_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command recieved");
     }
-} /* End of CS_ResetCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -195,7 +195,7 @@ void CS_BackgroundCheckCycle(const CS_NoArgsCmd_t *CmdPtr)
             /* CS is disabled, Application-wide */
         }
     }
-} /* End of CS_BackgroundCheckCycle () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -226,7 +226,7 @@ void CS_DisableAllCSCmd(const CS_NoArgsCmd_t *CmdPtr)
 
         CFE_EVS_SendEvent(CS_DISABLE_ALL_INF_EID, CFE_EVS_EventType_INFORMATION, "Background Checksumming Disabled");
     }
-} /* End of CS_DisableAllCSCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -247,7 +247,7 @@ void CS_EnableAllCSCmd(const CS_NoArgsCmd_t *CmdPtr)
 
         CFE_EVS_SendEvent(CS_ENABLE_ALL_INF_EID, CFE_EVS_EventType_INFORMATION, "Background Checksumming Enabled");
     }
-} /* End of CS_EnableAllCSCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -274,7 +274,7 @@ void CS_DisableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
 
         CS_AppData.HkPacket.CmdCounter++;
     }
-} /* End of CS_DisableCfeCoreCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -300,7 +300,7 @@ void CS_EnableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
 
         CS_AppData.HkPacket.CmdCounter++;
     }
-} /* End of CS_EnableCfeCoreCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -327,7 +327,7 @@ void CS_DisableOSCmd(const CS_NoArgsCmd_t *CmdPtr)
 
         CS_AppData.HkPacket.CmdCounter++;
     }
-} /* End of CS_DisableOSCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -353,7 +353,7 @@ void CS_EnableOSCmd(const CS_NoArgsCmd_t *CmdPtr)
 
         CS_AppData.HkPacket.CmdCounter++;
     }
-} /* End of CS_OSEnableCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -381,7 +381,7 @@ void CS_ReportBaselineCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
         }
         CS_AppData.HkPacket.CmdCounter++;
     }
-} /* End of CS_ReportBaselineCfeCoreCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -409,7 +409,7 @@ void CS_ReportBaselineOSCmd(const CS_NoArgsCmd_t *CmdPtr)
         }
         CS_AppData.HkPacket.CmdCounter++;
     }
-} /* End of CS_ReportBaselineOSCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -463,7 +463,7 @@ void CS_RecomputeBaselineCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdErrCounter++;
         }
     }
-} /* end CS_RecomputeBaselineCfeCoreCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -515,7 +515,7 @@ void CS_RecomputeBaselineOSCmd(const CS_NoArgsCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdErrCounter++;
         }
     }
-} /* end CS_RecomputeBaselineOSCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -596,7 +596,7 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdErrCounter++;
         }
     }
-} /* end CS_OneShotCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -641,8 +641,4 @@ void CS_CancelOneShotCmd(const CS_NoArgsCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdErrCounter++;
         }
     }
-} /* end CS_CancelOneShotCmd */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/cs_cmds.c
+++ b/fsw/src/cs_cmds.c
@@ -121,7 +121,6 @@ void CS_BackgroundCheckCycle(const CS_NoArgsCmd_t *CmdPtr)
     {
         if (CS_AppData.HkPacket.ChecksumState == CS_STATE_ENABLED)
         {
-
             DoneWithCycle = false;
             EndOfList     = false;
 
@@ -533,7 +532,6 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
     /* Verify command packet length... */
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))
     {
-
         /* validate size and address */
         Status = CFE_PSP_MemValidateRange(CmdPtr->Address, CmdPtr->Size, CFE_PSP_MEM_ANY);
 

--- a/fsw/src/cs_compute.c
+++ b/fsw/src/cs_compute.c
@@ -109,7 +109,6 @@ int32 CS_ComputeEepromMemory(CS_Res_EepromMemory_Table_Entry_t *ResultsEntry, ui
     }
 
     return Status;
-
 } /* End of CS_ComputeEepromMemory () */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -289,7 +288,6 @@ int32 CS_ComputeTables(CS_Res_Tables_Table_Entry_t *ResultsEntry, uint32 *Comput
     } /* end if tabled was success or updated */
     else
     {
-
         CFE_EVS_SendEvent(CS_COMPUTE_TABLES_ERR_EID, CFE_EVS_EventType_ERROR,
                           "CS Tables: Problem Getting table %s info Share: 0x%08X, GetInfo: 0x%08X, GetAddress: 0x%08X",
                           ResultsEntry->Name, (unsigned int)ResultShare, (unsigned int)ResultGetInfo,
@@ -299,7 +297,6 @@ int32 CS_ComputeTables(CS_Res_Tables_Table_Entry_t *ResultsEntry, uint32 *Comput
     }
 
     return Status;
-
 } /* End of CS_ComputeTables () */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -433,7 +430,6 @@ int32 CS_ComputeApp(CS_Res_App_Table_Entry_t *ResultsEntry, uint32 *ComputedCSVa
     }
 
     return Status;
-
 } /* End of CS_ComputeApp () */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/cs_compute.c
+++ b/fsw/src/cs_compute.c
@@ -109,7 +109,7 @@ int32 CS_ComputeEepromMemory(CS_Res_EepromMemory_Table_Entry_t *ResultsEntry, ui
     }
 
     return Status;
-} /* End of CS_ComputeEepromMemory () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -297,7 +297,7 @@ int32 CS_ComputeTables(CS_Res_Tables_Table_Entry_t *ResultsEntry, uint32 *Comput
     }
 
     return Status;
-} /* End of CS_ComputeTables () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -430,7 +430,7 @@ int32 CS_ComputeApp(CS_Res_App_Table_Entry_t *ResultsEntry, uint32 *ComputedCSVa
     }
 
     return Status;
-} /* End of CS_ComputeApp () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -560,7 +560,7 @@ void CS_RecomputeEepromMemoryChildTask(void)
 
     CS_AppData.HkPacket.RecomputeInProgress = false;
     CFE_ES_ExitChildTask();
-} /* end CS_RecomputeEepromMemoryChildTask */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -666,7 +666,7 @@ void CS_RecomputeAppChildTask(void)
 
     CS_AppData.HkPacket.RecomputeInProgress = false;
     CFE_ES_ExitChildTask();
-} /* end CS_RecomputeAppChildTask */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -772,7 +772,7 @@ void CS_RecomputeTablesChildTask(void)
 
     CS_AppData.HkPacket.RecomputeInProgress = false;
     CFE_ES_ExitChildTask();
-} /* end CS_RecomputeTablesChildTask */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -822,8 +822,4 @@ void CS_OneShotChildTask(void)
     CS_AppData.ChildTaskID                = CFE_ES_TASKID_UNDEFINED;
 
     CFE_ES_ExitChildTask();
-} /* end CS_OneShotChildTask */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/cs_eeprom_cmds.c
+++ b/fsw/src/cs_eeprom_cmds.c
@@ -54,10 +54,8 @@ void CS_DisableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
     /* Verify command packet length */
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))
     {
-
         if (CS_CheckRecomputeOneshot() == false)
         {
-
             CS_AppData.HkPacket.EepromCSState = CS_STATE_DISABLED;
             CS_ZeroEepromTempValues();
 
@@ -86,10 +84,8 @@ void CS_EnableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
     /* Verify command packet length */
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))
     {
-
         if (CS_CheckRecomputeOneshot() == false)
         {
-
             CS_AppData.HkPacket.EepromCSState = CS_STATE_ENABLED;
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
@@ -188,7 +184,6 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
             if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
                 (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
             {
-
                 /* There is no child task running right now, we can use it*/
                 CS_AppData.HkPacket.RecomputeInProgress = true;
 
@@ -263,10 +258,8 @@ void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
     /* Verify command packet length */
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))
     {
-
         if (CS_CheckRecomputeOneshot() == false)
         {
-
             EntryID = CmdPtr->EntryID;
 
             if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
@@ -331,7 +324,6 @@ void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
     /* Verify command packet length */
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))
     {
-
         if (CS_CheckRecomputeOneshot() == false)
         {
             EntryID = CmdPtr->EntryID;
@@ -412,7 +404,6 @@ void CS_GetEntryIDEepromCmd(const CS_GetEntryIDCmd_t *CmdPtr)
                 CmdPtr->Address <= (ResultsEntry.StartAddress + ResultsEntry.NumBytesToChecksum) &&
                 ResultsEntry.State != CS_STATE_EMPTY)
             {
-
                 CFE_EVS_SendEvent(CS_GET_ENTRY_ID_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
                                   "Eeprom Found Address 0x%08X in Entry ID %d", (unsigned int)(CmdPtr->Address), Loop);
                 EntryFound = true;

--- a/fsw/src/cs_eeprom_cmds.c
+++ b/fsw/src/cs_eeprom_cmds.c
@@ -69,7 +69,7 @@ void CS_DisableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdCounter++;
         }
     }
-} /* End of CS_DisableEepromCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -98,7 +98,7 @@ void CS_EnableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdCounter++;
         }
     }
-} /* End of CS_EnableEepromCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -156,7 +156,7 @@ void CS_ReportBaselineEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdErrCounter++;
         }
     }
-} /* End of CS_ReportBaselineEntryIDCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -239,7 +239,7 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdErrCounter++;
         }
     }
-} /* end CS_RecomputeBaselineEepromCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -305,7 +305,7 @@ void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
             }
         } /* end InProgress if */
     }
-} /* End of CS_EnableCSEntryIDEepromCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -374,7 +374,7 @@ void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
             }
         } /* end InProgress if */
     }
-} /* End of CS_DisableCSEntryIDEepromCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -417,8 +417,4 @@ void CS_GetEntryIDEepromCmd(const CS_GetEntryIDCmd_t *CmdPtr)
         }
         CS_AppData.HkPacket.CmdCounter++;
     }
-} /* End of CS_GetEntryIDEepromCmd () */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/cs_memory_cmds.c
+++ b/fsw/src/cs_memory_cmds.c
@@ -56,7 +56,6 @@ void CS_DisableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
     {
         if (CS_CheckRecomputeOneshot() == false)
         {
-
             CS_AppData.HkPacket.MemoryCSState = CS_STATE_DISABLED;
             CS_ZeroMemoryTempValues();
 
@@ -85,10 +84,8 @@ void CS_EnableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
     /* Verify command packet length */
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))
     {
-
         if (CS_CheckRecomputeOneshot() == false)
         {
-
             CS_AppData.HkPacket.MemoryCSState = CS_STATE_ENABLED;
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
@@ -181,12 +178,10 @@ void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 
         if (CS_AppData.HkPacket.RecomputeInProgress == false && CS_AppData.HkPacket.OneShotInProgress == false)
         {
-
             /* make sure the entry is a valid number and is defined in the table */
             if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
                 (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
             {
-
                 /* There is no child task running right now, we can use it*/
                 CS_AppData.HkPacket.RecomputeInProgress = true;
 
@@ -325,7 +320,6 @@ void CS_DisableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
     /* Verify command packet length */
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))
     {
-
         if (CS_CheckRecomputeOneshot() == false)
         {
             EntryID = CmdPtr->EntryID;
@@ -405,7 +399,6 @@ void CS_GetEntryIDMemoryCmd(const CS_GetEntryIDCmd_t *CmdPtr)
                 CmdPtr->Address <= (ResultsEntry->StartAddress + ResultsEntry->NumBytesToChecksum) &&
                 ResultsEntry->State != CS_STATE_EMPTY)
             {
-
                 CFE_EVS_SendEvent(CS_GET_ENTRY_ID_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
                                   "Memory Found Address 0x%08X in Entry ID %d", (unsigned int)(CmdPtr->Address), Loop);
                 EntryFound = true;

--- a/fsw/src/cs_memory_cmds.c
+++ b/fsw/src/cs_memory_cmds.c
@@ -69,7 +69,7 @@ void CS_DisableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdCounter++;
         }
     }
-} /* End of CS_DisableMemoryCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -98,7 +98,7 @@ void CS_EnableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdCounter++;
         }
     }
-} /* End of CS_EnableMemoryCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -155,7 +155,7 @@ void CS_ReportBaselineEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdErrCounter++;
         }
     }
-} /* End of CS_ReportBaselineEntryIDCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -237,7 +237,7 @@ void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdErrCounter++;
         }
     }
-} /* end CS_RecomputeBaselineMemoryCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -302,7 +302,7 @@ void CS_EnableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
             }
         } /* end InProgress if */
     }
-} /* End of CS_EnableCSEntryIDMemoryCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -370,7 +370,7 @@ void CS_DisableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
             }
         } /* end InProgress if */
     }
-} /* End of CS_DisableCSEntryIDMemoryCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -412,8 +412,4 @@ void CS_GetEntryIDMemoryCmd(const CS_GetEntryIDCmd_t *CmdPtr)
         }
         CS_AppData.HkPacket.CmdCounter++;
     }
-} /* End of CS_GetEntryIDMemoryCmd () */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/cs_msg.h
+++ b/fsw/src/cs_msg.h
@@ -99,7 +99,6 @@ typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader;
     cpuaddr                 Address; /**< \brief Address to get the ID for */
-
 } CS_GetEntryIDCmd_t;
 
 /**

--- a/fsw/src/cs_table_cmds.c
+++ b/fsw/src/cs_table_cmds.c
@@ -52,7 +52,6 @@ void CS_DisableTablesCmd(const CS_NoArgsCmd_t *CmdPtr)
     /* Verify command packet length */
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))
     {
-
         if (CS_CheckRecomputeOneshot() == false)
         {
             CS_AppData.HkPacket.TablesCSState = CS_STATE_DISABLED;
@@ -82,10 +81,8 @@ void CS_EnableTablesCmd(const CS_NoArgsCmd_t *CmdPtr)
     /* Verify command packet length */
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))
     {
-
         if (CS_CheckRecomputeOneshot() == false)
         {
-
             CS_AppData.HkPacket.TablesCSState = CS_STATE_ENABLED;
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
@@ -162,7 +159,6 @@ void CS_RecomputeBaselineTablesCmd(const CS_TableNameCmd_t *CmdPtr)
 
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))
     {
-
         if (CS_AppData.HkPacket.RecomputeInProgress == false && CS_AppData.HkPacket.OneShotInProgress == false)
         {
             strncpy(Name, CmdPtr->Name, sizeof(Name) - 1);
@@ -237,7 +233,6 @@ void CS_DisableNameTablesCmd(const CS_TableNameCmd_t *CmdPtr)
 
             if (CS_GetTableResTblEntryByName(&ResultsEntry, Name))
             {
-
                 ResultsEntry->State             = CS_STATE_DISABLED;
                 ResultsEntry->TempChecksumValue = 0;
                 ResultsEntry->ByteOffset        = 0;

--- a/fsw/src/cs_table_cmds.c
+++ b/fsw/src/cs_table_cmds.c
@@ -66,7 +66,7 @@ void CS_DisableTablesCmd(const CS_NoArgsCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdCounter++;
         }
     }
-} /* End of CS_DisableTablesCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -94,7 +94,7 @@ void CS_EnableTablesCmd(const CS_NoArgsCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdCounter++;
         }
     }
-} /* End of CS_EnableTablesCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -138,7 +138,7 @@ void CS_ReportBaselineTablesCmd(const CS_TableNameCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdErrCounter++;
         }
     }
-} /* End of CS_ReportBaselineTablesCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -207,7 +207,7 @@ void CS_RecomputeBaselineTablesCmd(const CS_TableNameCmd_t *CmdPtr)
             CS_AppData.HkPacket.CmdErrCounter++;
         }
     }
-} /* end CS_RecomputeBaselineTablesCmd */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -262,7 +262,7 @@ void CS_DisableNameTablesCmd(const CS_TableNameCmd_t *CmdPtr)
             }
         } /* end InProgress if */
     }
-} /* End of CS_DisableNameTablesCmd () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -315,8 +315,4 @@ void CS_EnableNameTablesCmd(const CS_TableNameCmd_t *CmdPtr)
             }
         } /* end InProgress if */
     }
-} /* End of CS_EnableNameTablesCmd () */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/cs_table_processing.c
+++ b/fsw/src/cs_table_processing.c
@@ -118,7 +118,7 @@ int32 CS_ValidateEepromChecksumDefinitionTable(void *TblPtr)
                       (int)BadCount, (int)EmptyCount);
 
     return Result;
-} /* CS_ValidateEEPROMCheckSumDefinitionTable */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -202,7 +202,7 @@ int32 CS_ValidateMemoryChecksumDefinitionTable(void *TblPtr)
                       (int)BadCount, (int)EmptyCount);
 
     return Result;
-} /* CS_ValidateMemoryCheckSumDefinitionTable */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -318,7 +318,7 @@ int32 CS_ValidateTablesChecksumDefinitionTable(void *TblPtr)
                       (int)BadCount, (int)EmptyCount);
 
     return Result;
-} /* CS_ValidateTablesCheckSumDefinitionTable */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -433,7 +433,7 @@ int32 CS_ValidateAppChecksumDefinitionTable(void *TblPtr)
                       (int)BadCount, (int)EmptyCount);
 
     return Result;
-} /* CS_ValidateAppCheckSumDefinitionTable */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -528,7 +528,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable(const CS_Def_EepromMemory_Table_En
         CFE_EVS_SendEvent(CS_PROCESS_EEPROM_MEMORY_NO_ENTRIES_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "CS %s Table: No valid entries in the table", TableType);
     }
-} /* end of CS_ProcessNewEepromMemoryDefinitionTable () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -720,7 +720,7 @@ void CS_ProcessNewTablesDefinitionTable(const CS_Def_Tables_Table_Entry_t *Defin
         CFE_EVS_SendEvent(CS_PROCESS_TABLES_NO_ENTRIES_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "CS Tables Table: No valid entries in the table");
     }
-} /* end of CS_ProcessNewTablesDefinitionTable () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -791,7 +791,7 @@ void CS_ProcessNewAppDefinitionTable(const CS_Def_App_Table_Entry_t *DefinitionT
         CFE_EVS_SendEvent(CS_PROCESS_APP_NO_ENTRIES_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "CS Apps Table: No valid entries in the table");
     }
-} /* end of CS_ProcessNewAppsDefinitionTable () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -935,7 +935,7 @@ int32 CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handle_t *Re
         }
     }
     return Result;
-} /* end of CS_CheckSum_Definition_Table_Init () */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -1043,8 +1043,4 @@ int32 CS_HandleTableUpdate(void *DefinitionTblPtr, void *ResultsTblPtr, CFE_TBL_
         }
     }
     return Result;
-} /* end CS_HandleTableUpdate */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/fsw/src/cs_table_processing.c
+++ b/fsw/src/cs_table_processing.c
@@ -769,7 +769,6 @@ void CS_ProcessNewAppDefinitionTable(const CS_Def_App_Table_Entry_t *DefinitionT
         }
         else
         {
-
             ResultsEntry->State              = CS_STATE_EMPTY;
             ResultsEntry->ComputedYet        = false;
             ResultsEntry->NumBytesToChecksum = 0;
@@ -852,7 +851,6 @@ int32 CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handle_t *Re
      the default tables in CS */
     if (ResultFromLoad != CFE_SUCCESS)
     {
-
         Result           = CFE_TBL_Load(*DefinitionTableHandle, CFE_TBL_SRC_ADDRESS, DefaultDefTableAddress);
         LoadedFromMemory = true;
     }
@@ -865,7 +863,6 @@ int32 CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handle_t *Re
         {
             if (Table == CS_APP_TABLE)
             {
-
                 CS_ProcessNewAppDefinitionTable((CS_Def_App_Table_Entry_t *)DefinitionTblPtr,
                                                 (CS_Res_App_Table_Entry_t *)ResultsTblPtr);
             }
@@ -938,7 +935,6 @@ int32 CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handle_t *Re
         }
     }
     return Result;
-
 } /* end of CS_CheckSum_Definition_Table_Init () */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -990,10 +986,8 @@ int32 CS_HandleTableUpdate(void *DefinitionTblPtr, void *ResultsTblPtr, CFE_TBL_
             {
                 if (CS_AppData.ResTablesTblPtr[Loop].TblHandle != CFE_TBL_BAD_TABLE_HANDLE)
                 {
-
                     if (CS_AppData.ResTablesTblPtr[Loop].IsCSOwner == false)
                     {
-
                         CFE_TBL_Unregister(CS_AppData.ResTablesTblPtr[Loop].TblHandle);
                     }
                 }
@@ -1004,7 +998,6 @@ int32 CS_HandleTableUpdate(void *DefinitionTblPtr, void *ResultsTblPtr, CFE_TBL_
         }
         else
         {
-
             if (Table == CS_APP_TABLE)
             {
                 CS_ProcessNewAppDefinitionTable((CS_Def_App_Table_Entry_t *)DefinitionTblPtr,

--- a/fsw/src/cs_utils.c
+++ b/fsw/src/cs_utils.c
@@ -102,6 +102,7 @@ void CS_ZeroAppTempValues(void)
         CS_AppData.ResAppTblPtr[Loop].ByteOffset        = 0;
     }
 }
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* CS Zero out the temp chcksum values ofthe cFE core              */
@@ -123,6 +124,7 @@ void CS_ZeroOSTempValues(void)
     CS_AppData.OSCodeSeg.TempChecksumValue = 0;
     CS_AppData.OSCodeSeg.ByteOffset        = 0;
 }
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* CS Nullifies the entries in the Results table for All           */
@@ -454,7 +456,6 @@ bool CS_VerifyCmdLength(const CFE_MSG_Message_t *msg, size_t ExpectedLength)
     /* Verify the command packet length */
     if (ExpectedLength != ActualLength)
     {
-
         CFE_MSG_GetMsgId(msg, &MessageID);
         CFE_MSG_GetFcnCode(msg, &CommandCode);
 
@@ -489,7 +490,6 @@ bool CS_BackgroundCfeCore(void)
            a ground-commanded recompute) */
         if (ResultsEntry->State == CS_STATE_ENABLED)
         {
-
             /* If we complete an entry's checksum, this function will update it for us */
             Status = CS_ComputeEepromMemory(ResultsEntry, &ComputedCSValue, &DoneWithEntry);
 
@@ -599,7 +599,6 @@ bool CS_BackgroundOS(void)
         CS_GoToNextTable();
     }
     return DoneWithCycle;
-
 } /* end CS_BackgroundOS */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -675,7 +674,6 @@ bool CS_BackgroundEeprom(void)
     }
 
     return DoneWithCycle;
-
 } /* end CS_BackgroundEeprom */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -745,7 +743,6 @@ bool CS_BackgroundMemory(void)
     }
 
     return DoneWithCycle;
-
 } /* end CS_BackgroundMemory */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -823,7 +820,6 @@ bool CS_BackgroundTables(void)
     }
 
     return DoneWithCycle;
-
 } /* end CS_BackgroundTables */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -898,7 +894,6 @@ bool CS_BackgroundApp(void)
         CS_GoToNextTable();
     }
     return DoneWithCycle;
-
 } /* end CS_BackgroundApp */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/cs_utils.c
+++ b/fsw/src/cs_utils.c
@@ -159,7 +159,7 @@ void CS_InitializeDefaultTables(void)
         CS_AppData.DefaultTablesDefTable[Loop].State   = CS_STATE_EMPTY;
         CS_AppData.DefaultTablesDefTable[Loop].Name[0] = '\0';
     }
-} /* end CS_InitializeDefaultTables */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -211,7 +211,7 @@ bool CS_GetTableResTblEntryByName(CS_Res_Tables_Table_Entry_t **EntryPtr, const 
         }
     }
     return Status;
-} /* end CS_GetTableResTblEntryByName */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -242,7 +242,7 @@ bool CS_GetTableDefTblEntryByName(CS_Def_Tables_Table_Entry_t **EntryPtr, const 
         }
     }
     return Status;
-} /* end CS_GetTableDefTblEntryByName */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -272,7 +272,7 @@ bool CS_GetAppResTblEntryByName(CS_Res_App_Table_Entry_t **EntryPtr, const char 
         }
     }
     return Status;
-} /* end CS_GetAppResTblEntryByName */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -302,7 +302,7 @@ bool CS_GetAppDefTblEntryByName(CS_Def_App_Table_Entry_t **EntryPtr, const char 
         }
     }
     return Status;
-} /* end CS_GetAppDefTblEntryByName */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -336,7 +336,7 @@ bool CS_FindEnabledEepromEntry(uint16 *EnabledEntry)
     *EnabledEntry = CS_AppData.HkPacket.CurrentEntryInTable;
 
     return EnabledEntries;
-} /* end CS FindEnabledEepromEntry */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -369,7 +369,7 @@ bool CS_FindEnabledMemoryEntry(uint16 *EnabledEntry)
     *EnabledEntry = CS_AppData.HkPacket.CurrentEntryInTable;
 
     return EnabledEntries;
-} /* end CS FindEnabledMemoryEntry */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -404,7 +404,7 @@ bool CS_FindEnabledTablesEntry(uint16 *EnabledEntry)
     *EnabledEntry = CS_AppData.HkPacket.CurrentEntryInTable;
 
     return EnabledEntries;
-} /* end CS FindEnabledTablesEntry */
+}
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* CS Get the next CS-enabled entry of this table                  */
@@ -437,7 +437,7 @@ bool CS_FindEnabledAppEntry(uint16 *EnabledEntry)
     *EnabledEntry = CS_AppData.HkPacket.CurrentEntryInTable;
 
     return EnabledEntries;
-} /* end CS FindEnabledAppEntry */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -467,7 +467,7 @@ bool CS_VerifyCmdLength(const CFE_MSG_Message_t *msg, size_t ExpectedLength)
         CS_AppData.HkPacket.CmdErrCounter++;
     }
     return Result;
-} /* End of CS_VerifyCmdLength */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -534,7 +534,7 @@ bool CS_BackgroundCfeCore(void)
     }
 
     return DoneWithCycle;
-} /* end CS_BackgroundCfeCore */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -599,7 +599,7 @@ bool CS_BackgroundOS(void)
         CS_GoToNextTable();
     }
     return DoneWithCycle;
-} /* end CS_BackgroundOS */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -674,7 +674,7 @@ bool CS_BackgroundEeprom(void)
     }
 
     return DoneWithCycle;
-} /* end CS_BackgroundEeprom */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -743,7 +743,7 @@ bool CS_BackgroundMemory(void)
     }
 
     return DoneWithCycle;
-} /* end CS_BackgroundMemory */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -820,7 +820,7 @@ bool CS_BackgroundTables(void)
     }
 
     return DoneWithCycle;
-} /* end CS_BackgroundTables */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -894,7 +894,7 @@ bool CS_BackgroundApp(void)
         CS_GoToNextTable();
     }
     return DoneWithCycle;
-} /* end CS_BackgroundApp */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -910,7 +910,7 @@ void CS_ResetTablesTblResultEntry(CS_Res_Tables_Table_Entry_t *TablesTblResultEn
         TablesTblResultEntry->TempChecksumValue = 0;
         TablesTblResultEntry->ComputedYet       = false;
     }
-} /* end CS_ResetTablesTblResultEntry */
+}
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
@@ -999,7 +999,7 @@ int32 CS_HandleRoutineTableUpdates(void)
     }
 
     return ErrorCode;
-} /* end CS_HandleRoutineTableUpdates */
+}
 
 int32 CS_AttemptTableReshare(CS_Res_Tables_Table_Entry_t *ResultsEntry, CFE_TBL_Handle_t *LocalTblHandle,
                              CFE_TBL_Info_t *TblInfo, cpuaddr *LocalAddress, int32 *ResultGetInfo)
@@ -1052,7 +1052,3 @@ bool CS_CheckRecomputeOneshot(void)
     }
     return Result;
 }
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/tables/cs_apptbl.c
+++ b/fsw/tables/cs_apptbl.c
@@ -62,7 +62,3 @@ CS_Def_App_Table_Entry_t CS_AppTable[CS_MAX_NUM_APP_TABLE_ENTRIES] = {
 ** Table file header
 */
 CFE_TBL_FILEDEF(CS_AppTable, CS.DefAppTbl, CS App Tbl, cs_apptbl.tbl)
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/tables/cs_eepromtbl.c
+++ b/fsw/tables/cs_eepromtbl.c
@@ -70,7 +70,3 @@ CS_Def_EepromMemory_Table_Entry_t CS_EepromTable[CS_MAX_NUM_EEPROM_TABLE_ENTRIES
 ** Table file header
 */
 CFE_TBL_FILEDEF(CS_EepromTable, CS.DefEepromTbl, CS EEPROM Tbl, cs_eepromtbl.tbl)
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/tables/cs_memorytbl.c
+++ b/fsw/tables/cs_memorytbl.c
@@ -70,7 +70,3 @@ CS_Def_EepromMemory_Table_Entry_t CS_MemoryTable[CS_MAX_NUM_MEMORY_TABLE_ENTRIES
 ** Table file header
 */
 CFE_TBL_FILEDEF(CS_MemoryTable, CS.DefMemoryTbl, CS Memory Tbl, cs_memorytbl.tbl)
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/fsw/tables/cs_tablestbl.c
+++ b/fsw/tables/cs_tablestbl.c
@@ -63,7 +63,3 @@ CS_Def_Tables_Table_Entry_t CS_TablesTable[CS_MAX_NUM_TABLES_TABLE_ENTRIES] = {
 ** Table file header
 */
 CFE_TBL_FILEDEF(CS_TablesTable, CS.DefTablesTbl, CS Tables Tbl, cs_tablestbl.tbl)
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/unit-test/cs_app_cmds_tests.c
+++ b/unit-test/cs_app_cmds_tests.c
@@ -104,7 +104,7 @@ void CS_DisableAppCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableAppCmd_Test */
+}
 
 void CS_DisableAppCmd_Test_VerifyError(void)
 {
@@ -122,7 +122,7 @@ void CS_DisableAppCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableAppCmd_Test_VerifyError */
+}
 
 void CS_DisableAppCmd_Test_OneShot(void)
 {
@@ -142,7 +142,7 @@ void CS_DisableAppCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableAppCmd_Test_OneShot */
+}
 
 void CS_EnableAppCmd_Test(void)
 {
@@ -176,7 +176,7 @@ void CS_EnableAppCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableAppCmd_Test */
+}
 
 void CS_EnableAppCmd_Test_VerifyError(void)
 {
@@ -194,7 +194,7 @@ void CS_EnableAppCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableAppCmd_Test_VerifyError */
+}
 
 void CS_EnableAppCmd_Test_OneShot(void)
 {
@@ -214,7 +214,7 @@ void CS_EnableAppCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableAppCmd_Test_OneShot */
+}
 
 void CS_ReportBaselineAppCmd_Test_Baseline(void)
 {
@@ -254,7 +254,7 @@ void CS_ReportBaselineAppCmd_Test_Baseline(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineAppCmd_Test_Baseline */
+}
 
 void CS_ReportBaselineAppCmd_Test_NoBaseline(void)
 {
@@ -296,7 +296,7 @@ void CS_ReportBaselineAppCmd_Test_NoBaseline(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineAppCmd_Test_NoBaseline */
+}
 
 void CS_ReportBaselineAppCmd_Test_BaselineInvalidName(void)
 {
@@ -332,7 +332,7 @@ void CS_ReportBaselineAppCmd_Test_BaselineInvalidName(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineAppCmd_Test_BaselineInvalidName */
+}
 
 void CS_ReportBaselineAppCmd_Test_VerifyError(void)
 {
@@ -350,7 +350,7 @@ void CS_ReportBaselineAppCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineAppCmd_Test_VerifyError */
+}
 
 void CS_ReportBaselineAppCmd_Test_OneShot(void)
 {
@@ -389,7 +389,7 @@ void CS_ReportBaselineAppCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineAppCmd_Test_OneShot */
+}
 
 void CS_RecomputeBaselineAppCmd_Test_Nominal(void)
 {
@@ -437,7 +437,7 @@ void CS_RecomputeBaselineAppCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineAppCmd_Test_Nominal */
+}
 
 void CS_RecomputeBaselineAppCmd_Test_CreateChildTaskError(void)
 {
@@ -484,7 +484,7 @@ void CS_RecomputeBaselineAppCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineAppCmd_Test_CreateChildTaskError */
+}
 
 void CS_RecomputeBaselineAppCmd_Test_UnknownNameError(void)
 {
@@ -523,7 +523,7 @@ void CS_RecomputeBaselineAppCmd_Test_UnknownNameError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineAppCmd_Test_UnknownNameError */
+}
 
 void CS_RecomputeBaselineAppCmd_Test_RecomputeInProgress(void)
 {
@@ -561,7 +561,7 @@ void CS_RecomputeBaselineAppCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineAppCmd_Test_RecomputeInProgress */
+}
 
 void CS_RecomputeBaselineAppCmd_Test_VerifyError(void)
 {
@@ -579,7 +579,7 @@ void CS_RecomputeBaselineAppCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineAppCmd_Test_VerifyError */
+}
 
 void CS_DisableNameAppCmd_Test_Nominal(void)
 {
@@ -627,7 +627,7 @@ void CS_DisableNameAppCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableNameAppCmd_Test_Nominal */
+}
 
 void CS_DisableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
 {
@@ -683,7 +683,7 @@ void CS_DisableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableNameAppCmd_Test_UpdateAppsDefinitionTableError */
+}
 
 void CS_DisableNameAppCmd_Test_UnknownNameError(void)
 {
@@ -721,7 +721,7 @@ void CS_DisableNameAppCmd_Test_UnknownNameError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableNameAppCmd_Test_UnknownNameError */
+}
 
 void CS_DisableNameAppCmd_Test_VerifyError(void)
 {
@@ -739,7 +739,7 @@ void CS_DisableNameAppCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableNameAppCmd_Test_VerifyError */
+}
 
 void CS_DisableNameAppCmd_Test_OneShot(void)
 {
@@ -759,7 +759,7 @@ void CS_DisableNameAppCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableNameAppCmd_Test_OneShot */
+}
 
 void CS_EnableNameAppCmd_Test_Nominal(void)
 {
@@ -807,7 +807,7 @@ void CS_EnableNameAppCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableNameAppCmd_Test_Nominal */
+}
 
 void CS_EnableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
 {
@@ -863,7 +863,7 @@ void CS_EnableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableNameAppCmd_Test_UpdateAppsDefinitionTableError */
+}
 
 void CS_EnableNameAppCmd_Test_UnknownNameError(void)
 {
@@ -902,7 +902,7 @@ void CS_EnableNameAppCmd_Test_UnknownNameError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableNameAppCmd_Test_UnknownNameError */
+}
 
 void CS_EnableNameAppCmd_Test_VerifyError(void)
 {
@@ -920,7 +920,7 @@ void CS_EnableNameAppCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableNameAppCmd_Test_VerifyError */
+}
 
 void CS_EnableNameAppCmd_Test_OneShot(void)
 {
@@ -940,7 +940,7 @@ void CS_EnableNameAppCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableNameAppCmd_Test_OneShot */
+}
 
 void UtTest_Setup(void)
 {
@@ -991,8 +991,4 @@ void UtTest_Setup(void)
     UtTest_Add(CS_EnableNameAppCmd_Test_VerifyError, CS_Test_Setup, CS_Test_TearDown,
                "CS_EnableNameAppCmd_Test_VerifyError");
     UtTest_Add(CS_EnableNameAppCmd_Test_OneShot, CS_Test_Setup, CS_Test_TearDown, "CS_EnableNameAppCmd_Test_OneShot");
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/cs_app_cmds_tests.c
+++ b/unit-test/cs_app_cmds_tests.c
@@ -104,7 +104,6 @@ void CS_DisableAppCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableAppCmd_Test */
 
 void CS_DisableAppCmd_Test_VerifyError(void)
@@ -123,7 +122,6 @@ void CS_DisableAppCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableAppCmd_Test_VerifyError */
 
 void CS_DisableAppCmd_Test_OneShot(void)
@@ -144,7 +142,6 @@ void CS_DisableAppCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableAppCmd_Test_OneShot */
 
 void CS_EnableAppCmd_Test(void)
@@ -179,7 +176,6 @@ void CS_EnableAppCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableAppCmd_Test */
 
 void CS_EnableAppCmd_Test_VerifyError(void)
@@ -198,7 +194,6 @@ void CS_EnableAppCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableAppCmd_Test_VerifyError */
 
 void CS_EnableAppCmd_Test_OneShot(void)
@@ -219,7 +214,6 @@ void CS_EnableAppCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableAppCmd_Test_OneShot */
 
 void CS_ReportBaselineAppCmd_Test_Baseline(void)
@@ -260,7 +254,6 @@ void CS_ReportBaselineAppCmd_Test_Baseline(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineAppCmd_Test_Baseline */
 
 void CS_ReportBaselineAppCmd_Test_NoBaseline(void)
@@ -303,7 +296,6 @@ void CS_ReportBaselineAppCmd_Test_NoBaseline(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineAppCmd_Test_NoBaseline */
 
 void CS_ReportBaselineAppCmd_Test_BaselineInvalidName(void)
@@ -340,7 +332,6 @@ void CS_ReportBaselineAppCmd_Test_BaselineInvalidName(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineAppCmd_Test_BaselineInvalidName */
 
 void CS_ReportBaselineAppCmd_Test_VerifyError(void)
@@ -359,7 +350,6 @@ void CS_ReportBaselineAppCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineAppCmd_Test_VerifyError */
 
 void CS_ReportBaselineAppCmd_Test_OneShot(void)
@@ -399,7 +389,6 @@ void CS_ReportBaselineAppCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineAppCmd_Test_OneShot */
 
 void CS_RecomputeBaselineAppCmd_Test_Nominal(void)
@@ -448,7 +437,6 @@ void CS_RecomputeBaselineAppCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineAppCmd_Test_Nominal */
 
 void CS_RecomputeBaselineAppCmd_Test_CreateChildTaskError(void)
@@ -496,7 +484,6 @@ void CS_RecomputeBaselineAppCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineAppCmd_Test_CreateChildTaskError */
 
 void CS_RecomputeBaselineAppCmd_Test_UnknownNameError(void)
@@ -536,7 +523,6 @@ void CS_RecomputeBaselineAppCmd_Test_UnknownNameError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineAppCmd_Test_UnknownNameError */
 
 void CS_RecomputeBaselineAppCmd_Test_RecomputeInProgress(void)
@@ -575,7 +561,6 @@ void CS_RecomputeBaselineAppCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineAppCmd_Test_RecomputeInProgress */
 
 void CS_RecomputeBaselineAppCmd_Test_VerifyError(void)
@@ -594,7 +579,6 @@ void CS_RecomputeBaselineAppCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineAppCmd_Test_VerifyError */
 
 void CS_DisableNameAppCmd_Test_Nominal(void)
@@ -643,7 +627,6 @@ void CS_DisableNameAppCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableNameAppCmd_Test_Nominal */
 
 void CS_DisableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
@@ -700,7 +683,6 @@ void CS_DisableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableNameAppCmd_Test_UpdateAppsDefinitionTableError */
 
 void CS_DisableNameAppCmd_Test_UnknownNameError(void)
@@ -739,7 +721,6 @@ void CS_DisableNameAppCmd_Test_UnknownNameError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableNameAppCmd_Test_UnknownNameError */
 
 void CS_DisableNameAppCmd_Test_VerifyError(void)
@@ -758,7 +739,6 @@ void CS_DisableNameAppCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableNameAppCmd_Test_VerifyError */
 
 void CS_DisableNameAppCmd_Test_OneShot(void)
@@ -779,7 +759,6 @@ void CS_DisableNameAppCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableNameAppCmd_Test_OneShot */
 
 void CS_EnableNameAppCmd_Test_Nominal(void)
@@ -828,7 +807,6 @@ void CS_EnableNameAppCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableNameAppCmd_Test_Nominal */
 
 void CS_EnableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
@@ -885,7 +863,6 @@ void CS_EnableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableNameAppCmd_Test_UpdateAppsDefinitionTableError */
 
 void CS_EnableNameAppCmd_Test_UnknownNameError(void)
@@ -925,7 +902,6 @@ void CS_EnableNameAppCmd_Test_UnknownNameError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableNameAppCmd_Test_UnknownNameError */
 
 void CS_EnableNameAppCmd_Test_VerifyError(void)
@@ -944,7 +920,6 @@ void CS_EnableNameAppCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableNameAppCmd_Test_VerifyError */
 
 void CS_EnableNameAppCmd_Test_OneShot(void)
@@ -965,7 +940,6 @@ void CS_EnableNameAppCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableNameAppCmd_Test_OneShot */
 
 void UtTest_Setup(void)
@@ -1017,7 +991,6 @@ void UtTest_Setup(void)
     UtTest_Add(CS_EnableNameAppCmd_Test_VerifyError, CS_Test_Setup, CS_Test_TearDown,
                "CS_EnableNameAppCmd_Test_VerifyError");
     UtTest_Add(CS_EnableNameAppCmd_Test_OneShot, CS_Test_Setup, CS_Test_TearDown, "CS_EnableNameAppCmd_Test_OneShot");
-
 } /* end UtTest_Setup */
 
 /************************/

--- a/unit-test/cs_app_tests.c
+++ b/unit-test/cs_app_tests.c
@@ -151,7 +151,6 @@ void CS_AppMain_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* Generates 2 event messages we don't care about in this test */
-
 } /* end CS_AppMain_Test_Nominal */
 
 void CS_AppMain_Test_AppInitError(void)
@@ -190,7 +189,6 @@ void CS_AppMain_Test_AppInitError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppMain_Test_AppInitError */
 
 void CS_AppMain_Test_SysException(void)
@@ -239,7 +237,6 @@ void CS_AppMain_Test_SysException(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-
 } /* end CS_AppMain_Test_SysException */
 
 void CS_AppMain_Test_RcvMsgError(void)
@@ -285,7 +282,6 @@ void CS_AppMain_Test_RcvMsgError(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-
 } /* end CS_AppMain_Test_RcvMsgError */
 
 void CS_AppMain_Test_RcvMsgTimeout(void)
@@ -342,7 +338,6 @@ void CS_AppMain_Test_RcvMsgTimeout(void)
     strCmpResult = strncmp(ExpectedSysLogString, context_CFE_ES_WriteToSysLog.Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Sys Log string matched expected result, '%s'", context_CFE_ES_WriteToSysLog.Spec);
-
 } /* end CS_AppMain_Test_RcvMsgTimeout */
 
 void CS_AppMain_Test_RcvNoMsg(void)
@@ -391,7 +386,6 @@ void CS_AppMain_Test_RcvNoMsg(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* Generates 2 event messages we don't care about in this test */
-
 } /* end CS_AppMain_Test_RcvNoMsg */
 
 void CS_AppMain_Test_RcvNullBufPtr(void)
@@ -438,7 +432,6 @@ void CS_AppMain_Test_RcvNullBufPtr(void)
     strCmpResult = strncmp(ExpectedSysLogString, context_CFE_ES_WriteToSysLog.Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Sys Log string matched expected result, '%s'", context_CFE_ES_WriteToSysLog.Spec);
-
 } /* end CS_AppMain_Test_RcvNullBufPtr */
 
 void CS_AppMain_Test_AppPipeError(void)
@@ -495,7 +488,6 @@ void CS_AppMain_Test_AppPipeError(void)
     strCmpResult = strncmp(ExpectedSysLogString, context_CFE_ES_WriteToSysLog.Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Sys Log string matched expected result, '%s'", context_CFE_ES_WriteToSysLog.Spec);
-
 } /* end CS_AppMain_Test_AppPipeError */
 
 void CS_AppInit_Test_Nominal(void)
@@ -530,7 +522,6 @@ void CS_AppInit_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppInit_Test_Nominal */
 
 void CS_AppInit_Test_NominalPowerOnReset(void)
@@ -584,7 +575,6 @@ void CS_AppInit_Test_NominalPowerOnReset(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppInit_Test_NominalPowerOnReset */
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
@@ -610,7 +600,6 @@ void CS_AppInit_Test_NominalProcReset(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_INIT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-
 } /* end CS_AppInit_Test_NominalProcReset */
 
 void CS_CreateRestoreStatesFromCDS_Test_NoExistingCDS(void)
@@ -643,7 +632,6 @@ void CS_CreateRestoreStatesFromCDS_Test_NoExistingCDS(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_CreateRestoreStatesFromCDS_Test_NoCDS */
 
 void CS_CreateRestoreStatesFromCDS_Test_CDSSuccess(void)
@@ -686,7 +674,6 @@ void CS_CreateRestoreStatesFromCDS_Test_CDSSuccess(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_CreateRestoreStatesFromCDS_Test_CDSSuccess */
 
 void CS_CreateRestoreStatesFromCDS_Test_CDSFail(void)
@@ -742,7 +729,6 @@ void CS_CreateRestoreStatesFromCDS_Test_CDSFail(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppInit_Test_ProcResetRestoreCDSFail */
 
 void CS_CreateRestoreStatesFromCDS_Test_CopyToCDSFail(void)
@@ -800,7 +786,6 @@ void CS_CreateRestoreStatesFromCDS_Test_CopyToCDSFail(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_CreateRestoreStatesFromCDS_Test_CopyToCDSFail */
 
 void CS_CreateRestoreStatesFromCDS_Test_RegisterCDSFail(void)
@@ -858,7 +843,6 @@ void CS_CreateRestoreStatesFromCDS_Test_RegisterCDSFail(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_CreateRestoreStatesFromCDS_Test_RegisterCDSFail */
 
 #endif /* #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true) */
@@ -889,7 +873,6 @@ void CS_AppInit_Test_EVSRegisterError(void)
     strCmpResult = strncmp(ExpectedSysLogString, context_CFE_ES_WriteToSysLog.Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Sys Log string matched expected result, '%s'", context_CFE_ES_WriteToSysLog.Spec);
-
 } /* end CS_AppInit_Test_EVSRegisterError */
 
 void CS_AppPipe_Test_TableUpdateErrors(void)
@@ -919,7 +902,6 @@ void CS_AppPipe_Test_TableUpdateErrors(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 5 event messages we don't care about in this test */
-
 } /* end CS_AppPipe_Test_TableUpdateErrors */
 
 void CS_AppPipe_Test_BackgroundCycle(void)
@@ -948,7 +930,6 @@ void CS_AppPipe_Test_BackgroundCycle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_BackgroundCycle */
 
 void CS_AppPipe_Test_NoopCmd(void)
@@ -978,7 +959,6 @@ void CS_AppPipe_Test_NoopCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_NoopCmd */
 
 void CS_AppPipe_Test_ResetCmd(void)
@@ -1008,7 +988,6 @@ void CS_AppPipe_Test_ResetCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_ResetCmd */
 
 void CS_AppPipe_Test_OneShotCmd(void)
@@ -1038,7 +1017,6 @@ void CS_AppPipe_Test_OneShotCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_OneShotCmd */
 
 void CS_AppPipe_Test_CancelOneShotCmd(void)
@@ -1068,7 +1046,6 @@ void CS_AppPipe_Test_CancelOneShotCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_CancelOneShotCmd */
 
 void CS_AppPipe_Test_EnableAllCSCmd(void)
@@ -1098,7 +1075,6 @@ void CS_AppPipe_Test_EnableAllCSCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_EnableAllCSCmd */
 
 void CS_AppPipe_Test_DisableAllCSCmd(void)
@@ -1128,7 +1104,6 @@ void CS_AppPipe_Test_DisableAllCSCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_DisableAllCSCmd */
 
 void CS_AppPipe_Test_EnableCfeCoreCmd(void)
@@ -1158,7 +1133,6 @@ void CS_AppPipe_Test_EnableCfeCoreCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_EnableCfeCoreCmd */
 
 void CS_AppPipe_Test_DisableCfeCoreCmd(void)
@@ -1188,7 +1162,6 @@ void CS_AppPipe_Test_DisableCfeCoreCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_DisableCfeCoreCmd */
 
 void CS_AppPipe_Test_ReportBaselineCfeCoreCmd(void)
@@ -1218,7 +1191,6 @@ void CS_AppPipe_Test_ReportBaselineCfeCoreCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_ReportBaselineCfeCoreCmd */
 
 void CS_AppPipe_Test_RecomputeBaselineCfeCoreCmd(void)
@@ -1248,7 +1220,6 @@ void CS_AppPipe_Test_RecomputeBaselineCfeCoreCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_RecomputeBaselineCfeCoreCmd */
 
 void CS_AppPipe_Test_EnableOSCmd(void)
@@ -1278,7 +1249,6 @@ void CS_AppPipe_Test_EnableOSCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_EnableOSCmd */
 
 void CS_AppPipe_Test_DisableOSCmd(void)
@@ -1308,7 +1278,6 @@ void CS_AppPipe_Test_DisableOSCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_DisableOSCmd */
 
 void CS_AppPipe_Test_ReportBaselineOSCmd(void)
@@ -1338,7 +1307,6 @@ void CS_AppPipe_Test_ReportBaselineOSCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_ReportBaselineOSCmd */
 
 void CS_AppPipe_Test_RecomputeBaselineOSCmd(void)
@@ -1368,7 +1336,6 @@ void CS_AppPipe_Test_RecomputeBaselineOSCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_RecomputeBaselineOSCmd */
 
 void CS_AppPipe_Test_EnableEepromCmd(void)
@@ -1398,7 +1365,6 @@ void CS_AppPipe_Test_EnableEepromCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_EnableEepromCmd */
 
 void CS_AppPipe_Test_DisableEepromCmd(void)
@@ -1428,7 +1394,6 @@ void CS_AppPipe_Test_DisableEepromCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_DisableEepromCmd */
 
 void CS_AppPipe_Test_ReportBaselineEntryIDEepromCmd(void)
@@ -1458,7 +1423,6 @@ void CS_AppPipe_Test_ReportBaselineEntryIDEepromCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_ReportBaselineEntryIDEepromCmd */
 
 void CS_AppPipe_Test_RecomputeBaselineEepromCmd(void)
@@ -1488,7 +1452,6 @@ void CS_AppPipe_Test_RecomputeBaselineEepromCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_RecomputeBaselineEepromCmd */
 
 void CS_AppPipe_Test_EnableEntryIDEepromCmd(void)
@@ -1518,7 +1481,6 @@ void CS_AppPipe_Test_EnableEntryIDEepromCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_EnableEntryIDEepromCmd */
 
 void CS_AppPipe_Test_DisableEntryIDEepromCmd(void)
@@ -1548,7 +1510,6 @@ void CS_AppPipe_Test_DisableEntryIDEepromCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_DisableEntryIDEepromCmd */
 
 void CS_AppPipe_Test_GetEntryIDEepromCmd(void)
@@ -1578,7 +1539,6 @@ void CS_AppPipe_Test_GetEntryIDEepromCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_GetEntryIDEepromCmd */
 
 void CS_AppPipe_Test_EnableMemoryCmd(void)
@@ -1608,7 +1568,6 @@ void CS_AppPipe_Test_EnableMemoryCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_EnableMemoryCmd */
 
 void CS_AppPipe_Test_DisableMemoryCmd(void)
@@ -1638,7 +1597,6 @@ void CS_AppPipe_Test_DisableMemoryCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_DisableMemoryCmd */
 
 void CS_AppPipe_Test_ReportBaselineEntryIDMemoryCmd(void)
@@ -1668,7 +1626,6 @@ void CS_AppPipe_Test_ReportBaselineEntryIDMemoryCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_ReportBaselineEntryIDMemoryCmd */
 
 void CS_AppPipe_Test_RecomputeBaselineMemoryCmd(void)
@@ -1698,7 +1655,6 @@ void CS_AppPipe_Test_RecomputeBaselineMemoryCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_RecomputeBaselineMemoryCmd */
 
 void CS_AppPipe_Test_EnableEntryIDMemoryCmd(void)
@@ -1728,7 +1684,6 @@ void CS_AppPipe_Test_EnableEntryIDMemoryCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_EnableEntryIDMemoryCmd */
 
 void CS_AppPipe_Test_DisableEntryIDMemoryCmd(void)
@@ -1758,7 +1713,6 @@ void CS_AppPipe_Test_DisableEntryIDMemoryCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_DisableEntryIDMemoryCmd */
 
 void CS_AppPipe_Test_GetEntryIDMemoryCmd(void)
@@ -1788,7 +1742,6 @@ void CS_AppPipe_Test_GetEntryIDMemoryCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_GetEntryIDMemoryCmd */
 
 void CS_AppPipe_Test_EnableTablesCmd(void)
@@ -1818,7 +1771,6 @@ void CS_AppPipe_Test_EnableTablesCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_EnableTablesCmd */
 
 void CS_AppPipe_Test_DisableTablesCmd(void)
@@ -1848,7 +1800,6 @@ void CS_AppPipe_Test_DisableTablesCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_DisableTablesCmd */
 
 void CS_AppPipe_Test_ReportBaselineTablesCmd(void)
@@ -1878,7 +1829,6 @@ void CS_AppPipe_Test_ReportBaselineTablesCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_ReportBaselineTablesCmd */
 
 void CS_AppPipe_Test_RecomputeBaselineTablesCmd(void)
@@ -1908,7 +1858,6 @@ void CS_AppPipe_Test_RecomputeBaselineTablesCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_RecomputeBaselineTablesCmd */
 
 void CS_AppPipe_Test_EnableNameTablesCmd(void)
@@ -1938,7 +1887,6 @@ void CS_AppPipe_Test_EnableNameTablesCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_EnableNameTablesCmd */
 
 void CS_AppPipe_Test_DisableNameTablesCmd(void)
@@ -1968,7 +1916,6 @@ void CS_AppPipe_Test_DisableNameTablesCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_DisableNameTablesCmd */
 
 void CS_AppPipe_Test_EnableAppCmd(void)
@@ -1998,7 +1945,6 @@ void CS_AppPipe_Test_EnableAppCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_EnableAppCmd */
 
 void CS_AppPipe_Test_DisableAppCmd(void)
@@ -2028,7 +1974,6 @@ void CS_AppPipe_Test_DisableAppCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_DisableAppCmd */
 
 void CS_AppPipe_Test_ReportBaselineAppCmd(void)
@@ -2058,7 +2003,6 @@ void CS_AppPipe_Test_ReportBaselineAppCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_ReportBaselineAppCmd */
 
 void CS_AppPipe_Test_RecomputeBaselineAppCmd(void)
@@ -2088,7 +2032,6 @@ void CS_AppPipe_Test_RecomputeBaselineAppCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_RecomputeBaselineAppCmd */
 
 void CS_AppPipe_Test_EnableNameAppCmd(void)
@@ -2118,7 +2061,6 @@ void CS_AppPipe_Test_EnableNameAppCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_EnableNameAppCmd */
 
 void CS_AppPipe_Test_DisableNameAppCmd(void)
@@ -2148,7 +2090,6 @@ void CS_AppPipe_Test_DisableNameAppCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_DisableNameAppCmd */
 
 void CS_AppPipe_Test_InvalidCCError(void)
@@ -2190,7 +2131,6 @@ void CS_AppPipe_Test_InvalidCCError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_InvalidCCError */
 
 void CS_AppPipe_Test_InvalidMIDError(void)
@@ -2228,7 +2168,6 @@ void CS_AppPipe_Test_InvalidMIDError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_AppPipe_Test_InvalidMIDError */
 
 void CS_HousekeepingCmd_Test_Nominal(void)
@@ -2310,7 +2249,6 @@ void CS_HousekeepingCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_HousekeepingCmd_Test_Nominal */
 
 void CS_HousekeepingCmd_Test_InvalidMsgLength(void)
@@ -2351,7 +2289,6 @@ void CS_HousekeepingCmd_Test_InvalidMsgLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_HousekeepingCmd_Test_InvalidMsgLength */
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
@@ -2371,7 +2308,6 @@ void CS_UpdateCDS_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_UpdateCDS_Test_Nominal */
 
 void CS_UpdateCDS_Test_CopyToCDSFail(void)
@@ -2402,7 +2338,6 @@ void CS_UpdateCDS_Test_CopyToCDSFail(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_UpdateCDS_Test_CopyToCDSFail */
 
 void CS_UpdateCDS_Test_NullCDSHandle(void)
@@ -2417,7 +2352,6 @@ void CS_UpdateCDS_Test_NullCDSHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_UpdateCDS_Test_NullCDSHandle */
 #endif /* #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true) */
 
@@ -2526,7 +2460,6 @@ void UtTest_Setup(void)
     UtTest_Add(CS_UpdateCDS_Test_CopyToCDSFail, CS_Test_Setup, CS_Test_TearDown, "CS_UpdateCDS_Test_CopyToCDSFail");
     UtTest_Add(CS_UpdateCDS_Test_NullCDSHandle, CS_Test_Setup, CS_Test_TearDown, "CS_UpdateCDS_Test_NullCDSHandle");
 #endif /* #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true) */
-
 } /* end UtTest_Setup */
 
 /************************/

--- a/unit-test/cs_app_tests.c
+++ b/unit-test/cs_app_tests.c
@@ -151,7 +151,7 @@ void CS_AppMain_Test_Nominal(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* Generates 2 event messages we don't care about in this test */
-} /* end CS_AppMain_Test_Nominal */
+}
 
 void CS_AppMain_Test_AppInitError(void)
 {
@@ -189,7 +189,7 @@ void CS_AppMain_Test_AppInitError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppMain_Test_AppInitError */
+}
 
 void CS_AppMain_Test_SysException(void)
 {
@@ -237,7 +237,7 @@ void CS_AppMain_Test_SysException(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-} /* end CS_AppMain_Test_SysException */
+}
 
 void CS_AppMain_Test_RcvMsgError(void)
 {
@@ -282,7 +282,7 @@ void CS_AppMain_Test_RcvMsgError(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-} /* end CS_AppMain_Test_RcvMsgError */
+}
 
 void CS_AppMain_Test_RcvMsgTimeout(void)
 {
@@ -338,7 +338,7 @@ void CS_AppMain_Test_RcvMsgTimeout(void)
     strCmpResult = strncmp(ExpectedSysLogString, context_CFE_ES_WriteToSysLog.Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Sys Log string matched expected result, '%s'", context_CFE_ES_WriteToSysLog.Spec);
-} /* end CS_AppMain_Test_RcvMsgTimeout */
+}
 
 void CS_AppMain_Test_RcvNoMsg(void)
 {
@@ -386,7 +386,7 @@ void CS_AppMain_Test_RcvNoMsg(void)
                   call_count_CFE_EVS_SendEvent);
 
     /* Generates 2 event messages we don't care about in this test */
-} /* end CS_AppMain_Test_RcvNoMsg */
+}
 
 void CS_AppMain_Test_RcvNullBufPtr(void)
 {
@@ -432,7 +432,7 @@ void CS_AppMain_Test_RcvNullBufPtr(void)
     strCmpResult = strncmp(ExpectedSysLogString, context_CFE_ES_WriteToSysLog.Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Sys Log string matched expected result, '%s'", context_CFE_ES_WriteToSysLog.Spec);
-} /* end CS_AppMain_Test_RcvNullBufPtr */
+}
 
 void CS_AppMain_Test_AppPipeError(void)
 {
@@ -488,7 +488,7 @@ void CS_AppMain_Test_AppPipeError(void)
     strCmpResult = strncmp(ExpectedSysLogString, context_CFE_ES_WriteToSysLog.Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Sys Log string matched expected result, '%s'", context_CFE_ES_WriteToSysLog.Spec);
-} /* end CS_AppMain_Test_AppPipeError */
+}
 
 void CS_AppInit_Test_Nominal(void)
 {
@@ -522,7 +522,7 @@ void CS_AppInit_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppInit_Test_Nominal */
+}
 
 void CS_AppInit_Test_NominalPowerOnReset(void)
 {
@@ -575,7 +575,7 @@ void CS_AppInit_Test_NominalPowerOnReset(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppInit_Test_NominalPowerOnReset */
+}
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
 
@@ -600,7 +600,7 @@ void CS_AppInit_Test_NominalProcReset(void)
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_INIT_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
-} /* end CS_AppInit_Test_NominalProcReset */
+}
 
 void CS_CreateRestoreStatesFromCDS_Test_NoExistingCDS(void)
 {
@@ -632,7 +632,7 @@ void CS_CreateRestoreStatesFromCDS_Test_NoExistingCDS(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_CreateRestoreStatesFromCDS_Test_NoCDS */
+}
 
 void CS_CreateRestoreStatesFromCDS_Test_CDSSuccess(void)
 {
@@ -674,7 +674,7 @@ void CS_CreateRestoreStatesFromCDS_Test_CDSSuccess(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_CreateRestoreStatesFromCDS_Test_CDSSuccess */
+}
 
 void CS_CreateRestoreStatesFromCDS_Test_CDSFail(void)
 {
@@ -729,7 +729,7 @@ void CS_CreateRestoreStatesFromCDS_Test_CDSFail(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppInit_Test_ProcResetRestoreCDSFail */
+}
 
 void CS_CreateRestoreStatesFromCDS_Test_CopyToCDSFail(void)
 {
@@ -786,7 +786,7 @@ void CS_CreateRestoreStatesFromCDS_Test_CopyToCDSFail(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_CreateRestoreStatesFromCDS_Test_CopyToCDSFail */
+}
 
 void CS_CreateRestoreStatesFromCDS_Test_RegisterCDSFail(void)
 {
@@ -843,7 +843,7 @@ void CS_CreateRestoreStatesFromCDS_Test_RegisterCDSFail(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_CreateRestoreStatesFromCDS_Test_RegisterCDSFail */
+}
 
 #endif /* #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true) */
 
@@ -873,7 +873,7 @@ void CS_AppInit_Test_EVSRegisterError(void)
     strCmpResult = strncmp(ExpectedSysLogString, context_CFE_ES_WriteToSysLog.Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Sys Log string matched expected result, '%s'", context_CFE_ES_WriteToSysLog.Spec);
-} /* end CS_AppInit_Test_EVSRegisterError */
+}
 
 void CS_AppPipe_Test_TableUpdateErrors(void)
 {
@@ -902,7 +902,7 @@ void CS_AppPipe_Test_TableUpdateErrors(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 5 event messages we don't care about in this test */
-} /* end CS_AppPipe_Test_TableUpdateErrors */
+}
 
 void CS_AppPipe_Test_BackgroundCycle(void)
 {
@@ -930,7 +930,7 @@ void CS_AppPipe_Test_BackgroundCycle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_BackgroundCycle */
+}
 
 void CS_AppPipe_Test_NoopCmd(void)
 {
@@ -959,7 +959,7 @@ void CS_AppPipe_Test_NoopCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_NoopCmd */
+}
 
 void CS_AppPipe_Test_ResetCmd(void)
 {
@@ -988,7 +988,7 @@ void CS_AppPipe_Test_ResetCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_ResetCmd */
+}
 
 void CS_AppPipe_Test_OneShotCmd(void)
 {
@@ -1017,7 +1017,7 @@ void CS_AppPipe_Test_OneShotCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_OneShotCmd */
+}
 
 void CS_AppPipe_Test_CancelOneShotCmd(void)
 {
@@ -1046,7 +1046,7 @@ void CS_AppPipe_Test_CancelOneShotCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_CancelOneShotCmd */
+}
 
 void CS_AppPipe_Test_EnableAllCSCmd(void)
 {
@@ -1075,7 +1075,7 @@ void CS_AppPipe_Test_EnableAllCSCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_EnableAllCSCmd */
+}
 
 void CS_AppPipe_Test_DisableAllCSCmd(void)
 {
@@ -1104,7 +1104,7 @@ void CS_AppPipe_Test_DisableAllCSCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_DisableAllCSCmd */
+}
 
 void CS_AppPipe_Test_EnableCfeCoreCmd(void)
 {
@@ -1133,7 +1133,7 @@ void CS_AppPipe_Test_EnableCfeCoreCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_EnableCfeCoreCmd */
+}
 
 void CS_AppPipe_Test_DisableCfeCoreCmd(void)
 {
@@ -1162,7 +1162,7 @@ void CS_AppPipe_Test_DisableCfeCoreCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_DisableCfeCoreCmd */
+}
 
 void CS_AppPipe_Test_ReportBaselineCfeCoreCmd(void)
 {
@@ -1191,7 +1191,7 @@ void CS_AppPipe_Test_ReportBaselineCfeCoreCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_ReportBaselineCfeCoreCmd */
+}
 
 void CS_AppPipe_Test_RecomputeBaselineCfeCoreCmd(void)
 {
@@ -1220,7 +1220,7 @@ void CS_AppPipe_Test_RecomputeBaselineCfeCoreCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_RecomputeBaselineCfeCoreCmd */
+}
 
 void CS_AppPipe_Test_EnableOSCmd(void)
 {
@@ -1249,7 +1249,7 @@ void CS_AppPipe_Test_EnableOSCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_EnableOSCmd */
+}
 
 void CS_AppPipe_Test_DisableOSCmd(void)
 {
@@ -1278,7 +1278,7 @@ void CS_AppPipe_Test_DisableOSCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_DisableOSCmd */
+}
 
 void CS_AppPipe_Test_ReportBaselineOSCmd(void)
 {
@@ -1307,7 +1307,7 @@ void CS_AppPipe_Test_ReportBaselineOSCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_ReportBaselineOSCmd */
+}
 
 void CS_AppPipe_Test_RecomputeBaselineOSCmd(void)
 {
@@ -1336,7 +1336,7 @@ void CS_AppPipe_Test_RecomputeBaselineOSCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_RecomputeBaselineOSCmd */
+}
 
 void CS_AppPipe_Test_EnableEepromCmd(void)
 {
@@ -1365,7 +1365,7 @@ void CS_AppPipe_Test_EnableEepromCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_EnableEepromCmd */
+}
 
 void CS_AppPipe_Test_DisableEepromCmd(void)
 {
@@ -1394,7 +1394,7 @@ void CS_AppPipe_Test_DisableEepromCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_DisableEepromCmd */
+}
 
 void CS_AppPipe_Test_ReportBaselineEntryIDEepromCmd(void)
 {
@@ -1423,7 +1423,7 @@ void CS_AppPipe_Test_ReportBaselineEntryIDEepromCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_ReportBaselineEntryIDEepromCmd */
+}
 
 void CS_AppPipe_Test_RecomputeBaselineEepromCmd(void)
 {
@@ -1452,7 +1452,7 @@ void CS_AppPipe_Test_RecomputeBaselineEepromCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_RecomputeBaselineEepromCmd */
+}
 
 void CS_AppPipe_Test_EnableEntryIDEepromCmd(void)
 {
@@ -1481,7 +1481,7 @@ void CS_AppPipe_Test_EnableEntryIDEepromCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_EnableEntryIDEepromCmd */
+}
 
 void CS_AppPipe_Test_DisableEntryIDEepromCmd(void)
 {
@@ -1510,7 +1510,7 @@ void CS_AppPipe_Test_DisableEntryIDEepromCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_DisableEntryIDEepromCmd */
+}
 
 void CS_AppPipe_Test_GetEntryIDEepromCmd(void)
 {
@@ -1539,7 +1539,7 @@ void CS_AppPipe_Test_GetEntryIDEepromCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_GetEntryIDEepromCmd */
+}
 
 void CS_AppPipe_Test_EnableMemoryCmd(void)
 {
@@ -1568,7 +1568,7 @@ void CS_AppPipe_Test_EnableMemoryCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_EnableMemoryCmd */
+}
 
 void CS_AppPipe_Test_DisableMemoryCmd(void)
 {
@@ -1597,7 +1597,7 @@ void CS_AppPipe_Test_DisableMemoryCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_DisableMemoryCmd */
+}
 
 void CS_AppPipe_Test_ReportBaselineEntryIDMemoryCmd(void)
 {
@@ -1626,7 +1626,7 @@ void CS_AppPipe_Test_ReportBaselineEntryIDMemoryCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_ReportBaselineEntryIDMemoryCmd */
+}
 
 void CS_AppPipe_Test_RecomputeBaselineMemoryCmd(void)
 {
@@ -1655,7 +1655,7 @@ void CS_AppPipe_Test_RecomputeBaselineMemoryCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_RecomputeBaselineMemoryCmd */
+}
 
 void CS_AppPipe_Test_EnableEntryIDMemoryCmd(void)
 {
@@ -1684,7 +1684,7 @@ void CS_AppPipe_Test_EnableEntryIDMemoryCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_EnableEntryIDMemoryCmd */
+}
 
 void CS_AppPipe_Test_DisableEntryIDMemoryCmd(void)
 {
@@ -1713,7 +1713,7 @@ void CS_AppPipe_Test_DisableEntryIDMemoryCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_DisableEntryIDMemoryCmd */
+}
 
 void CS_AppPipe_Test_GetEntryIDMemoryCmd(void)
 {
@@ -1742,7 +1742,7 @@ void CS_AppPipe_Test_GetEntryIDMemoryCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_GetEntryIDMemoryCmd */
+}
 
 void CS_AppPipe_Test_EnableTablesCmd(void)
 {
@@ -1771,7 +1771,7 @@ void CS_AppPipe_Test_EnableTablesCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_EnableTablesCmd */
+}
 
 void CS_AppPipe_Test_DisableTablesCmd(void)
 {
@@ -1800,7 +1800,7 @@ void CS_AppPipe_Test_DisableTablesCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_DisableTablesCmd */
+}
 
 void CS_AppPipe_Test_ReportBaselineTablesCmd(void)
 {
@@ -1829,7 +1829,7 @@ void CS_AppPipe_Test_ReportBaselineTablesCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_ReportBaselineTablesCmd */
+}
 
 void CS_AppPipe_Test_RecomputeBaselineTablesCmd(void)
 {
@@ -1858,7 +1858,7 @@ void CS_AppPipe_Test_RecomputeBaselineTablesCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_RecomputeBaselineTablesCmd */
+}
 
 void CS_AppPipe_Test_EnableNameTablesCmd(void)
 {
@@ -1887,7 +1887,7 @@ void CS_AppPipe_Test_EnableNameTablesCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_EnableNameTablesCmd */
+}
 
 void CS_AppPipe_Test_DisableNameTablesCmd(void)
 {
@@ -1916,7 +1916,7 @@ void CS_AppPipe_Test_DisableNameTablesCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_DisableNameTablesCmd */
+}
 
 void CS_AppPipe_Test_EnableAppCmd(void)
 {
@@ -1945,7 +1945,7 @@ void CS_AppPipe_Test_EnableAppCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_EnableAppCmd */
+}
 
 void CS_AppPipe_Test_DisableAppCmd(void)
 {
@@ -1974,7 +1974,7 @@ void CS_AppPipe_Test_DisableAppCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_DisableAppCmd */
+}
 
 void CS_AppPipe_Test_ReportBaselineAppCmd(void)
 {
@@ -2003,7 +2003,7 @@ void CS_AppPipe_Test_ReportBaselineAppCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_ReportBaselineAppCmd */
+}
 
 void CS_AppPipe_Test_RecomputeBaselineAppCmd(void)
 {
@@ -2032,7 +2032,7 @@ void CS_AppPipe_Test_RecomputeBaselineAppCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_RecomputeBaselineAppCmd */
+}
 
 void CS_AppPipe_Test_EnableNameAppCmd(void)
 {
@@ -2061,7 +2061,7 @@ void CS_AppPipe_Test_EnableNameAppCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_EnableNameAppCmd */
+}
 
 void CS_AppPipe_Test_DisableNameAppCmd(void)
 {
@@ -2090,7 +2090,7 @@ void CS_AppPipe_Test_DisableNameAppCmd(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_DisableNameAppCmd */
+}
 
 void CS_AppPipe_Test_InvalidCCError(void)
 {
@@ -2131,7 +2131,7 @@ void CS_AppPipe_Test_InvalidCCError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_InvalidCCError */
+}
 
 void CS_AppPipe_Test_InvalidMIDError(void)
 {
@@ -2168,7 +2168,7 @@ void CS_AppPipe_Test_InvalidMIDError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_AppPipe_Test_InvalidMIDError */
+}
 
 void CS_HousekeepingCmd_Test_Nominal(void)
 {
@@ -2249,7 +2249,7 @@ void CS_HousekeepingCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_HousekeepingCmd_Test_Nominal */
+}
 
 void CS_HousekeepingCmd_Test_InvalidMsgLength(void)
 {
@@ -2289,7 +2289,7 @@ void CS_HousekeepingCmd_Test_InvalidMsgLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_HousekeepingCmd_Test_InvalidMsgLength */
+}
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
 
@@ -2308,7 +2308,7 @@ void CS_UpdateCDS_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_UpdateCDS_Test_Nominal */
+}
 
 void CS_UpdateCDS_Test_CopyToCDSFail(void)
 {
@@ -2338,7 +2338,7 @@ void CS_UpdateCDS_Test_CopyToCDSFail(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_UpdateCDS_Test_CopyToCDSFail */
+}
 
 void CS_UpdateCDS_Test_NullCDSHandle(void)
 {
@@ -2352,7 +2352,7 @@ void CS_UpdateCDS_Test_NullCDSHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_UpdateCDS_Test_NullCDSHandle */
+}
 #endif /* #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true) */
 
 void UtTest_Setup(void)
@@ -2460,8 +2460,4 @@ void UtTest_Setup(void)
     UtTest_Add(CS_UpdateCDS_Test_CopyToCDSFail, CS_Test_Setup, CS_Test_TearDown, "CS_UpdateCDS_Test_CopyToCDSFail");
     UtTest_Add(CS_UpdateCDS_Test_NullCDSHandle, CS_Test_Setup, CS_Test_TearDown, "CS_UpdateCDS_Test_NullCDSHandle");
 #endif /* #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true) */
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/cs_cmds_tests.c
+++ b/unit-test/cs_cmds_tests.c
@@ -77,7 +77,6 @@ void CS_NoopCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_NoopCmd_Test */
 
 void CS_NoopCmd_Test_VerifyError(void)
@@ -94,7 +93,6 @@ void CS_NoopCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_NoopCmd_Test_VerifyError */
 
 void CS_ResetCmd_Test(void)
@@ -142,7 +140,6 @@ void CS_ResetCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ResetCmd_Test */
 
 void CS_ResetCmd_Test_VerifyError(void)
@@ -159,7 +156,6 @@ void CS_ResetCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ResetCmd_Test_VerifyError */
 
 void CS_BackgroundCheckCycle_Test_InvalidMsgLength(void)
@@ -205,7 +201,6 @@ void CS_BackgroundCheckCycle_Test_InvalidMsgLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_BackgroundCheckCycle_Test_InvalidMsgLength */
 
 void CS_BackgroundCheckCycle_Test_BackgroundInProgress(void)
@@ -253,7 +248,6 @@ void CS_BackgroundCheckCycle_Test_BackgroundInProgress(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_BackgroundCheckCycle_Test_BackgroundCfeCore */
 
 void CS_BackgroundCheckCycle_Test_BackgroundCfeCore(void)
@@ -287,7 +281,6 @@ void CS_BackgroundCheckCycle_Test_BackgroundCfeCore(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_BackgroundCheckCycle_Test_BackgroundCfeCore */
 
 void CS_BackgroundCheckCycle_Test_BackgroundOS(void)
@@ -321,7 +314,6 @@ void CS_BackgroundCheckCycle_Test_BackgroundOS(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_BackgroundCheckCycle_Test_BackgroundOS */
 
 void CS_BackgroundCheckCycle_Test_BackgroundEeprom(void)
@@ -354,7 +346,6 @@ void CS_BackgroundCheckCycle_Test_BackgroundEeprom(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_BackgroundCheckCycle_Test_BackgroundEeprom */
 
 void CS_BackgroundCheckCycle_Test_BackgroundMemory(void)
@@ -387,7 +378,6 @@ void CS_BackgroundCheckCycle_Test_BackgroundMemory(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_BackgroundCheckCycle_Test_BackgroundMemory */
 
 void CS_BackgroundCheckCycle_Test_BackgroundTables(void)
@@ -420,7 +410,6 @@ void CS_BackgroundCheckCycle_Test_BackgroundTables(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_BackgroundCheckCycle_Test_BackgroundTables */
 
 void CS_BackgroundCheckCycle_Test_BackgroundApp(void)
@@ -453,7 +442,6 @@ void CS_BackgroundCheckCycle_Test_BackgroundApp(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_BackgroundCheckCycle_Test_BackgroundApp */
 
 void CS_BackgroundCheckCycle_Test_Default(void)
@@ -488,7 +476,6 @@ void CS_BackgroundCheckCycle_Test_Default(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_BackgroundCheckCycle_Test_Default */
 
 void CS_BackgroundCheckCycle_Test_Disabled(void)
@@ -520,7 +507,6 @@ void CS_BackgroundCheckCycle_Test_Disabled(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_BackgroundCheckCycle_Test_Disabled */
 
 void CS_BackgroundCheckCycle_Test_OneShot(void)
@@ -569,7 +555,6 @@ void CS_BackgroundCheckCycle_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_BackgroundCheckCycle_Test_OneShot */
 
 void CS_BackgroundCheckCycle_Test_EndOfList(void)
@@ -606,7 +591,6 @@ void CS_BackgroundCheckCycle_Test_EndOfList(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_BackgroundCheckCycle_Test_EndOfList */
 
 void CS_DisableAllCSCmd_Test(void)
@@ -638,7 +622,6 @@ void CS_DisableAllCSCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableAllCSCmd_Test */
 
 void CS_DisableAllCSCmd_Test_VerifyError(void)
@@ -655,7 +638,6 @@ void CS_DisableAllCSCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableAllCSCmd_Test_VerifyError */
 
 void CS_EnableAllCSCmd_Test(void)
@@ -687,7 +669,6 @@ void CS_EnableAllCSCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableAllCSCmd_Test */
 
 void CS_EnableAllCSCmd_Test_VerifyError(void)
@@ -704,7 +685,6 @@ void CS_EnableAllCSCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableAllCSCmd_Test_VerifyError */
 
 void CS_DisableCfeCoreCmd_Test(void)
@@ -737,7 +717,6 @@ void CS_DisableCfeCoreCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableCfeCoreCmd_Test */
 
 void CS_DisableCfeCoreCmd_Test_VerifyError(void)
@@ -754,7 +733,6 @@ void CS_DisableCfeCoreCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableCfeCoreCmd_Test_VerifyError */
 
 void CS_EnableCfeCoreCmd_Test(void)
@@ -787,7 +765,6 @@ void CS_EnableCfeCoreCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableCfeCoreCmd_Test */
 
 void CS_EnableCfeCoreCmd_Test_VerifyError(void)
@@ -804,7 +781,6 @@ void CS_EnableCfeCoreCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableCfeCoreCmd_Test_VerifyError */
 
 void CS_DisableOSCmd_Test(void)
@@ -837,7 +813,6 @@ void CS_DisableOSCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableOSCmd_Test */
 
 void CS_DisableOSCmd_Test_VerifyError(void)
@@ -854,7 +829,6 @@ void CS_DisableOSCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableOSCmd_Test_VerifyError */
 
 void CS_EnableOSCmd_Test(void)
@@ -887,7 +861,6 @@ void CS_EnableOSCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableOSCmd_Test */
 
 void CS_EnableOSCmd_Test_VerifyError(void)
@@ -904,7 +877,6 @@ void CS_EnableOSCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableOSCmd_Test_VerifyError */
 
 void CS_ReportBaselineCfeCoreCmd_Test_Nominal(void)
@@ -937,7 +909,6 @@ void CS_ReportBaselineCfeCoreCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineCfeCoreCmd_Test_Nominal */
 
 void CS_ReportBaselineCfeCoreCmd_Test_NotComputedYet(void)
@@ -969,7 +940,6 @@ void CS_ReportBaselineCfeCoreCmd_Test_NotComputedYet(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineCfeCoreCmd_Test_NotComputedYet */
 
 void CS_ReportBaselineCfeCoreCmd_Test_VerifyError(void)
@@ -986,7 +956,6 @@ void CS_ReportBaselineCfeCoreCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineCfeCoreCmd_Test_VerifyError */
 
 void CS_ReportBaselineOSCmd_Test_Nominal(void)
@@ -1019,7 +988,6 @@ void CS_ReportBaselineOSCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineOSCmd_Test_Nominal */
 
 void CS_ReportBaselineOSCmd_Test_NotComputedYet(void)
@@ -1052,7 +1020,6 @@ void CS_ReportBaselineOSCmd_Test_NotComputedYet(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineOSCmd_Test_NotComputedYet */
 
 void CS_ReportBaselineOSCmd_Test_VerifyError(void)
@@ -1069,7 +1036,6 @@ void CS_ReportBaselineOSCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineOSCmd_Test_VerifyError */
 
 void CS_RecomputeBaselineCfeCoreCmd_Test_Nominal(void)
@@ -1108,7 +1074,6 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineCfeCoreCmd_Test_Nominal */
 
 void CS_RecomputeBaselineCfeCoreCmd_Test_CreateChildTaskError(void)
@@ -1151,7 +1116,6 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineCfeCoreCmd_Test_CreateChildTaskError */
 
 void CS_RecomputeBaselineCfeCoreCmd_Test_ChildTaskError(void)
@@ -1183,7 +1147,6 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_ChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineCfeCoreCmd_Test_ChildTaskError */
 
 void CS_RecomputeBaselineCfeCoreCmd_Test_VerifyError(void)
@@ -1200,7 +1163,6 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineCfeCoreCmd_Test_VerifyError */
 
 void CS_RecomputeBaselineCfeCoreCmd_Test_OneShot(void)
@@ -1234,7 +1196,6 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineCfeCoreCmd_Test_OneShot */
 
 void CS_RecomputeBaselineOSCmd_Test_Nominal(void)
@@ -1273,7 +1234,6 @@ void CS_RecomputeBaselineOSCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineOSCmd_Test_Nominal */
 
 void CS_RecomputeBaselineOSCmd_Test_CreateChildTaskError(void)
@@ -1316,7 +1276,6 @@ void CS_RecomputeBaselineOSCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineOSCmd_Test_CreateChildTaskError */
 
 void CS_RecomputeBaselineOSCmd_Test_ChildTaskError(void)
@@ -1349,7 +1308,6 @@ void CS_RecomputeBaselineOSCmd_Test_ChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineOSCmd_Test_ChildTaskError */
 
 void CS_RecomputeBaselineOSCmd_Test_VerifyError(void)
@@ -1366,7 +1324,6 @@ void CS_RecomputeBaselineOSCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineOSCmd_Test_VerifyError */
 
 void CS_RecomputeBaselineOSCmd_Test_OneShot(void)
@@ -1401,7 +1358,6 @@ void CS_RecomputeBaselineOSCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineOSCmd_Test_OneShot */
 
 void CS_OneShotCmd_Test_Nominal(void)
@@ -1451,7 +1407,6 @@ void CS_OneShotCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_OneShotCmd_Test_Nominal */
 
 void CS_OneShotCmd_Test_MaxBytesPerCycleNonZero(void)
@@ -1501,7 +1456,6 @@ void CS_OneShotCmd_Test_MaxBytesPerCycleNonZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_OneShotCmd_Test_MaxBytesPerCycleNonZero */
 
 void CS_OneShotCmd_Test_CreateChildTaskError(void)
@@ -1547,7 +1501,6 @@ void CS_OneShotCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_OneShotCmd_Test_CreateChildTaskError */
 
 void CS_OneShotCmd_Test_ChildTaskError(void)
@@ -1579,7 +1532,6 @@ void CS_OneShotCmd_Test_ChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_OneShotCmd_Test_ChildTaskError */
 
 void CS_OneShotCmd_Test_MemValidateRangeError(void)
@@ -1615,7 +1567,6 @@ void CS_OneShotCmd_Test_MemValidateRangeError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_OneShotCmd_Test_MemValidateRangeError */
 
 void CS_OneShotCmd_Test_VerifyError(void)
@@ -1632,7 +1583,6 @@ void CS_OneShotCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_OneShotCmd_Test_VerifyError */
 
 void CS_OneShotCmd_Test_OneShot(void)
@@ -1666,7 +1616,6 @@ void CS_OneShotCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_OneShotCmd_Test_OneShot */
 
 void CS_CancelOneShotCmd_Test_Nominal(void)
@@ -1703,7 +1652,6 @@ void CS_CancelOneShotCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_CancelOneShotCmd_Test_Nominal */
 
 void CS_CancelOneShotCmd_Test_DeleteChildTaskError(void)
@@ -1740,7 +1688,6 @@ void CS_CancelOneShotCmd_Test_DeleteChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_CancelOneShotCmd_Test_DeleteChildTaskError */
 
 void CS_CancelOneShotCmd_Test_NoChildTaskError(void)
@@ -1777,7 +1724,6 @@ void CS_CancelOneShotCmd_Test_NoChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_CancelOneShotCmd_Test_NoChildTaskError */
 
 void CS_CancelOneShotCmd_Test_VerifyError(void)
@@ -1794,7 +1740,6 @@ void CS_CancelOneShotCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_CancelOneShotCmd_Test_VerifyError */
 
 void CS_CancelOneShotCmd_Test_OneShot(void)
@@ -1831,7 +1776,6 @@ void CS_CancelOneShotCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_CancelOneShotCmd_Test_OneShot */
 
 void UtTest_Setup(void)
@@ -1944,7 +1888,6 @@ void UtTest_Setup(void)
     UtTest_Add(CS_CancelOneShotCmd_Test_VerifyError, CS_Test_Setup, CS_Test_TearDown,
                "CS_CancelOneShotCmd_Test_VerifyError");
     UtTest_Add(CS_CancelOneShotCmd_Test_OneShot, CS_Test_Setup, CS_Test_TearDown, "CS_CancelOneShotCmd_Test_OneShot");
-
 } /* end UtTest_Setup */
 
 /************************/

--- a/unit-test/cs_cmds_tests.c
+++ b/unit-test/cs_cmds_tests.c
@@ -77,7 +77,7 @@ void CS_NoopCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_NoopCmd_Test */
+}
 
 void CS_NoopCmd_Test_VerifyError(void)
 {
@@ -93,7 +93,7 @@ void CS_NoopCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_NoopCmd_Test_VerifyError */
+}
 
 void CS_ResetCmd_Test(void)
 {
@@ -140,7 +140,7 @@ void CS_ResetCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ResetCmd_Test */
+}
 
 void CS_ResetCmd_Test_VerifyError(void)
 {
@@ -156,7 +156,7 @@ void CS_ResetCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ResetCmd_Test_VerifyError */
+}
 
 void CS_BackgroundCheckCycle_Test_InvalidMsgLength(void)
 {
@@ -201,7 +201,7 @@ void CS_BackgroundCheckCycle_Test_InvalidMsgLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_BackgroundCheckCycle_Test_InvalidMsgLength */
+}
 
 void CS_BackgroundCheckCycle_Test_BackgroundInProgress(void)
 {
@@ -248,7 +248,7 @@ void CS_BackgroundCheckCycle_Test_BackgroundInProgress(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_BackgroundCheckCycle_Test_BackgroundCfeCore */
+}
 
 void CS_BackgroundCheckCycle_Test_BackgroundCfeCore(void)
 {
@@ -281,7 +281,7 @@ void CS_BackgroundCheckCycle_Test_BackgroundCfeCore(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_BackgroundCheckCycle_Test_BackgroundCfeCore */
+}
 
 void CS_BackgroundCheckCycle_Test_BackgroundOS(void)
 {
@@ -314,7 +314,7 @@ void CS_BackgroundCheckCycle_Test_BackgroundOS(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_BackgroundCheckCycle_Test_BackgroundOS */
+}
 
 void CS_BackgroundCheckCycle_Test_BackgroundEeprom(void)
 {
@@ -346,7 +346,7 @@ void CS_BackgroundCheckCycle_Test_BackgroundEeprom(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_BackgroundCheckCycle_Test_BackgroundEeprom */
+}
 
 void CS_BackgroundCheckCycle_Test_BackgroundMemory(void)
 {
@@ -378,7 +378,7 @@ void CS_BackgroundCheckCycle_Test_BackgroundMemory(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_BackgroundCheckCycle_Test_BackgroundMemory */
+}
 
 void CS_BackgroundCheckCycle_Test_BackgroundTables(void)
 {
@@ -410,7 +410,7 @@ void CS_BackgroundCheckCycle_Test_BackgroundTables(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_BackgroundCheckCycle_Test_BackgroundTables */
+}
 
 void CS_BackgroundCheckCycle_Test_BackgroundApp(void)
 {
@@ -442,7 +442,7 @@ void CS_BackgroundCheckCycle_Test_BackgroundApp(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_BackgroundCheckCycle_Test_BackgroundApp */
+}
 
 void CS_BackgroundCheckCycle_Test_Default(void)
 {
@@ -476,7 +476,7 @@ void CS_BackgroundCheckCycle_Test_Default(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_BackgroundCheckCycle_Test_Default */
+}
 
 void CS_BackgroundCheckCycle_Test_Disabled(void)
 {
@@ -507,7 +507,7 @@ void CS_BackgroundCheckCycle_Test_Disabled(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_BackgroundCheckCycle_Test_Disabled */
+}
 
 void CS_BackgroundCheckCycle_Test_OneShot(void)
 {
@@ -555,7 +555,7 @@ void CS_BackgroundCheckCycle_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_BackgroundCheckCycle_Test_OneShot */
+}
 
 void CS_BackgroundCheckCycle_Test_EndOfList(void)
 {
@@ -591,7 +591,7 @@ void CS_BackgroundCheckCycle_Test_EndOfList(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_BackgroundCheckCycle_Test_EndOfList */
+}
 
 void CS_DisableAllCSCmd_Test(void)
 {
@@ -622,7 +622,7 @@ void CS_DisableAllCSCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableAllCSCmd_Test */
+}
 
 void CS_DisableAllCSCmd_Test_VerifyError(void)
 {
@@ -638,7 +638,7 @@ void CS_DisableAllCSCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableAllCSCmd_Test_VerifyError */
+}
 
 void CS_EnableAllCSCmd_Test(void)
 {
@@ -669,7 +669,7 @@ void CS_EnableAllCSCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableAllCSCmd_Test */
+}
 
 void CS_EnableAllCSCmd_Test_VerifyError(void)
 {
@@ -685,7 +685,7 @@ void CS_EnableAllCSCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableAllCSCmd_Test_VerifyError */
+}
 
 void CS_DisableCfeCoreCmd_Test(void)
 {
@@ -717,7 +717,7 @@ void CS_DisableCfeCoreCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableCfeCoreCmd_Test */
+}
 
 void CS_DisableCfeCoreCmd_Test_VerifyError(void)
 {
@@ -733,7 +733,7 @@ void CS_DisableCfeCoreCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableCfeCoreCmd_Test_VerifyError */
+}
 
 void CS_EnableCfeCoreCmd_Test(void)
 {
@@ -765,7 +765,7 @@ void CS_EnableCfeCoreCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableCfeCoreCmd_Test */
+}
 
 void CS_EnableCfeCoreCmd_Test_VerifyError(void)
 {
@@ -781,7 +781,7 @@ void CS_EnableCfeCoreCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableCfeCoreCmd_Test_VerifyError */
+}
 
 void CS_DisableOSCmd_Test(void)
 {
@@ -813,7 +813,7 @@ void CS_DisableOSCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableOSCmd_Test */
+}
 
 void CS_DisableOSCmd_Test_VerifyError(void)
 {
@@ -829,7 +829,7 @@ void CS_DisableOSCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableOSCmd_Test_VerifyError */
+}
 
 void CS_EnableOSCmd_Test(void)
 {
@@ -861,7 +861,7 @@ void CS_EnableOSCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableOSCmd_Test */
+}
 
 void CS_EnableOSCmd_Test_VerifyError(void)
 {
@@ -877,7 +877,7 @@ void CS_EnableOSCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableOSCmd_Test_VerifyError */
+}
 
 void CS_ReportBaselineCfeCoreCmd_Test_Nominal(void)
 {
@@ -909,7 +909,7 @@ void CS_ReportBaselineCfeCoreCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineCfeCoreCmd_Test_Nominal */
+}
 
 void CS_ReportBaselineCfeCoreCmd_Test_NotComputedYet(void)
 {
@@ -940,7 +940,7 @@ void CS_ReportBaselineCfeCoreCmd_Test_NotComputedYet(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineCfeCoreCmd_Test_NotComputedYet */
+}
 
 void CS_ReportBaselineCfeCoreCmd_Test_VerifyError(void)
 {
@@ -956,7 +956,7 @@ void CS_ReportBaselineCfeCoreCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineCfeCoreCmd_Test_VerifyError */
+}
 
 void CS_ReportBaselineOSCmd_Test_Nominal(void)
 {
@@ -988,7 +988,7 @@ void CS_ReportBaselineOSCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineOSCmd_Test_Nominal */
+}
 
 void CS_ReportBaselineOSCmd_Test_NotComputedYet(void)
 {
@@ -1020,7 +1020,7 @@ void CS_ReportBaselineOSCmd_Test_NotComputedYet(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineOSCmd_Test_NotComputedYet */
+}
 
 void CS_ReportBaselineOSCmd_Test_VerifyError(void)
 {
@@ -1036,7 +1036,7 @@ void CS_ReportBaselineOSCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineOSCmd_Test_VerifyError */
+}
 
 void CS_RecomputeBaselineCfeCoreCmd_Test_Nominal(void)
 {
@@ -1074,7 +1074,7 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineCfeCoreCmd_Test_Nominal */
+}
 
 void CS_RecomputeBaselineCfeCoreCmd_Test_CreateChildTaskError(void)
 {
@@ -1116,7 +1116,7 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineCfeCoreCmd_Test_CreateChildTaskError */
+}
 
 void CS_RecomputeBaselineCfeCoreCmd_Test_ChildTaskError(void)
 {
@@ -1147,7 +1147,7 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_ChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineCfeCoreCmd_Test_ChildTaskError */
+}
 
 void CS_RecomputeBaselineCfeCoreCmd_Test_VerifyError(void)
 {
@@ -1163,7 +1163,7 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineCfeCoreCmd_Test_VerifyError */
+}
 
 void CS_RecomputeBaselineCfeCoreCmd_Test_OneShot(void)
 {
@@ -1196,7 +1196,7 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineCfeCoreCmd_Test_OneShot */
+}
 
 void CS_RecomputeBaselineOSCmd_Test_Nominal(void)
 {
@@ -1234,7 +1234,7 @@ void CS_RecomputeBaselineOSCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineOSCmd_Test_Nominal */
+}
 
 void CS_RecomputeBaselineOSCmd_Test_CreateChildTaskError(void)
 {
@@ -1276,7 +1276,7 @@ void CS_RecomputeBaselineOSCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineOSCmd_Test_CreateChildTaskError */
+}
 
 void CS_RecomputeBaselineOSCmd_Test_ChildTaskError(void)
 {
@@ -1308,7 +1308,7 @@ void CS_RecomputeBaselineOSCmd_Test_ChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineOSCmd_Test_ChildTaskError */
+}
 
 void CS_RecomputeBaselineOSCmd_Test_VerifyError(void)
 {
@@ -1324,7 +1324,7 @@ void CS_RecomputeBaselineOSCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineOSCmd_Test_VerifyError */
+}
 
 void CS_RecomputeBaselineOSCmd_Test_OneShot(void)
 {
@@ -1358,7 +1358,7 @@ void CS_RecomputeBaselineOSCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineOSCmd_Test_OneShot */
+}
 
 void CS_OneShotCmd_Test_Nominal(void)
 {
@@ -1407,7 +1407,7 @@ void CS_OneShotCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_OneShotCmd_Test_Nominal */
+}
 
 void CS_OneShotCmd_Test_MaxBytesPerCycleNonZero(void)
 {
@@ -1456,7 +1456,7 @@ void CS_OneShotCmd_Test_MaxBytesPerCycleNonZero(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_OneShotCmd_Test_MaxBytesPerCycleNonZero */
+}
 
 void CS_OneShotCmd_Test_CreateChildTaskError(void)
 {
@@ -1501,7 +1501,7 @@ void CS_OneShotCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_OneShotCmd_Test_CreateChildTaskError */
+}
 
 void CS_OneShotCmd_Test_ChildTaskError(void)
 {
@@ -1532,7 +1532,7 @@ void CS_OneShotCmd_Test_ChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_OneShotCmd_Test_ChildTaskError */
+}
 
 void CS_OneShotCmd_Test_MemValidateRangeError(void)
 {
@@ -1567,7 +1567,7 @@ void CS_OneShotCmd_Test_MemValidateRangeError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_OneShotCmd_Test_MemValidateRangeError */
+}
 
 void CS_OneShotCmd_Test_VerifyError(void)
 {
@@ -1583,7 +1583,7 @@ void CS_OneShotCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_OneShotCmd_Test_VerifyError */
+}
 
 void CS_OneShotCmd_Test_OneShot(void)
 {
@@ -1616,7 +1616,7 @@ void CS_OneShotCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_OneShotCmd_Test_OneShot */
+}
 
 void CS_CancelOneShotCmd_Test_Nominal(void)
 {
@@ -1652,7 +1652,7 @@ void CS_CancelOneShotCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_CancelOneShotCmd_Test_Nominal */
+}
 
 void CS_CancelOneShotCmd_Test_DeleteChildTaskError(void)
 {
@@ -1688,7 +1688,7 @@ void CS_CancelOneShotCmd_Test_DeleteChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_CancelOneShotCmd_Test_DeleteChildTaskError */
+}
 
 void CS_CancelOneShotCmd_Test_NoChildTaskError(void)
 {
@@ -1724,7 +1724,7 @@ void CS_CancelOneShotCmd_Test_NoChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_CancelOneShotCmd_Test_NoChildTaskError */
+}
 
 void CS_CancelOneShotCmd_Test_VerifyError(void)
 {
@@ -1740,7 +1740,7 @@ void CS_CancelOneShotCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_CancelOneShotCmd_Test_VerifyError */
+}
 
 void CS_CancelOneShotCmd_Test_OneShot(void)
 {
@@ -1776,7 +1776,7 @@ void CS_CancelOneShotCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_CancelOneShotCmd_Test_OneShot */
+}
 
 void UtTest_Setup(void)
 {
@@ -1888,8 +1888,4 @@ void UtTest_Setup(void)
     UtTest_Add(CS_CancelOneShotCmd_Test_VerifyError, CS_Test_Setup, CS_Test_TearDown,
                "CS_CancelOneShotCmd_Test_VerifyError");
     UtTest_Add(CS_CancelOneShotCmd_Test_OneShot, CS_Test_Setup, CS_Test_TearDown, "CS_CancelOneShotCmd_Test_OneShot");
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/cs_compute_tests.c
+++ b/unit-test/cs_compute_tests.c
@@ -112,7 +112,6 @@ void CS_ComputeEepromMemory_Test_Nominal(void)
     UtAssert_BOOL_TRUE(DoneWithEntry);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
 } /* end CS_ComputeEepromMemory_Test_Nominal */
 
 void CS_ComputeEepromMemory_Test_Error(void)
@@ -140,7 +139,6 @@ void CS_ComputeEepromMemory_Test_Error(void)
     UtAssert_BOOL_TRUE(DoneWithEntry);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
 } /* end CS_ComputeEepromMemory_Test_Error */
 
 void CS_ComputeEepromMemory_Test_FirstTimeThrough(void)
@@ -172,7 +170,6 @@ void CS_ComputeEepromMemory_Test_FirstTimeThrough(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
 } /* end CS_ComputeEepromMemory_Test_FirstTimeThrough */
 
 void CS_ComputeEepromMemory_Test_NotFinished(void)
@@ -199,7 +196,6 @@ void CS_ComputeEepromMemory_Test_NotFinished(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
 } /* end CS_ComputeEepromMemory_Test_NotFinished */
 
 void CS_ComputeTables_Test_TableNeverLoaded(void)
@@ -234,7 +230,6 @@ void CS_ComputeTables_Test_TableNeverLoaded(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_ComputeTables_Test_TableNeverLoaded */
 
 void CS_ComputeTables_Test_TableUnregisteredAndNeverLoaded(void)
@@ -279,7 +274,6 @@ void CS_ComputeTables_Test_TableUnregisteredAndNeverLoaded(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_ComputeTables_Test_TableUnregisteredAndNeverLoaded */
 
 void CS_ComputeTables_Test_ResultShareNotSuccess(void)
@@ -323,7 +317,6 @@ void CS_ComputeTables_Test_ResultShareNotSuccess(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_ComputeTables_Test_ResultShareNotSuccess */
 
 void CS_ComputeTables_Test_TblInfoUpdated(void)
@@ -364,7 +357,6 @@ void CS_ComputeTables_Test_TblInfoUpdated(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
 } /* end CS_ComputeTables_Test_TblInfoUpdated */
 
 void CS_ComputeTables_Test_GetInfoResult(void)
@@ -406,7 +398,6 @@ void CS_ComputeTables_Test_GetInfoResult(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
 } /* end CS_ComputeTables_Test_GetInfoResult */
 
 void CS_ComputeTables_Test_CSError(void)
@@ -452,7 +443,6 @@ void CS_ComputeTables_Test_CSError(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
 } /* end CS_ComputeTables_Test_CSError */
 
 void CS_ComputeTables_Test_NominalBadTableHandle(void)
@@ -503,7 +493,6 @@ void CS_ComputeTables_Test_NominalBadTableHandle(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
 } /* end CS_ComputeTables_Test_NominalBadTableHandle */
 
 void CS_ComputeTables_Test_FirstTimeThrough(void)
@@ -558,7 +547,6 @@ void CS_ComputeTables_Test_FirstTimeThrough(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
 } /* end CS_ComputeTables_Test_FirstTimeThrough */
 
 void CS_ComputeTables_Test_EntryNotFinished(void)
@@ -610,7 +598,6 @@ void CS_ComputeTables_Test_EntryNotFinished(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 3);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
 } /* end CS_ComputeTables_Test_EntryNotFinished */
 
 void CS_ComputeTables_Test_ComputeTablesReleaseError(void)
@@ -677,7 +664,6 @@ void CS_ComputeTables_Test_ComputeTablesReleaseError(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_ComputeTables_Test_ComputeTablesReleaseError */
 
 void CS_ComputeTables_Test_ComputeTablesError(void)
@@ -722,7 +708,6 @@ void CS_ComputeTables_Test_ComputeTablesError(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_ComputeTables_Test_ComputeTablesError */
 
 void CS_ComputeApp_Test_NominalApp(void)
@@ -760,7 +745,6 @@ void CS_ComputeApp_Test_NominalApp(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
 } /* end CS_ComputeApp_Test_NominalApp */
 
 void CS_ComputeApp_Test_NominalLib(void)
@@ -801,7 +785,6 @@ void CS_ComputeApp_Test_NominalLib(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
 } /* end CS_ComputeApp_Test_NominalLib */
 
 void CS_ComputeApp_Test_GetAppAndLibIDByNameError(void)
@@ -838,7 +821,6 @@ void CS_ComputeApp_Test_GetAppAndLibIDByNameError(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_ComputeApp_Test_GetAppAndLibIDByNameError */
 
 void CS_ComputeApp_Test_GetModuleInfoError(void)
@@ -872,7 +854,6 @@ void CS_ComputeApp_Test_GetModuleInfoError(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_ComputeApp_Test_GetModuleInfoError */
 
 void CS_ComputeApp_Test_ComputeAppPlatformError(void)
@@ -915,7 +896,6 @@ void CS_ComputeApp_Test_ComputeAppPlatformError(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-
 } /* end CS_ComputeApp_Test_ComputeAppPlatformError */
 
 void CS_ComputeApp_Test_DifferFromSavedValue(void)
@@ -949,7 +929,6 @@ void CS_ComputeApp_Test_DifferFromSavedValue(void)
     UtAssert_UINT32_EQ(ResultsEntry.StartAddress, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
 } /* end CS_ComputeApp_Test_DifferFromSavedValue */
 
 void CS_ComputeApp_Test_FirstTimeThrough(void)
@@ -990,7 +969,6 @@ void CS_ComputeApp_Test_FirstTimeThrough(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
 } /* end CS_ComputeApp_Test_FirstTimeThrough */
 
 void CS_ComputeApp_Test_EntryNotFinished(void)
@@ -1035,7 +1013,6 @@ void CS_ComputeApp_Test_EntryNotFinished(void)
     UtAssert_UINT32_EQ(ComputedCSValue, 2);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-
 } /* end CS_ComputeApp_Test_EntryNotFinished */
 
 void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTable(void)
@@ -1090,7 +1067,6 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTable(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_RecomputeEepromMemoryChildTask_Test_EEPROMTable */
 
 void CS_RecomputeEepromMemoryChildTask_Test_MemoryTable(void)
@@ -1145,7 +1121,6 @@ void CS_RecomputeEepromMemoryChildTask_Test_MemoryTable(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_RecomputeEepromMemoryChildTask_Test_MemoryTable */
 
 void CS_RecomputeEepromMemoryChildTask_Test_CFECore(void)
@@ -1202,7 +1177,6 @@ void CS_RecomputeEepromMemoryChildTask_Test_CFECore(void)
     UtAssert_UINT32_EQ(CS_AppData.HkPacket.CfeCoreBaseline, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_RecomputeEepromMemoryChildTask_Test_CFECore */
 
 void CS_RecomputeEepromMemoryChildTask_Test_OSCore(void)
@@ -1259,7 +1233,6 @@ void CS_RecomputeEepromMemoryChildTask_Test_OSCore(void)
     UtAssert_UINT32_EQ(CS_AppData.HkPacket.OSBaseline, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_RecomputeEepromMemoryChildTask_Test_OSCore */
 
 void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableEntryId(void)
@@ -1313,7 +1286,6 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableEntryId(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableEntryId */
 
 void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableStartAddress(void)
@@ -1368,7 +1340,6 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableStartAddress(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableStartAddress */
 
 void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableState(void)
@@ -1423,7 +1394,6 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableState(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableState */
 
 void CS_RecomputeAppChildTask_Test_Nominal(void)
@@ -1481,7 +1451,6 @@ void CS_RecomputeAppChildTask_Test_Nominal(void)
     UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_RecomputeAppChildTask_Test_Nominal */
 
 void CS_RecomputeAppChildTask_Test_CouldNotGetAddress(void)
@@ -1532,7 +1501,6 @@ void CS_RecomputeAppChildTask_Test_CouldNotGetAddress(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_RECOMPUTE_ERROR_APP_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
-
 } /* end CS_RecomputeAppChildTask_Test_CouldNotGetAddress */
 
 void CS_RecomputeAppChildTask_Test_DefEntryId(void)
@@ -1589,7 +1557,6 @@ void CS_RecomputeAppChildTask_Test_DefEntryId(void)
     UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_RecomputeAppChildTask_Test_DefEntryId */
 
 void CS_RecomputeTablesChildTask_Test_Nominal(void)
@@ -1665,7 +1632,6 @@ void CS_RecomputeTablesChildTask_Test_Nominal(void)
     UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_RecomputeTablesChildTask_Test_Nominal */
 
 void CS_RecomputeTablesChildTask_Test_CouldNotGetAddress(void)
@@ -1713,7 +1679,6 @@ void CS_RecomputeTablesChildTask_Test_CouldNotGetAddress(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
 
     /* Note: generates 1 event message we don't care about in this test */
-
 } /* end CS_RecomputeTablesChildTask_Test_CouldNotGetAddress */
 
 void CS_RecomputeTablesChildTask_Test_DefEntryId(void)
@@ -1788,7 +1753,6 @@ void CS_RecomputeTablesChildTask_Test_DefEntryId(void)
     UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_RecomputeTablesChildTask_Test_DefEntryId*/
 
 void CS_OneShotChildTask_Test_Nominal(void)
@@ -1823,7 +1787,6 @@ void CS_OneShotChildTask_Test_Nominal(void)
     UtAssert_BOOL_FALSE(CFE_RESOURCEID_TEST_DEFINED(CS_AppData.ChildTaskID));
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-
 } /* end CS_OneShotChildTask_Test_Nominal */
 
 void UtTest_Setup(void)
@@ -1903,7 +1866,6 @@ void UtTest_Setup(void)
                "CS_RecomputeTablesChildTask_Test_DefEntryId");
 
     UtTest_Add(CS_OneShotChildTask_Test_Nominal, CS_Test_Setup, CS_Test_TearDown, "CS_OneShotChildTask_Test_Nominal");
-
 } /* end UtTest_Setup */
 
 /************************/

--- a/unit-test/cs_compute_tests.c
+++ b/unit-test/cs_compute_tests.c
@@ -112,7 +112,7 @@ void CS_ComputeEepromMemory_Test_Nominal(void)
     UtAssert_BOOL_TRUE(DoneWithEntry);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end CS_ComputeEepromMemory_Test_Nominal */
+}
 
 void CS_ComputeEepromMemory_Test_Error(void)
 {
@@ -139,7 +139,7 @@ void CS_ComputeEepromMemory_Test_Error(void)
     UtAssert_BOOL_TRUE(DoneWithEntry);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end CS_ComputeEepromMemory_Test_Error */
+}
 
 void CS_ComputeEepromMemory_Test_FirstTimeThrough(void)
 {
@@ -170,7 +170,7 @@ void CS_ComputeEepromMemory_Test_FirstTimeThrough(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end CS_ComputeEepromMemory_Test_FirstTimeThrough */
+}
 
 void CS_ComputeEepromMemory_Test_NotFinished(void)
 {
@@ -196,7 +196,7 @@ void CS_ComputeEepromMemory_Test_NotFinished(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end CS_ComputeEepromMemory_Test_NotFinished */
+}
 
 void CS_ComputeTables_Test_TableNeverLoaded(void)
 {
@@ -230,7 +230,7 @@ void CS_ComputeTables_Test_TableNeverLoaded(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_ComputeTables_Test_TableNeverLoaded */
+}
 
 void CS_ComputeTables_Test_TableUnregisteredAndNeverLoaded(void)
 {
@@ -274,7 +274,7 @@ void CS_ComputeTables_Test_TableUnregisteredAndNeverLoaded(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_ComputeTables_Test_TableUnregisteredAndNeverLoaded */
+}
 
 void CS_ComputeTables_Test_ResultShareNotSuccess(void)
 {
@@ -317,7 +317,7 @@ void CS_ComputeTables_Test_ResultShareNotSuccess(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_ComputeTables_Test_ResultShareNotSuccess */
+}
 
 void CS_ComputeTables_Test_TblInfoUpdated(void)
 {
@@ -357,7 +357,7 @@ void CS_ComputeTables_Test_TblInfoUpdated(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end CS_ComputeTables_Test_TblInfoUpdated */
+}
 
 void CS_ComputeTables_Test_GetInfoResult(void)
 {
@@ -398,7 +398,7 @@ void CS_ComputeTables_Test_GetInfoResult(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end CS_ComputeTables_Test_GetInfoResult */
+}
 
 void CS_ComputeTables_Test_CSError(void)
 {
@@ -443,7 +443,7 @@ void CS_ComputeTables_Test_CSError(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end CS_ComputeTables_Test_CSError */
+}
 
 void CS_ComputeTables_Test_NominalBadTableHandle(void)
 {
@@ -493,7 +493,7 @@ void CS_ComputeTables_Test_NominalBadTableHandle(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end CS_ComputeTables_Test_NominalBadTableHandle */
+}
 
 void CS_ComputeTables_Test_FirstTimeThrough(void)
 {
@@ -547,7 +547,7 @@ void CS_ComputeTables_Test_FirstTimeThrough(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end CS_ComputeTables_Test_FirstTimeThrough */
+}
 
 void CS_ComputeTables_Test_EntryNotFinished(void)
 {
@@ -598,7 +598,7 @@ void CS_ComputeTables_Test_EntryNotFinished(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 3);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end CS_ComputeTables_Test_EntryNotFinished */
+}
 
 void CS_ComputeTables_Test_ComputeTablesReleaseError(void)
 {
@@ -664,7 +664,7 @@ void CS_ComputeTables_Test_ComputeTablesReleaseError(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_ComputeTables_Test_ComputeTablesReleaseError */
+}
 
 void CS_ComputeTables_Test_ComputeTablesError(void)
 {
@@ -708,7 +708,7 @@ void CS_ComputeTables_Test_ComputeTablesError(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_ComputeTables_Test_ComputeTablesError */
+}
 
 void CS_ComputeApp_Test_NominalApp(void)
 {
@@ -745,7 +745,7 @@ void CS_ComputeApp_Test_NominalApp(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end CS_ComputeApp_Test_NominalApp */
+}
 
 void CS_ComputeApp_Test_NominalLib(void)
 {
@@ -785,7 +785,7 @@ void CS_ComputeApp_Test_NominalLib(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end CS_ComputeApp_Test_NominalLib */
+}
 
 void CS_ComputeApp_Test_GetAppAndLibIDByNameError(void)
 {
@@ -821,7 +821,7 @@ void CS_ComputeApp_Test_GetAppAndLibIDByNameError(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_ComputeApp_Test_GetAppAndLibIDByNameError */
+}
 
 void CS_ComputeApp_Test_GetModuleInfoError(void)
 {
@@ -854,7 +854,7 @@ void CS_ComputeApp_Test_GetModuleInfoError(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_ComputeApp_Test_GetModuleInfoError */
+}
 
 void CS_ComputeApp_Test_ComputeAppPlatformError(void)
 {
@@ -896,7 +896,7 @@ void CS_ComputeApp_Test_ComputeAppPlatformError(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-} /* end CS_ComputeApp_Test_ComputeAppPlatformError */
+}
 
 void CS_ComputeApp_Test_DifferFromSavedValue(void)
 {
@@ -929,7 +929,7 @@ void CS_ComputeApp_Test_DifferFromSavedValue(void)
     UtAssert_UINT32_EQ(ResultsEntry.StartAddress, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end CS_ComputeApp_Test_DifferFromSavedValue */
+}
 
 void CS_ComputeApp_Test_FirstTimeThrough(void)
 {
@@ -969,7 +969,7 @@ void CS_ComputeApp_Test_FirstTimeThrough(void)
     UtAssert_UINT32_EQ(ResultsEntry.TempChecksumValue, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end CS_ComputeApp_Test_FirstTimeThrough */
+}
 
 void CS_ComputeApp_Test_EntryNotFinished(void)
 {
@@ -1013,7 +1013,7 @@ void CS_ComputeApp_Test_EntryNotFinished(void)
     UtAssert_UINT32_EQ(ComputedCSValue, 2);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-} /* end CS_ComputeApp_Test_EntryNotFinished */
+}
 
 void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTable(void)
 {
@@ -1067,7 +1067,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTable(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_RecomputeEepromMemoryChildTask_Test_EEPROMTable */
+}
 
 void CS_RecomputeEepromMemoryChildTask_Test_MemoryTable(void)
 {
@@ -1121,7 +1121,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_MemoryTable(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_RecomputeEepromMemoryChildTask_Test_MemoryTable */
+}
 
 void CS_RecomputeEepromMemoryChildTask_Test_CFECore(void)
 {
@@ -1177,7 +1177,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_CFECore(void)
     UtAssert_UINT32_EQ(CS_AppData.HkPacket.CfeCoreBaseline, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_RecomputeEepromMemoryChildTask_Test_CFECore */
+}
 
 void CS_RecomputeEepromMemoryChildTask_Test_OSCore(void)
 {
@@ -1233,7 +1233,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_OSCore(void)
     UtAssert_UINT32_EQ(CS_AppData.HkPacket.OSBaseline, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_RecomputeEepromMemoryChildTask_Test_OSCore */
+}
 
 void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableEntryId(void)
 {
@@ -1286,7 +1286,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableEntryId(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableEntryId */
+}
 
 void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableStartAddress(void)
 {
@@ -1340,7 +1340,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableStartAddress(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableStartAddress */
+}
 
 void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableState(void)
 {
@@ -1394,7 +1394,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableState(void)
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableState */
+}
 
 void CS_RecomputeAppChildTask_Test_Nominal(void)
 {
@@ -1451,7 +1451,7 @@ void CS_RecomputeAppChildTask_Test_Nominal(void)
     UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_RecomputeAppChildTask_Test_Nominal */
+}
 
 void CS_RecomputeAppChildTask_Test_CouldNotGetAddress(void)
 {
@@ -1501,7 +1501,7 @@ void CS_RecomputeAppChildTask_Test_CouldNotGetAddress(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_RECOMPUTE_ERROR_APP_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
-} /* end CS_RecomputeAppChildTask_Test_CouldNotGetAddress */
+}
 
 void CS_RecomputeAppChildTask_Test_DefEntryId(void)
 {
@@ -1557,7 +1557,7 @@ void CS_RecomputeAppChildTask_Test_DefEntryId(void)
     UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_RecomputeAppChildTask_Test_DefEntryId */
+}
 
 void CS_RecomputeTablesChildTask_Test_Nominal(void)
 {
@@ -1632,7 +1632,7 @@ void CS_RecomputeTablesChildTask_Test_Nominal(void)
     UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_RecomputeTablesChildTask_Test_Nominal */
+}
 
 void CS_RecomputeTablesChildTask_Test_CouldNotGetAddress(void)
 {
@@ -1679,7 +1679,7 @@ void CS_RecomputeTablesChildTask_Test_CouldNotGetAddress(void)
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
 
     /* Note: generates 1 event message we don't care about in this test */
-} /* end CS_RecomputeTablesChildTask_Test_CouldNotGetAddress */
+}
 
 void CS_RecomputeTablesChildTask_Test_DefEntryId(void)
 {
@@ -1753,7 +1753,7 @@ void CS_RecomputeTablesChildTask_Test_DefEntryId(void)
     UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_RecomputeTablesChildTask_Test_DefEntryId*/
+}
 
 void CS_OneShotChildTask_Test_Nominal(void)
 {
@@ -1787,7 +1787,7 @@ void CS_OneShotChildTask_Test_Nominal(void)
     UtAssert_BOOL_FALSE(CFE_RESOURCEID_TEST_DEFINED(CS_AppData.ChildTaskID));
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-} /* end CS_OneShotChildTask_Test_Nominal */
+}
 
 void UtTest_Setup(void)
 {
@@ -1866,8 +1866,4 @@ void UtTest_Setup(void)
                "CS_RecomputeTablesChildTask_Test_DefEntryId");
 
     UtTest_Add(CS_OneShotChildTask_Test_Nominal, CS_Test_Setup, CS_Test_TearDown, "CS_OneShotChildTask_Test_Nominal");
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/cs_eeprom_cmds_tests.c
+++ b/unit-test/cs_eeprom_cmds_tests.c
@@ -73,7 +73,6 @@ void CS_DisableEepromCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableEepromCmd_Test */
 
 void CS_DisableEepromCmd_Test_VerifyError(void)
@@ -92,7 +91,6 @@ void CS_DisableEepromCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableEepromCmd_Test_VerifyError */
 
 void CS_DisableEepromCmd_Test_OneShot(void)
@@ -112,7 +110,6 @@ void CS_DisableEepromCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableEepromCmd_Test_OneShot */
 
 void CS_EnableEepromCmd_Test(void)
@@ -145,7 +142,6 @@ void CS_EnableEepromCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableEepromCmd_Test */
 
 void CS_EnableEepromCmd_Test_VerifyError(void)
@@ -164,7 +160,6 @@ void CS_EnableEepromCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableEepromCmd_Test_VerifyError */
 
 void CS_EnableEepromCmd_Test_OneShot(void)
@@ -184,7 +179,6 @@ void CS_EnableEepromCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableEepromCmd_Test_OneShot */
 
 void CS_ReportBaselineEntryIDEepromCmd_Test_Computed(void)
@@ -220,7 +214,6 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_Computed(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineEntryIDEepromCmd_Test_Computed */
 
 void CS_ReportBaselineEntryIDEepromCmd_Test_NotYetComputed(void)
@@ -257,7 +250,6 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_NotYetComputed(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineEntryIDEepromCmd_Test_NotYetComputed */
 
 void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
@@ -290,7 +282,6 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh */
 
 void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
@@ -325,7 +316,6 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty */
 
 void CS_ReportBaselineEntryIDEepromCmd_Test_VerifyError(void)
@@ -344,7 +334,6 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineEntryIDEepromCmd_Test_VerifyError */
 
 void CS_RecomputeBaselineEepromCmd_Test_Nominal(void)
@@ -387,7 +376,6 @@ void CS_RecomputeBaselineEepromCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineEepromCmd_Test_Nominal */
 
 void CS_RecomputeBaselineEepromCmd_Test_CreateChildTaskError(void)
@@ -433,7 +421,6 @@ void CS_RecomputeBaselineEepromCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineEepromCmd_Test_CreateChildTaskError */
 
 void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
@@ -466,7 +453,6 @@ void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh */
 
 void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
@@ -501,7 +487,6 @@ void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorStateEmpty */
 
 void CS_RecomputeBaselineEepromCmd_Test_RecomputeInProgress(void)
@@ -536,7 +521,6 @@ void CS_RecomputeBaselineEepromCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineEepromCmd_Test_RecomputeInProgress */
 
 void CS_RecomputeBaselineEepromCmd_Test_VerifyError(void)
@@ -555,7 +539,6 @@ void CS_RecomputeBaselineEepromCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineEepromCmd_Test_VerifyError */
 
 void CS_RecomputeBaselineEepromCmd_Test_OneShot(void)
@@ -591,7 +574,6 @@ void CS_RecomputeBaselineEepromCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineEepromCmd_Test_OneShot */
 
 void CS_EnableEntryIDEepromCmd_Test_Nominal(void)
@@ -632,7 +614,6 @@ void CS_EnableEntryIDEepromCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableEntryIDEepromCmd_Test_Nominal */
 
 void CS_EnableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
@@ -683,7 +664,6 @@ void CS_EnableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty */
 
 void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
@@ -716,7 +696,6 @@ void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh */
 
 void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
@@ -751,7 +730,6 @@ void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty */
 
 void CS_EnableEntryIDEepromCmd_Test_VerifyError(void)
@@ -770,7 +748,6 @@ void CS_EnableEntryIDEepromCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableEntryIDEepromCmd_Test_VerifyError */
 
 void CS_EnableEntryIDEepromCmd_Test_OneShot(void)
@@ -790,7 +767,6 @@ void CS_EnableEntryIDEepromCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableEntryIDEepromCmd_Test_OneShot */
 
 void CS_DisableEntryIDEepromCmd_Test_Nominal(void)
@@ -836,7 +812,6 @@ void CS_DisableEntryIDEepromCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableEntryIDEepromCmd_Test_Nominal */
 
 void CS_DisableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
@@ -891,7 +866,6 @@ void CS_DisableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty */
 
 void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
@@ -924,7 +898,6 @@ void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh */
 
 void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
@@ -959,7 +932,6 @@ void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty */
 
 void CS_DisableEntryIDEepromCmd_Test_VerifyError(void)
@@ -978,7 +950,6 @@ void CS_DisableEntryIDEepromCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableEntryIDEepromCmd_Test_VerifyError */
 
 void CS_DisableEntryIDEepromCmd_Test_OneShot(void)
@@ -998,7 +969,6 @@ void CS_DisableEntryIDEepromCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableEntryIDEepromCmd_Test_OneShot */
 
 void CS_GetEntryIDEepromCmd_Test_Nominal(void)
@@ -1035,7 +1005,6 @@ void CS_GetEntryIDEepromCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_GetEntryIDEepromCmd_Test_Nominal */
 
 void CS_GetEntryIDEepromCmd_Test_AddressNotFound(void)
@@ -1067,7 +1036,6 @@ void CS_GetEntryIDEepromCmd_Test_AddressNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_GetEntryIDEepromCmd_Test_AddressNotFound */
 
 void CS_GetEntryIDEepromCmd_Test_AddressPtr(void)
@@ -1104,7 +1072,6 @@ void CS_GetEntryIDEepromCmd_Test_AddressPtr(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_GetEntryIDEepromCmd_Test_AddressPtr */
 
 void CS_GetEntryIDEepromCmd_Test_State(void)
@@ -1141,7 +1108,6 @@ void CS_GetEntryIDEepromCmd_Test_State(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_GetEntryIDEepromCmd_Test_State */
 
 void CS_GetEntryIDEepromCmd_Test_VerifyError(void)
@@ -1160,7 +1126,6 @@ void CS_GetEntryIDEepromCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_GetEntryIDEepromCmd_Test_VerifyError */
 
 void UtTest_Setup(void)
@@ -1236,7 +1201,6 @@ void UtTest_Setup(void)
     UtTest_Add(CS_GetEntryIDEepromCmd_Test_State, CS_Test_Setup, CS_Test_TearDown, "CS_GetEntryIDEepromCmd_Test_State");
     UtTest_Add(CS_GetEntryIDEepromCmd_Test_VerifyError, CS_Test_Setup, CS_Test_TearDown,
                "CS_GetEntryIDEepromCmd_Test_VerifyError");
-
 } /* end UtTest_Setup */
 
 /************************/

--- a/unit-test/cs_eeprom_cmds_tests.c
+++ b/unit-test/cs_eeprom_cmds_tests.c
@@ -73,7 +73,7 @@ void CS_DisableEepromCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableEepromCmd_Test */
+}
 
 void CS_DisableEepromCmd_Test_VerifyError(void)
 {
@@ -91,7 +91,7 @@ void CS_DisableEepromCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableEepromCmd_Test_VerifyError */
+}
 
 void CS_DisableEepromCmd_Test_OneShot(void)
 {
@@ -110,7 +110,7 @@ void CS_DisableEepromCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableEepromCmd_Test_OneShot */
+}
 
 void CS_EnableEepromCmd_Test(void)
 {
@@ -142,7 +142,7 @@ void CS_EnableEepromCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableEepromCmd_Test */
+}
 
 void CS_EnableEepromCmd_Test_VerifyError(void)
 {
@@ -160,7 +160,7 @@ void CS_EnableEepromCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableEepromCmd_Test_VerifyError */
+}
 
 void CS_EnableEepromCmd_Test_OneShot(void)
 {
@@ -179,7 +179,7 @@ void CS_EnableEepromCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableEepromCmd_Test_OneShot */
+}
 
 void CS_ReportBaselineEntryIDEepromCmd_Test_Computed(void)
 {
@@ -214,7 +214,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_Computed(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineEntryIDEepromCmd_Test_Computed */
+}
 
 void CS_ReportBaselineEntryIDEepromCmd_Test_NotYetComputed(void)
 {
@@ -250,7 +250,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_NotYetComputed(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineEntryIDEepromCmd_Test_NotYetComputed */
+}
 
 void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 {
@@ -282,7 +282,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh */
+}
 
 void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 {
@@ -316,7 +316,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty */
+}
 
 void CS_ReportBaselineEntryIDEepromCmd_Test_VerifyError(void)
 {
@@ -334,7 +334,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineEntryIDEepromCmd_Test_VerifyError */
+}
 
 void CS_RecomputeBaselineEepromCmd_Test_Nominal(void)
 {
@@ -376,7 +376,7 @@ void CS_RecomputeBaselineEepromCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineEepromCmd_Test_Nominal */
+}
 
 void CS_RecomputeBaselineEepromCmd_Test_CreateChildTaskError(void)
 {
@@ -421,7 +421,7 @@ void CS_RecomputeBaselineEepromCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineEepromCmd_Test_CreateChildTaskError */
+}
 
 void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 {
@@ -453,7 +453,7 @@ void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh */
+}
 
 void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 {
@@ -487,7 +487,7 @@ void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorStateEmpty */
+}
 
 void CS_RecomputeBaselineEepromCmd_Test_RecomputeInProgress(void)
 {
@@ -521,7 +521,7 @@ void CS_RecomputeBaselineEepromCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineEepromCmd_Test_RecomputeInProgress */
+}
 
 void CS_RecomputeBaselineEepromCmd_Test_VerifyError(void)
 {
@@ -539,7 +539,7 @@ void CS_RecomputeBaselineEepromCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineEepromCmd_Test_VerifyError */
+}
 
 void CS_RecomputeBaselineEepromCmd_Test_OneShot(void)
 {
@@ -574,7 +574,7 @@ void CS_RecomputeBaselineEepromCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineEepromCmd_Test_OneShot */
+}
 
 void CS_EnableEntryIDEepromCmd_Test_Nominal(void)
 {
@@ -614,7 +614,7 @@ void CS_EnableEntryIDEepromCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableEntryIDEepromCmd_Test_Nominal */
+}
 
 void CS_EnableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
 {
@@ -664,7 +664,7 @@ void CS_EnableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty */
+}
 
 void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 {
@@ -696,7 +696,7 @@ void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh */
+}
 
 void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 {
@@ -730,7 +730,7 @@ void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty */
+}
 
 void CS_EnableEntryIDEepromCmd_Test_VerifyError(void)
 {
@@ -748,7 +748,7 @@ void CS_EnableEntryIDEepromCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableEntryIDEepromCmd_Test_VerifyError */
+}
 
 void CS_EnableEntryIDEepromCmd_Test_OneShot(void)
 {
@@ -767,7 +767,7 @@ void CS_EnableEntryIDEepromCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableEntryIDEepromCmd_Test_OneShot */
+}
 
 void CS_DisableEntryIDEepromCmd_Test_Nominal(void)
 {
@@ -812,7 +812,7 @@ void CS_DisableEntryIDEepromCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableEntryIDEepromCmd_Test_Nominal */
+}
 
 void CS_DisableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
 {
@@ -866,7 +866,7 @@ void CS_DisableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty */
+}
 
 void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 {
@@ -898,7 +898,7 @@ void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh */
+}
 
 void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 {
@@ -932,7 +932,7 @@ void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty */
+}
 
 void CS_DisableEntryIDEepromCmd_Test_VerifyError(void)
 {
@@ -950,7 +950,7 @@ void CS_DisableEntryIDEepromCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableEntryIDEepromCmd_Test_VerifyError */
+}
 
 void CS_DisableEntryIDEepromCmd_Test_OneShot(void)
 {
@@ -969,7 +969,7 @@ void CS_DisableEntryIDEepromCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableEntryIDEepromCmd_Test_OneShot */
+}
 
 void CS_GetEntryIDEepromCmd_Test_Nominal(void)
 {
@@ -1005,7 +1005,7 @@ void CS_GetEntryIDEepromCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_GetEntryIDEepromCmd_Test_Nominal */
+}
 
 void CS_GetEntryIDEepromCmd_Test_AddressNotFound(void)
 {
@@ -1036,7 +1036,7 @@ void CS_GetEntryIDEepromCmd_Test_AddressNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_GetEntryIDEepromCmd_Test_AddressNotFound */
+}
 
 void CS_GetEntryIDEepromCmd_Test_AddressPtr(void)
 {
@@ -1072,7 +1072,7 @@ void CS_GetEntryIDEepromCmd_Test_AddressPtr(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_GetEntryIDEepromCmd_Test_AddressPtr */
+}
 
 void CS_GetEntryIDEepromCmd_Test_State(void)
 {
@@ -1108,7 +1108,7 @@ void CS_GetEntryIDEepromCmd_Test_State(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_GetEntryIDEepromCmd_Test_State */
+}
 
 void CS_GetEntryIDEepromCmd_Test_VerifyError(void)
 {
@@ -1126,7 +1126,7 @@ void CS_GetEntryIDEepromCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_GetEntryIDEepromCmd_Test_VerifyError */
+}
 
 void UtTest_Setup(void)
 {
@@ -1201,8 +1201,4 @@ void UtTest_Setup(void)
     UtTest_Add(CS_GetEntryIDEepromCmd_Test_State, CS_Test_Setup, CS_Test_TearDown, "CS_GetEntryIDEepromCmd_Test_State");
     UtTest_Add(CS_GetEntryIDEepromCmd_Test_VerifyError, CS_Test_Setup, CS_Test_TearDown,
                "CS_GetEntryIDEepromCmd_Test_VerifyError");
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/cs_init_tests.c
+++ b/unit-test/cs_init_tests.c
@@ -69,7 +69,6 @@ void CS_Init_Test_SBCreatePipeError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_Init_Test_SBCreatePipeError */
 
 void CS_Init_Test_SBSubscribeHKNominal(void)
@@ -86,7 +85,6 @@ void CS_Init_Test_SBSubscribeHKNominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_Init_Test_SBSubscribeHKNominal */
 
 void CS_Init_Test_SBSubscribeHKError(void)
@@ -119,7 +117,6 @@ void CS_Init_Test_SBSubscribeHKError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_Init_Test_SBSubscribeHKError */
 
 void CS_Init_Test_SBSubscribeBackgroundCycleError(void)
@@ -151,7 +148,6 @@ void CS_Init_Test_SBSubscribeBackgroundCycleError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_Init_Test_SBSubscribeBackgroundCycleError */
 
 void CS_Init_Test_SBSubscribeCmdError(void)
@@ -183,7 +179,6 @@ void CS_Init_Test_SBSubscribeCmdError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_Init_Test_SBSubscribeCmdError */
 
 void CS_Init_Test_TableInitNominal(void)
@@ -201,7 +196,6 @@ void CS_Init_Test_TableInitNominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_Init_Test_TableInitNominal */
 
 void CS_Init_Test_TableInitErrorEEPROM(void)
@@ -235,7 +229,6 @@ void CS_Init_Test_TableInitErrorEEPROM(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-
 } /* end CS_Init_Test_TableInitErrorEEPROM */
 
 void CS_Init_Test_TableInitErrorMemory(void)
@@ -274,7 +267,6 @@ void CS_Init_Test_TableInitErrorMemory(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-
 } /* end CS_Init_Test_TableInitErrorMemory */
 
 void CS_Init_Test_TableInitErrorApps(void)
@@ -312,7 +304,6 @@ void CS_Init_Test_TableInitErrorApps(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-
 } /* end CS_Init_Test_TableInitErrorApps */
 
 void CS_Init_Test_TableInitErrorTables(void)
@@ -351,7 +342,6 @@ void CS_Init_Test_TableInitErrorTables(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-
 } /* end CS_Init_Test_TableInitErrorTables */
 
 void CS_Init_Test_CFETextSegmentInfoError(void)
@@ -384,7 +374,6 @@ void CS_Init_Test_CFETextSegmentInfoError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_Init_Test_TextSegmentInfoError */
 
 void CS_Init_Test_KernelTextSegmentInfoError(void)
@@ -417,7 +406,6 @@ void CS_Init_Test_KernelTextSegmentInfoError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_Init_Test_TextSegmentInfoError */
 
 void UtTest_Setup(void)
@@ -437,7 +425,6 @@ void UtTest_Setup(void)
                "CS_Init_Test_CFETextSegmentInfoError");
     UtTest_Add(CS_Init_Test_KernelTextSegmentInfoError, CS_Test_Setup, CS_Test_TearDown,
                "CS_Init_Test_KernelTextSegmentInfoError");
-
 } /* end UtTest_Setup */
 
 /************************/

--- a/unit-test/cs_init_tests.c
+++ b/unit-test/cs_init_tests.c
@@ -69,7 +69,7 @@ void CS_Init_Test_SBCreatePipeError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_Init_Test_SBCreatePipeError */
+}
 
 void CS_Init_Test_SBSubscribeHKNominal(void)
 {
@@ -85,7 +85,7 @@ void CS_Init_Test_SBSubscribeHKNominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_Init_Test_SBSubscribeHKNominal */
+}
 
 void CS_Init_Test_SBSubscribeHKError(void)
 {
@@ -117,7 +117,7 @@ void CS_Init_Test_SBSubscribeHKError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_Init_Test_SBSubscribeHKError */
+}
 
 void CS_Init_Test_SBSubscribeBackgroundCycleError(void)
 {
@@ -148,7 +148,7 @@ void CS_Init_Test_SBSubscribeBackgroundCycleError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_Init_Test_SBSubscribeBackgroundCycleError */
+}
 
 void CS_Init_Test_SBSubscribeCmdError(void)
 {
@@ -179,7 +179,7 @@ void CS_Init_Test_SBSubscribeCmdError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_Init_Test_SBSubscribeCmdError */
+}
 
 void CS_Init_Test_TableInitNominal(void)
 {
@@ -196,7 +196,7 @@ void CS_Init_Test_TableInitNominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_Init_Test_TableInitNominal */
+}
 
 void CS_Init_Test_TableInitErrorEEPROM(void)
 {
@@ -229,7 +229,7 @@ void CS_Init_Test_TableInitErrorEEPROM(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-} /* end CS_Init_Test_TableInitErrorEEPROM */
+}
 
 void CS_Init_Test_TableInitErrorMemory(void)
 {
@@ -267,7 +267,7 @@ void CS_Init_Test_TableInitErrorMemory(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-} /* end CS_Init_Test_TableInitErrorMemory */
+}
 
 void CS_Init_Test_TableInitErrorApps(void)
 {
@@ -304,7 +304,7 @@ void CS_Init_Test_TableInitErrorApps(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-} /* end CS_Init_Test_TableInitErrorApps */
+}
 
 void CS_Init_Test_TableInitErrorTables(void)
 {
@@ -342,7 +342,7 @@ void CS_Init_Test_TableInitErrorTables(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-} /* end CS_Init_Test_TableInitErrorTables */
+}
 
 void CS_Init_Test_CFETextSegmentInfoError(void)
 {
@@ -374,7 +374,7 @@ void CS_Init_Test_CFETextSegmentInfoError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_Init_Test_TextSegmentInfoError */
+}
 
 void CS_Init_Test_KernelTextSegmentInfoError(void)
 {
@@ -406,7 +406,7 @@ void CS_Init_Test_KernelTextSegmentInfoError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_Init_Test_TextSegmentInfoError */
+}
 
 void UtTest_Setup(void)
 {
@@ -425,8 +425,4 @@ void UtTest_Setup(void)
                "CS_Init_Test_CFETextSegmentInfoError");
     UtTest_Add(CS_Init_Test_KernelTextSegmentInfoError, CS_Test_Setup, CS_Test_TearDown,
                "CS_Init_Test_KernelTextSegmentInfoError");
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/cs_memory_cmds_tests.c
+++ b/unit-test/cs_memory_cmds_tests.c
@@ -73,7 +73,7 @@ void CS_DisableMemoryCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableMemoryCmd_Test */
+}
 
 void CS_DisableMemoryCmd_Test_VerifyError(void)
 {
@@ -91,7 +91,7 @@ void CS_DisableMemoryCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableMemoryCmd_Test_VerifyError */
+}
 
 void CS_DisableMemoryCmd_Test_OneShot(void)
 {
@@ -110,7 +110,7 @@ void CS_DisableMemoryCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableMemoryCmd_Test_OneShot */
+}
 
 void CS_EnableMemoryCmd_Test(void)
 {
@@ -142,7 +142,7 @@ void CS_EnableMemoryCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableMemoryCmd_Test */
+}
 
 void CS_EnableMemoryCmd_Test_VerifyError(void)
 {
@@ -160,7 +160,7 @@ void CS_EnableMemoryCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableMemoryCmd_Test_VerifyError */
+}
 
 void CS_EnableMemoryCmd_Test_OneShot(void)
 {
@@ -179,7 +179,7 @@ void CS_EnableMemoryCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableMemoryCmd_Test_OneShot */
+}
 
 void CS_ReportBaselineEntryIDMemoryCmd_Test_Computed(void)
 {
@@ -214,7 +214,7 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_Computed(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineEntryIDMemoryCmd_Test_Computed */
+}
 
 void CS_ReportBaselineEntryIDMemoryCmd_Test_NotYetComputed(void)
 {
@@ -250,7 +250,7 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_NotYetComputed(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineEntryIDMemoryCmd_Test_NotYetComputed */
+}
 
 void CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 {
@@ -282,7 +282,7 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh */
+}
 
 void CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 {
@@ -316,7 +316,7 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty */
+}
 
 void CS_ReportBaselineEntryIDMemoryCmd_Test_VerifyError(void)
 {
@@ -334,7 +334,7 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineEntryIDMemoryCmd_Test_VerifyError */
+}
 
 void CS_RecomputeBaselineMemoryCmd_Test_Nominal(void)
 {
@@ -376,7 +376,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineMemoryCmd_Test_Nominal */
+}
 
 void CS_RecomputeBaselineMemoryCmd_Test_CreateChildTaskError(void)
 {
@@ -421,7 +421,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineMemoryCmd_Test_CreateChildTaskError */
+}
 
 void CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 {
@@ -453,7 +453,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh */
+}
 
 void CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 {
@@ -487,7 +487,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorStateEmpty */
+}
 
 void CS_RecomputeBaselineMemoryCmd_Test_RecomputeInProgress(void)
 {
@@ -521,7 +521,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineMemoryCmd_Test_RecomputeInProgress */
+}
 
 void CS_RecomputeBaselineMemoryCmd_Test_VerifyError(void)
 {
@@ -539,7 +539,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineMemoryCmd_Test_VerifyError */
+}
 
 void CS_RecomputeBaselineMemoryCmd_Test_OneShot(void)
 {
@@ -574,7 +574,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineMemoryCmd_Test_OneShot */
+}
 
 void CS_EnableEntryIDMemoryCmd_Test_Nominal(void)
 {
@@ -614,7 +614,7 @@ void CS_EnableEntryIDMemoryCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableEntryIDMemoryCmd_Test_Nominal */
+}
 
 void CS_EnableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
 {
@@ -664,7 +664,7 @@ void CS_EnableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty */
+}
 
 void CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 {
@@ -696,7 +696,7 @@ void CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh */
+}
 
 void CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 {
@@ -730,7 +730,7 @@ void CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty */
+}
 
 void CS_EnableEntryIDMemoryCmd_Test_VerifyError(void)
 {
@@ -748,7 +748,7 @@ void CS_EnableEntryIDMemoryCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableEntryIDMemoryCmd_Test_VerifyError */
+}
 
 void CS_EnableEntryIDMemoryCmd_Test_OneShot(void)
 {
@@ -767,7 +767,7 @@ void CS_EnableEntryIDMemoryCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableEntryIDMemoryCmd_Test_OneShot */
+}
 
 void CS_DisableEntryIDMemoryCmd_Test_Nominal(void)
 {
@@ -812,7 +812,7 @@ void CS_DisableEntryIDMemoryCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableEntryIDMemoryCmd_Test_Nominal */
+}
 
 void CS_DisableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
 {
@@ -866,7 +866,7 @@ void CS_DisableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty */
+}
 
 void CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 {
@@ -898,7 +898,7 @@ void CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh */
+}
 
 void CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 {
@@ -932,7 +932,7 @@ void CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty */
+}
 
 void CS_DisableEntryIDMemoryCmd_Test_VerifyError(void)
 {
@@ -950,7 +950,7 @@ void CS_DisableEntryIDMemoryCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableEntryIDMemoryCmd_Test_VerifyError */
+}
 
 void CS_DisableEntryIDMemoryCmd_Test_OneShot(void)
 {
@@ -969,7 +969,7 @@ void CS_DisableEntryIDMemoryCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableEntryIDMemoryCmd_Test_OneShot */
+}
 
 void CS_GetEntryIDMemoryCmd_Test_Nominal(void)
 {
@@ -1005,7 +1005,7 @@ void CS_GetEntryIDMemoryCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_GetEntryIDMemoryCmd_Test_Nominal */
+}
 
 void CS_GetEntryIDMemoryCmd_Test_AddressNotFound(void)
 {
@@ -1036,7 +1036,7 @@ void CS_GetEntryIDMemoryCmd_Test_AddressNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_GetEntryIDMemoryCmd_Test_AddressNotFound */
+}
 
 void CS_GetEntryIDMemoryCmd_Test_AddressPtr(void)
 {
@@ -1072,7 +1072,7 @@ void CS_GetEntryIDMemoryCmd_Test_AddressPtr(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_GetEntryIDMemoryCmd_Test_AddressPtr */
+}
 
 void CS_GetEntryIDMemoryCmd_Test_State(void)
 {
@@ -1108,7 +1108,7 @@ void CS_GetEntryIDMemoryCmd_Test_State(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_GetEntryIDMemoryCmd_Test_State */
+}
 
 void CS_GetEntryIDMemoryCmd_Test_VerifyError(void)
 {
@@ -1126,7 +1126,7 @@ void CS_GetEntryIDMemoryCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_GetEntryIDMemoryCmd_Test_VerifyError */
+}
 
 void UtTest_Setup(void)
 {
@@ -1201,8 +1201,4 @@ void UtTest_Setup(void)
     UtTest_Add(CS_GetEntryIDMemoryCmd_Test_State, CS_Test_Setup, CS_Test_TearDown, "CS_GetEntryIDMemoryCmd_Test_State");
     UtTest_Add(CS_GetEntryIDMemoryCmd_Test_VerifyError, CS_Test_Setup, CS_Test_TearDown,
                "CS_GetEntryIDMemoryCmd_Test_VerifyError");
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/cs_memory_cmds_tests.c
+++ b/unit-test/cs_memory_cmds_tests.c
@@ -73,7 +73,6 @@ void CS_DisableMemoryCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableMemoryCmd_Test */
 
 void CS_DisableMemoryCmd_Test_VerifyError(void)
@@ -92,7 +91,6 @@ void CS_DisableMemoryCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableMemoryCmd_Test_VerifyError */
 
 void CS_DisableMemoryCmd_Test_OneShot(void)
@@ -112,7 +110,6 @@ void CS_DisableMemoryCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableMemoryCmd_Test_OneShot */
 
 void CS_EnableMemoryCmd_Test(void)
@@ -145,7 +142,6 @@ void CS_EnableMemoryCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableMemoryCmd_Test */
 
 void CS_EnableMemoryCmd_Test_VerifyError(void)
@@ -164,7 +160,6 @@ void CS_EnableMemoryCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableMemoryCmd_Test_VerifyError */
 
 void CS_EnableMemoryCmd_Test_OneShot(void)
@@ -184,7 +179,6 @@ void CS_EnableMemoryCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableMemoryCmd_Test_OneShot */
 
 void CS_ReportBaselineEntryIDMemoryCmd_Test_Computed(void)
@@ -220,7 +214,6 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_Computed(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineEntryIDMemoryCmd_Test_Computed */
 
 void CS_ReportBaselineEntryIDMemoryCmd_Test_NotYetComputed(void)
@@ -257,7 +250,6 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_NotYetComputed(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineEntryIDMemoryCmd_Test_NotYetComputed */
 
 void CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
@@ -290,7 +282,6 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh */
 
 void CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
@@ -325,7 +316,6 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty */
 
 void CS_ReportBaselineEntryIDMemoryCmd_Test_VerifyError(void)
@@ -344,7 +334,6 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineEntryIDMemoryCmd_Test_VerifyError */
 
 void CS_RecomputeBaselineMemoryCmd_Test_Nominal(void)
@@ -387,7 +376,6 @@ void CS_RecomputeBaselineMemoryCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineMemoryCmd_Test_Nominal */
 
 void CS_RecomputeBaselineMemoryCmd_Test_CreateChildTaskError(void)
@@ -433,7 +421,6 @@ void CS_RecomputeBaselineMemoryCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineMemoryCmd_Test_CreateChildTaskError */
 
 void CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
@@ -466,7 +453,6 @@ void CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh */
 
 void CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
@@ -501,7 +487,6 @@ void CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorStateEmpty */
 
 void CS_RecomputeBaselineMemoryCmd_Test_RecomputeInProgress(void)
@@ -536,7 +521,6 @@ void CS_RecomputeBaselineMemoryCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineMemoryCmd_Test_RecomputeInProgress */
 
 void CS_RecomputeBaselineMemoryCmd_Test_VerifyError(void)
@@ -555,7 +539,6 @@ void CS_RecomputeBaselineMemoryCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineMemoryCmd_Test_VerifyError */
 
 void CS_RecomputeBaselineMemoryCmd_Test_OneShot(void)
@@ -591,7 +574,6 @@ void CS_RecomputeBaselineMemoryCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineMemoryCmd_Test_OneShot */
 
 void CS_EnableEntryIDMemoryCmd_Test_Nominal(void)
@@ -632,7 +614,6 @@ void CS_EnableEntryIDMemoryCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableEntryIDMemoryCmd_Test_Nominal */
 
 void CS_EnableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
@@ -683,7 +664,6 @@ void CS_EnableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty */
 
 void CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
@@ -716,7 +696,6 @@ void CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh */
 
 void CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
@@ -751,7 +730,6 @@ void CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty */
 
 void CS_EnableEntryIDMemoryCmd_Test_VerifyError(void)
@@ -770,7 +748,6 @@ void CS_EnableEntryIDMemoryCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableEntryIDMemoryCmd_Test_VerifyError */
 
 void CS_EnableEntryIDMemoryCmd_Test_OneShot(void)
@@ -790,7 +767,6 @@ void CS_EnableEntryIDMemoryCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableEntryIDMemoryCmd_Test_OneShot */
 
 void CS_DisableEntryIDMemoryCmd_Test_Nominal(void)
@@ -836,7 +812,6 @@ void CS_DisableEntryIDMemoryCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableEntryIDMemoryCmd_Test_Nominal */
 
 void CS_DisableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
@@ -891,7 +866,6 @@ void CS_DisableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty */
 
 void CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
@@ -924,7 +898,6 @@ void CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh */
 
 void CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
@@ -959,7 +932,6 @@ void CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty */
 
 void CS_DisableEntryIDMemoryCmd_Test_VerifyError(void)
@@ -978,7 +950,6 @@ void CS_DisableEntryIDMemoryCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableEntryIDMemoryCmd_Test_VerifyError */
 
 void CS_DisableEntryIDMemoryCmd_Test_OneShot(void)
@@ -998,7 +969,6 @@ void CS_DisableEntryIDMemoryCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableEntryIDMemoryCmd_Test_OneShot */
 
 void CS_GetEntryIDMemoryCmd_Test_Nominal(void)
@@ -1035,7 +1005,6 @@ void CS_GetEntryIDMemoryCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_GetEntryIDMemoryCmd_Test_Nominal */
 
 void CS_GetEntryIDMemoryCmd_Test_AddressNotFound(void)
@@ -1067,7 +1036,6 @@ void CS_GetEntryIDMemoryCmd_Test_AddressNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_GetEntryIDMemoryCmd_Test_AddressNotFound */
 
 void CS_GetEntryIDMemoryCmd_Test_AddressPtr(void)
@@ -1104,7 +1072,6 @@ void CS_GetEntryIDMemoryCmd_Test_AddressPtr(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_GetEntryIDMemoryCmd_Test_AddressPtr */
 
 void CS_GetEntryIDMemoryCmd_Test_State(void)
@@ -1141,7 +1108,6 @@ void CS_GetEntryIDMemoryCmd_Test_State(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_GetEntryIDMemoryCmd_Test_State */
 
 void CS_GetEntryIDMemoryCmd_Test_VerifyError(void)
@@ -1160,7 +1126,6 @@ void CS_GetEntryIDMemoryCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_GetEntryIDMemoryCmd_Test_VerifyError */
 
 void UtTest_Setup(void)
@@ -1236,7 +1201,6 @@ void UtTest_Setup(void)
     UtTest_Add(CS_GetEntryIDMemoryCmd_Test_State, CS_Test_Setup, CS_Test_TearDown, "CS_GetEntryIDMemoryCmd_Test_State");
     UtTest_Add(CS_GetEntryIDMemoryCmd_Test_VerifyError, CS_Test_Setup, CS_Test_TearDown,
                "CS_GetEntryIDMemoryCmd_Test_VerifyError");
-
 } /* end UtTest_Setup */
 
 /************************/

--- a/unit-test/cs_table_cmds_tests.c
+++ b/unit-test/cs_table_cmds_tests.c
@@ -107,7 +107,7 @@ void CS_DisableTablesCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableTablesCmd_Test */
+}
 
 void CS_DisableTablesCmd_Test_VerifyError(void)
 {
@@ -126,7 +126,7 @@ void CS_DisableTablesCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableTablesCmd_Test_VerifyError */
+}
 
 void CS_DisableTablesCmd_Test_OneShot(void)
 {
@@ -145,7 +145,7 @@ void CS_DisableTablesCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableTablesCmd_Test_OneShot */
+}
 
 void CS_EnableTablesCmd_Test(void)
 {
@@ -178,7 +178,7 @@ void CS_EnableTablesCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableTablesCmd_Test */
+}
 
 void CS_EnableTablesCmd_Test_VerifyError(void)
 {
@@ -197,7 +197,7 @@ void CS_EnableTablesCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableTablesCmd_Test_VerifyError */
+}
 
 void CS_EnableTablesCmd_Test_OneShot(void)
 {
@@ -216,7 +216,7 @@ void CS_EnableTablesCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableTablesCmd_Test_OneShot */
+}
 
 void CS_ReportBaselineTablesCmd_Test_Computed(void)
 {
@@ -257,7 +257,7 @@ void CS_ReportBaselineTablesCmd_Test_Computed(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineTablesCmd_Test_Computed */
+}
 
 void CS_ReportBaselineTablesCmd_Test_NotYetComputed(void)
 {
@@ -298,7 +298,7 @@ void CS_ReportBaselineTablesCmd_Test_NotYetComputed(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineTablesCmd_Test_NotYetComputed */
+}
 
 void CS_ReportBaselineTablesCmd_Test_TableNotFound(void)
 {
@@ -333,7 +333,7 @@ void CS_ReportBaselineTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineTablesCmd_Test_TableNotFound */
+}
 
 void CS_ReportBaselineTablesCmd_Test_VerifyError(void)
 {
@@ -351,7 +351,7 @@ void CS_ReportBaselineTablesCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ReportBaselineTablesCmd_Test_VerifyError */
+}
 
 void CS_RecomputeBaselineTablesCmd_Test_Nominal(void)
 {
@@ -394,7 +394,7 @@ void CS_RecomputeBaselineTablesCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineTablesCmd_Test_Nominal */
+}
 
 void CS_RecomputeBaselineTablesCmd_Test_CreateChildTaskError(void)
 {
@@ -442,7 +442,7 @@ void CS_RecomputeBaselineTablesCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineTablesCmd_Test_CreateChildTaskError */
+}
 
 void CS_RecomputeBaselineTablesCmd_Test_TableNotFound(void)
 {
@@ -476,7 +476,7 @@ void CS_RecomputeBaselineTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineTablesCmd_Test_TableNotFound */
+}
 
 void CS_RecomputeBaselineTablesCmd_Test_RecomputeInProgress(void)
 {
@@ -512,7 +512,7 @@ void CS_RecomputeBaselineTablesCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineTablesCmd_Test_RecomputeInProgress */
+}
 
 void CS_RecomputeBaselineTablesCmd_Test_VerifyError(void)
 {
@@ -530,7 +530,7 @@ void CS_RecomputeBaselineTablesCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineTablesCmd_Test_VerifyError */
+}
 
 void CS_RecomputeBaselineTablesCmd_Test_OneShot(void)
 {
@@ -566,7 +566,7 @@ void CS_RecomputeBaselineTablesCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_RecomputeBaselineTablesCmd_Test_OneShot */
+}
 
 void CS_DisableNameTablesCmd_Test_Nominal(void)
 {
@@ -615,7 +615,7 @@ void CS_DisableNameTablesCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableNameTablesCmd_Test_Nominal */
+}
 
 void CS_DisableNameTablesCmd_Test_TableDefNotFound(void)
 {
@@ -670,7 +670,7 @@ void CS_DisableNameTablesCmd_Test_TableDefNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableNameTablesCmd_Test_TableDefNotFound */
+}
 
 void CS_DisableNameTablesCmd_Test_TableNotFound(void)
 {
@@ -705,7 +705,7 @@ void CS_DisableNameTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableNameTablesCmd_Test_TableNotFound */
+}
 
 void CS_DisableNameTablesCmd_Test_VerifyError(void)
 {
@@ -724,7 +724,7 @@ void CS_DisableNameTablesCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableNameTablesCmd_Test_VerifyError */
+}
 
 void CS_DisableNameTablesCmd_Test_OneShot(void)
 {
@@ -743,7 +743,7 @@ void CS_DisableNameTablesCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_DisableNameTablesCmd_Test_OneShot */
+}
 
 void CS_EnableNameTablesCmd_Test_Nominal(void)
 {
@@ -789,7 +789,7 @@ void CS_EnableNameTablesCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableNameTablesCmd_Test_Nominal */
+}
 
 void CS_EnableNameTablesCmd_Test_TableDefNotFound(void)
 {
@@ -841,7 +841,7 @@ void CS_EnableNameTablesCmd_Test_TableDefNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableNameTablesCmd_Test_TableDefNotFound */
+}
 
 void CS_EnableNameTablesCmd_Test_TableNotFound(void)
 {
@@ -876,7 +876,7 @@ void CS_EnableNameTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableNameTablesCmd_Test_TableNotFound */
+}
 
 void CS_EnableNameTablesCmd_Test_VerifyError(void)
 {
@@ -895,7 +895,7 @@ void CS_EnableNameTablesCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableNameTablesCmd_Test_VerifyError */
+}
 
 void CS_EnableNameTablesCmd_Test_OneShot(void)
 {
@@ -914,7 +914,7 @@ void CS_EnableNameTablesCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_EnableNameTablesCmd_Test_OneShot */
+}
 
 void UtTest_Setup(void)
 {
@@ -971,8 +971,4 @@ void UtTest_Setup(void)
                "CS_EnableNameTablesCmd_Test_VerifyError");
     UtTest_Add(CS_EnableNameTablesCmd_Test_OneShot, CS_Test_Setup, CS_Test_TearDown,
                "CS_EnableNameTablesCmd_Test_OneShot");
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/cs_table_cmds_tests.c
+++ b/unit-test/cs_table_cmds_tests.c
@@ -107,7 +107,6 @@ void CS_DisableTablesCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableTablesCmd_Test */
 
 void CS_DisableTablesCmd_Test_VerifyError(void)
@@ -127,7 +126,6 @@ void CS_DisableTablesCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableTablesCmd_Test_VerifyError */
 
 void CS_DisableTablesCmd_Test_OneShot(void)
@@ -147,7 +145,6 @@ void CS_DisableTablesCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableTablesCmd_Test_OneShot */
 
 void CS_EnableTablesCmd_Test(void)
@@ -181,7 +178,6 @@ void CS_EnableTablesCmd_Test(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableTablesCmd_Test */
 
 void CS_EnableTablesCmd_Test_VerifyError(void)
@@ -201,7 +197,6 @@ void CS_EnableTablesCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableTablesCmd_Test_VerifyError */
 
 void CS_EnableTablesCmd_Test_OneShot(void)
@@ -221,7 +216,6 @@ void CS_EnableTablesCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableTablesCmd_Test_OneShot */
 
 void CS_ReportBaselineTablesCmd_Test_Computed(void)
@@ -263,7 +257,6 @@ void CS_ReportBaselineTablesCmd_Test_Computed(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineTablesCmd_Test_Computed */
 
 void CS_ReportBaselineTablesCmd_Test_NotYetComputed(void)
@@ -305,7 +298,6 @@ void CS_ReportBaselineTablesCmd_Test_NotYetComputed(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineTablesCmd_Test_NotYetComputed */
 
 void CS_ReportBaselineTablesCmd_Test_TableNotFound(void)
@@ -341,7 +333,6 @@ void CS_ReportBaselineTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineTablesCmd_Test_TableNotFound */
 
 void CS_ReportBaselineTablesCmd_Test_VerifyError(void)
@@ -360,7 +351,6 @@ void CS_ReportBaselineTablesCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ReportBaselineTablesCmd_Test_VerifyError */
 
 void CS_RecomputeBaselineTablesCmd_Test_Nominal(void)
@@ -404,7 +394,6 @@ void CS_RecomputeBaselineTablesCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineTablesCmd_Test_Nominal */
 
 void CS_RecomputeBaselineTablesCmd_Test_CreateChildTaskError(void)
@@ -453,7 +442,6 @@ void CS_RecomputeBaselineTablesCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineTablesCmd_Test_CreateChildTaskError */
 
 void CS_RecomputeBaselineTablesCmd_Test_TableNotFound(void)
@@ -488,7 +476,6 @@ void CS_RecomputeBaselineTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineTablesCmd_Test_TableNotFound */
 
 void CS_RecomputeBaselineTablesCmd_Test_RecomputeInProgress(void)
@@ -525,7 +512,6 @@ void CS_RecomputeBaselineTablesCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineTablesCmd_Test_RecomputeInProgress */
 
 void CS_RecomputeBaselineTablesCmd_Test_VerifyError(void)
@@ -544,7 +530,6 @@ void CS_RecomputeBaselineTablesCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineTablesCmd_Test_VerifyError */
 
 void CS_RecomputeBaselineTablesCmd_Test_OneShot(void)
@@ -581,7 +566,6 @@ void CS_RecomputeBaselineTablesCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_RecomputeBaselineTablesCmd_Test_OneShot */
 
 void CS_DisableNameTablesCmd_Test_Nominal(void)
@@ -631,7 +615,6 @@ void CS_DisableNameTablesCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableNameTablesCmd_Test_Nominal */
 
 void CS_DisableNameTablesCmd_Test_TableDefNotFound(void)
@@ -687,7 +670,6 @@ void CS_DisableNameTablesCmd_Test_TableDefNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableNameTablesCmd_Test_TableDefNotFound */
 
 void CS_DisableNameTablesCmd_Test_TableNotFound(void)
@@ -723,7 +705,6 @@ void CS_DisableNameTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableNameTablesCmd_Test_TableNotFound */
 
 void CS_DisableNameTablesCmd_Test_VerifyError(void)
@@ -743,7 +724,6 @@ void CS_DisableNameTablesCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableNameTablesCmd_Test_VerifyError */
 
 void CS_DisableNameTablesCmd_Test_OneShot(void)
@@ -763,7 +743,6 @@ void CS_DisableNameTablesCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_DisableNameTablesCmd_Test_OneShot */
 
 void CS_EnableNameTablesCmd_Test_Nominal(void)
@@ -810,7 +789,6 @@ void CS_EnableNameTablesCmd_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableNameTablesCmd_Test_Nominal */
 
 void CS_EnableNameTablesCmd_Test_TableDefNotFound(void)
@@ -863,7 +841,6 @@ void CS_EnableNameTablesCmd_Test_TableDefNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableNameTablesCmd_Test_TableDefNotFound */
 
 void CS_EnableNameTablesCmd_Test_TableNotFound(void)
@@ -899,7 +876,6 @@ void CS_EnableNameTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableNameTablesCmd_Test_TableNotFound */
 
 void CS_EnableNameTablesCmd_Test_VerifyError(void)
@@ -919,7 +895,6 @@ void CS_EnableNameTablesCmd_Test_VerifyError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableNameTablesCmd_Test_VerifyError */
 
 void CS_EnableNameTablesCmd_Test_OneShot(void)
@@ -939,7 +914,6 @@ void CS_EnableNameTablesCmd_Test_OneShot(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_EnableNameTablesCmd_Test_OneShot */
 
 void UtTest_Setup(void)
@@ -997,7 +971,6 @@ void UtTest_Setup(void)
                "CS_EnableNameTablesCmd_Test_VerifyError");
     UtTest_Add(CS_EnableNameTablesCmd_Test_OneShot, CS_Test_Setup, CS_Test_TearDown,
                "CS_EnableNameTablesCmd_Test_OneShot");
-
 } /* end UtTest_Setup */
 
 /************************/

--- a/unit-test/cs_table_processing_tests.c
+++ b/unit-test/cs_table_processing_tests.c
@@ -91,7 +91,7 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateEepromChecksumDefinitionTable_Test_Nominal */
+}
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnabled(void)
 {
@@ -138,7 +138,7 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnab
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnabled */
+}
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisabled(void)
 {
@@ -185,7 +185,7 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisa
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisabled */
+}
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalStateField(void)
 {
@@ -228,7 +228,7 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalStateField(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateEepromChecksumDefinitionTable_Test_IllegalStateField */
+}
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_TableErrorResult(void)
 {
@@ -275,7 +275,7 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_TableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateEepromChecksumDefinitionTable_Test_TableErrorResult */
+}
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 {
@@ -322,7 +322,7 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateEepromChecksumDefinitionTable_Test_UndefTableErrorResult */
+}
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_Nominal(void)
 {
@@ -353,7 +353,7 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateMemoryChecksumDefinitionTable_Test_Nominal */
+}
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnabled(void)
 {
@@ -400,7 +400,7 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnab
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnabled */
+}
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisabled(void)
 {
@@ -447,7 +447,7 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisa
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisabled */
+}
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalStateField(void)
 {
@@ -490,7 +490,7 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalStateField(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalStateField */
+}
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_TableErrorResult(void)
 {
@@ -537,7 +537,7 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_TableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateMemoryChecksumDefinitionTable_Test_TableErrorResult */
+}
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 {
@@ -584,7 +584,7 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateMemoryChecksumDefinitionTable_Test_UndefTableErrorResult */
+}
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_Nominal(void)
 {
@@ -617,7 +617,7 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateTablesChecksumDefinitionTable_Test_Nominal */
+}
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEmpty(void)
 {
@@ -663,7 +663,7 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEmpty */
+}
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEnabled(void)
 {
@@ -712,7 +712,7 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEnabled(voi
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEnabled */
+}
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateDisabled(void)
 {
@@ -761,7 +761,7 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateDisabled(vo
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateDisabled */
+}
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateField(void)
 {
@@ -806,7 +806,7 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateField(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateField */
+}
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateEmptyName(void)
 {
@@ -849,7 +849,7 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateEmptyName(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateEmptyName */
+}
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_TableErrorResult(void)
 {
@@ -899,7 +899,7 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_TableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateTablesChecksumDefinitionTable_Test_TableErrorResult */
+}
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 {
@@ -947,7 +947,7 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateTablesChecksumDefinitionTable_Test_UndefState */
+}
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_CsTableError(void)
 {
@@ -994,7 +994,7 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_CsTableError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateTablesChecksumDefinitionTable_Test_CsTableError */
+}
 
 void CS_ValidateAppChecksumDefinitionTable_Test_Nominal(void)
 {
@@ -1027,7 +1027,7 @@ void CS_ValidateAppChecksumDefinitionTable_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateAppChecksumDefinitionTable_Test_Nominal */
+}
 
 void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEmpty(void)
 {
@@ -1073,7 +1073,7 @@ void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEmpty */
+}
 
 void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEnabled(void)
 {
@@ -1122,7 +1122,7 @@ void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEnabled(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEnabled */
+}
 
 void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateDisabled(void)
 {
@@ -1171,7 +1171,7 @@ void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateDisabled(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateDisabled */
+}
 
 void CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateField(void)
 {
@@ -1216,7 +1216,7 @@ void CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateField(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateField */
+}
 
 void CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateEmptyName(void)
 {
@@ -1259,7 +1259,7 @@ void CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateEmptyName(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateEmptyName */
+}
 
 void CS_ValidateAppChecksumDefinitionTable_Test_TableErrorResult(void)
 {
@@ -1308,7 +1308,7 @@ void CS_ValidateAppChecksumDefinitionTable_Test_TableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateAppChecksumDefinitionTable_Test_TableErrorResult */
+}
 
 void CS_ValidateAppChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 {
@@ -1356,7 +1356,7 @@ void CS_ValidateAppChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateAppChecksumDefinitionTable_Test_UndefTableErrorResult */
+}
 
 void CS_ValidateAppChecksumDefinitionTable_Test_EmptyNameTableResult(void)
 {
@@ -1401,7 +1401,7 @@ void CS_ValidateAppChecksumDefinitionTable_Test_EmptyNameTableResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ValidateAppChecksumDefinitionTable_Test_EmptyNameTableResult */
+}
 
 void CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNominal(void)
 {
@@ -1455,7 +1455,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNominal */
+}
 
 void CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNominal(void)
 {
@@ -1509,7 +1509,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNominal */
+}
 
 void CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNoValidEntries(void)
 {
@@ -1547,7 +1547,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNoValidEntries(voi
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNoValidEntries */
+}
 
 void CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNoValidEntries(void)
 {
@@ -1585,7 +1585,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNoValidEntries(voi
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNoValidEntries */
+}
 
 void CS_ProcessNewTablesDefinitionTable_Test_DefEepromTableHandle(void)
 {
@@ -1637,7 +1637,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefEepromTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewTablesDefinitionTable_Test_DefEepromTableHandle */
+}
 
 void CS_ProcessNewTablesDefinitionTable_Test_DefMemoryTableHandle(void)
 {
@@ -1689,7 +1689,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefMemoryTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewTablesDefinitionTable_Test_DefMemoryTableHandle */
+}
 
 void CS_ProcessNewTablesDefinitionTable_Test_DefTablesTableHandle(void)
 {
@@ -1741,7 +1741,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefTablesTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewTablesDefinitionTable_Test_DefTablesTableHandle */
+}
 
 void CS_ProcessNewTablesDefinitionTable_Test_DefAppTableHandle(void)
 {
@@ -1793,7 +1793,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefAppTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewTablesDefinitionTable_Test_DefAppTableHandle */
+}
 
 void CS_ProcessNewTablesDefinitionTable_Test_ResEepromTableHandle(void)
 {
@@ -1843,7 +1843,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_ResEepromTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewTablesDefinitionTable_Test_ResEepromTableHandle */
+}
 
 void CS_ProcessNewTablesDefinitionTable_Test_ResMemoryTableHandle(void)
 {
@@ -1893,7 +1893,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_ResMemoryTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewTablesDefinitionTable_Test_ResMemoryTableHandle */
+}
 
 void CS_ProcessNewTablesDefinitionTable_Test_ResTablesTableHandle(void)
 {
@@ -1943,7 +1943,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_ResTablesTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewTablesDefinitionTable_Test_ResTablesTableHandle */
+}
 
 void CS_ProcessNewTablesDefinitionTable_Test_ResAppTableHandle(void)
 {
@@ -1993,7 +1993,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_ResAppTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewTablesDefinitionTable_Test_ResAppTableHandle */
+}
 
 void CS_ProcessNewTablesDefinitionTable_Test_StateEmptyNoValidEntries(void)
 {
@@ -2052,7 +2052,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_StateEmptyNoValidEntries(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewTablesDefinitionTable_Test_StateEmptyNoValidEntries */
+}
 
 void CS_ProcessNewTablesDefinitionTable_Test_LimitApplicationNameLength(void)
 {
@@ -2096,7 +2096,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_LimitApplicationNameLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewTablesDefinitionTable_Test_LimitApplicationNameLength */
+}
 
 void CS_ProcessNewTablesDefinitionTable_Test_LimitTableNameLength(void)
 {
@@ -2139,7 +2139,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_LimitTableNameLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewTablesDefinitionTable_Test_LimitTableNameLength */
+}
 
 void CS_ProcessNewTablesDefinitionTable_Test_MaxTableNameLength(void)
 {
@@ -2182,7 +2182,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_MaxTableNameLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewTablesDefinitionTable_Test_MaxTableNameLength */
+}
 
 void CS_ProcessNewAppDefinitionTable_Test_Nominal(void)
 {
@@ -2217,7 +2217,7 @@ void CS_ProcessNewAppDefinitionTable_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewAppDefinitionTable_Test_Nominal */
+}
 
 void CS_ProcessNewAppDefinitionTable_Test_StateEmptyNoValidEntries(void)
 {
@@ -2262,7 +2262,7 @@ void CS_ProcessNewAppDefinitionTable_Test_StateEmptyNoValidEntries(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_ProcessNewAppDefinitionTable_Test_StateEmptyNoValidEntries */
+}
 
 void CS_TableInit_Test_DefaultDefinitionTableLoadErrorEEPROM(void)
 {
@@ -2302,7 +2302,7 @@ void CS_TableInit_Test_DefaultDefinitionTableLoadErrorEEPROM(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_TableInit_Test_DefaultDefinitionTableLoadErrorEEPROM */
+}
 
 void CS_TableInit_Test_DefinitionTableGetAddressErrorEEPROM(void)
 {
@@ -2345,7 +2345,7 @@ void CS_TableInit_Test_DefinitionTableGetAddressErrorEEPROM(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_TableInit_Test_DefinitionTableGetAddressErrorEEPROM */
+}
 
 void CS_TableInit_Test_DefinitionTableGetAddressErrorMemory(void)
 {
@@ -2388,7 +2388,7 @@ void CS_TableInit_Test_DefinitionTableGetAddressErrorMemory(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_TableInit_Test_DefinitionTableGetAddressErrorMemory */
+}
 
 void CS_TableInit_Test_DefinitionTableGetAddressErrorTables(void)
 {
@@ -2431,7 +2431,7 @@ void CS_TableInit_Test_DefinitionTableGetAddressErrorTables(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_TableInit_Test_DefinitionTableGetAddressErrorTables */
+}
 
 void CS_TableInit_Test_DefinitionTableGetAddressErrorApps(void)
 {
@@ -2473,7 +2473,7 @@ void CS_TableInit_Test_DefinitionTableGetAddressErrorApps(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_TableInit_Test_DefinitionTableGetAddressErrorApps */
+}
 
 void CS_TableInit_Test_EepromTableAndNotLoadedFromMemory(void)
 {
@@ -2505,7 +2505,7 @@ void CS_TableInit_Test_EepromTableAndNotLoadedFromMemory(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-} /* end CS_TableInit_Test_EepromTableAndNotLoadedFromMemory */
+}
 
 void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableRegisterError(void)
 {
@@ -2542,7 +2542,7 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableRegisterEr
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableRegisterError */
+}
 
 void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableGetAddressError(void)
 {
@@ -2576,7 +2576,7 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableGetAddress
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableGetAddressError */
+}
 
 void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableRegisterError(void)
 {
@@ -2613,7 +2613,7 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableRegiste
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableRegisterError */
+}
 
 void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableFileLoadError(void)
 {
@@ -2648,7 +2648,7 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableFileLoa
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableFileLoadError */
+}
 
 void CS_TableInit_Test_MemoryTableAndNotLoadedFromMemory(void)
 {
@@ -2680,7 +2680,7 @@ void CS_TableInit_Test_MemoryTableAndNotLoadedFromMemory(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-} /* end CS_TableInit_Test_MemoryTableAndNotLoadedFromMemory */
+}
 
 void CS_TableInit_Test_MemoryTableAndLoadedFromMemory(void)
 {
@@ -2717,7 +2717,7 @@ void CS_TableInit_Test_MemoryTableAndLoadedFromMemory(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_TableInit_Test_MemoryTableAndLoadedFromMemory */
+}
 
 void CS_TableInit_Test_AppTableAndNotLoadedFromMemory(void)
 {
@@ -2748,7 +2748,7 @@ void CS_TableInit_Test_AppTableAndNotLoadedFromMemory(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-} /* end CS_TableInit_Test_AppTableAndNotLoadedFromMemory */
+}
 
 void CS_TableInit_Test_AppTableAndLoadedFromMemory(void)
 {
@@ -2784,7 +2784,7 @@ void CS_TableInit_Test_AppTableAndLoadedFromMemory(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_TableInit_Test_AppTableAndLoadedFromMemory */
+}
 
 void CS_TableInit_Test_TablesTableAndNotLoadedFromMemory(void)
 {
@@ -2816,7 +2816,7 @@ void CS_TableInit_Test_TablesTableAndNotLoadedFromMemory(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-} /* end CS_TableInit_Test_TablesTableAndNotLoadedFromMemory */
+}
 
 void CS_TableInit_Test_TablesTableAndLoadedFromMemory(void)
 {
@@ -2853,7 +2853,7 @@ void CS_TableInit_Test_TablesTableAndLoadedFromMemory(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_TableInit_Test_TablesTableAndLoadedFromMemory */
+}
 
 void CS_TableInit_Test_DefaultAndLoadedFromMemory(void)
 {
@@ -2890,7 +2890,7 @@ void CS_TableInit_Test_DefaultAndLoadedFromMemory(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_TableInit_Test_DefaultAndLoadedFromMemory */
+}
 
 void CS_TableInit_Test_OpenCreateError(void)
 {
@@ -2929,7 +2929,7 @@ void CS_TableInit_Test_OpenCreateError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_TableInit_Test_OpenCreateError */
+}
 
 void CS_HandleTableUpdate_Test_ProcessNewTablesDefinitionTable(void)
 {
@@ -2960,7 +2960,7 @@ void CS_HandleTableUpdate_Test_ProcessNewTablesDefinitionTable(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-} /* end CS_HandleTableUpdate_Test_ProcessNewTablesDefinitionTable */
+}
 
 void CS_HandleTableUpdate_Test_ProcessNewAppDefinitionTable(void)
 {
@@ -2989,7 +2989,7 @@ void CS_HandleTableUpdate_Test_ProcessNewAppDefinitionTable(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-} /* end CS_HandleTableUpdate_Test_ProcessNewAppDefinitionTable */
+}
 
 void CS_HandleTableUpdate_Test_ProcessNewEepromMemoryDefinitionTable(void)
 {
@@ -3018,7 +3018,7 @@ void CS_HandleTableUpdate_Test_ProcessNewEepromMemoryDefinitionTable(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-} /* end CS_HandleTableUpdate_Test_ProcessNewEepromMemoryDefinitionTable */
+}
 
 void CS_HandleTableUpdate_Test_ResultsTableGetAddressErrorEEPROM(void)
 {
@@ -3061,7 +3061,7 @@ void CS_HandleTableUpdate_Test_ResultsTableGetAddressErrorEEPROM(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-} /* end CS_HandleTableUpdate_Test_ResultsTableGetAddressErrorEEPROM */
+}
 
 void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorEEPROM(void)
 {
@@ -3105,7 +3105,7 @@ void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorEEPROM(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-} /* end CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorEEPROM */
+}
 
 void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorMemory(void)
 {
@@ -3149,7 +3149,7 @@ void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorMemory(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-} /* end CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorMemory */
+}
 
 void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorTables(void)
 {
@@ -3193,7 +3193,7 @@ void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorTables(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-} /* end CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorTables */
+}
 
 void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorApps(void)
 {
@@ -3237,7 +3237,7 @@ void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorApps(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-} /* end CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorApp */
+}
 
 void CS_HandleTableUpdate_Test_BadTableHandle(void)
 {
@@ -3268,7 +3268,7 @@ void CS_HandleTableUpdate_Test_BadTableHandle(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-} /* end CS_HandleTableUpdate_Test_BadTableHandle */
+}
 
 void CS_HandleTableUpdate_Test_CsOwner(void)
 {
@@ -3299,7 +3299,7 @@ void CS_HandleTableUpdate_Test_CsOwner(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-} /* end CS_HandleTableUpdate_Test_CsOwner */
+}
 
 void CS_HandleTableUpdate_Test_GetAddressError(void)
 {
@@ -3327,7 +3327,7 @@ void CS_HandleTableUpdate_Test_GetAddressError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-} /* end CS_HandleTableUpdate_Test_GetAddressError */
+}
 
 void UtTest_Setup(void)
 {
@@ -3491,8 +3491,4 @@ void UtTest_Setup(void)
     UtTest_Add(CS_HandleTableUpdate_Test_CsOwner, CS_Test_Setup, CS_Test_TearDown, "CS_HandleTableUpdate_Test_CsOwner");
     UtTest_Add(CS_HandleTableUpdate_Test_GetAddressError, CS_Test_Setup, CS_Test_TearDown,
                "CS_HandleTableUpdate_Test_GetAddressError");
-} /* end UtTest_Setup */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/cs_table_processing_tests.c
+++ b/unit-test/cs_table_processing_tests.c
@@ -91,7 +91,6 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateEepromChecksumDefinitionTable_Test_Nominal */
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnabled(void)
@@ -139,7 +138,6 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnab
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnabled */
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisabled(void)
@@ -187,7 +185,6 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisa
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisabled */
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalStateField(void)
@@ -231,7 +228,6 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalStateField(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateEepromChecksumDefinitionTable_Test_IllegalStateField */
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_TableErrorResult(void)
@@ -279,7 +275,6 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_TableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateEepromChecksumDefinitionTable_Test_TableErrorResult */
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_UndefTableErrorResult(void)
@@ -327,7 +322,6 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateEepromChecksumDefinitionTable_Test_UndefTableErrorResult */
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_Nominal(void)
@@ -359,7 +353,6 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateMemoryChecksumDefinitionTable_Test_Nominal */
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnabled(void)
@@ -407,7 +400,6 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnab
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnabled */
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisabled(void)
@@ -455,7 +447,6 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisa
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisabled */
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalStateField(void)
@@ -499,7 +490,6 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalStateField(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalStateField */
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_TableErrorResult(void)
@@ -547,7 +537,6 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_TableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateMemoryChecksumDefinitionTable_Test_TableErrorResult */
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_UndefTableErrorResult(void)
@@ -595,7 +584,6 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateMemoryChecksumDefinitionTable_Test_UndefTableErrorResult */
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_Nominal(void)
@@ -629,7 +617,6 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateTablesChecksumDefinitionTable_Test_Nominal */
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEmpty(void)
@@ -676,7 +663,6 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEmpty */
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEnabled(void)
@@ -726,7 +712,6 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEnabled(voi
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEnabled */
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateDisabled(void)
@@ -776,7 +761,6 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateDisabled(vo
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateDisabled */
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateField(void)
@@ -822,7 +806,6 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateField(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateField */
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateEmptyName(void)
@@ -866,7 +849,6 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateEmptyName(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateEmptyName */
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_TableErrorResult(void)
@@ -917,7 +899,6 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_TableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateTablesChecksumDefinitionTable_Test_TableErrorResult */
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_UndefTableErrorResult(void)
@@ -966,7 +947,6 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateTablesChecksumDefinitionTable_Test_UndefState */
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_CsTableError(void)
@@ -1014,7 +994,6 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_CsTableError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateTablesChecksumDefinitionTable_Test_CsTableError */
 
 void CS_ValidateAppChecksumDefinitionTable_Test_Nominal(void)
@@ -1048,7 +1027,6 @@ void CS_ValidateAppChecksumDefinitionTable_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateAppChecksumDefinitionTable_Test_Nominal */
 
 void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEmpty(void)
@@ -1095,7 +1073,6 @@ void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEmpty(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEmpty */
 
 void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEnabled(void)
@@ -1145,7 +1122,6 @@ void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEnabled(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEnabled */
 
 void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateDisabled(void)
@@ -1195,7 +1171,6 @@ void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateDisabled(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateDisabled */
 
 void CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateField(void)
@@ -1241,7 +1216,6 @@ void CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateField(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateField */
 
 void CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateEmptyName(void)
@@ -1285,7 +1259,6 @@ void CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateEmptyName(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateEmptyName */
 
 void CS_ValidateAppChecksumDefinitionTable_Test_TableErrorResult(void)
@@ -1335,7 +1308,6 @@ void CS_ValidateAppChecksumDefinitionTable_Test_TableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateAppChecksumDefinitionTable_Test_TableErrorResult */
 
 void CS_ValidateAppChecksumDefinitionTable_Test_UndefTableErrorResult(void)
@@ -1384,7 +1356,6 @@ void CS_ValidateAppChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateAppChecksumDefinitionTable_Test_UndefTableErrorResult */
 
 void CS_ValidateAppChecksumDefinitionTable_Test_EmptyNameTableResult(void)
@@ -1430,7 +1401,6 @@ void CS_ValidateAppChecksumDefinitionTable_Test_EmptyNameTableResult(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 2, "CFE_EVS_SendEvent was called %u time(s), expected 2",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ValidateAppChecksumDefinitionTable_Test_EmptyNameTableResult */
 
 void CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNominal(void)
@@ -1485,7 +1455,6 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNominal */
 
 void CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNominal(void)
@@ -1540,7 +1509,6 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNominal */
 
 void CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNoValidEntries(void)
@@ -1579,7 +1547,6 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNoValidEntries(voi
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNoValidEntries */
 
 void CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNoValidEntries(void)
@@ -1618,7 +1585,6 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNoValidEntries(voi
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNoValidEntries */
 
 void CS_ProcessNewTablesDefinitionTable_Test_DefEepromTableHandle(void)
@@ -1671,7 +1637,6 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefEepromTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewTablesDefinitionTable_Test_DefEepromTableHandle */
 
 void CS_ProcessNewTablesDefinitionTable_Test_DefMemoryTableHandle(void)
@@ -1724,7 +1689,6 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefMemoryTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewTablesDefinitionTable_Test_DefMemoryTableHandle */
 
 void CS_ProcessNewTablesDefinitionTable_Test_DefTablesTableHandle(void)
@@ -1777,7 +1741,6 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefTablesTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewTablesDefinitionTable_Test_DefTablesTableHandle */
 
 void CS_ProcessNewTablesDefinitionTable_Test_DefAppTableHandle(void)
@@ -1830,7 +1793,6 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefAppTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewTablesDefinitionTable_Test_DefAppTableHandle */
 
 void CS_ProcessNewTablesDefinitionTable_Test_ResEepromTableHandle(void)
@@ -1881,7 +1843,6 @@ void CS_ProcessNewTablesDefinitionTable_Test_ResEepromTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewTablesDefinitionTable_Test_ResEepromTableHandle */
 
 void CS_ProcessNewTablesDefinitionTable_Test_ResMemoryTableHandle(void)
@@ -1932,7 +1893,6 @@ void CS_ProcessNewTablesDefinitionTable_Test_ResMemoryTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewTablesDefinitionTable_Test_ResMemoryTableHandle */
 
 void CS_ProcessNewTablesDefinitionTable_Test_ResTablesTableHandle(void)
@@ -1983,7 +1943,6 @@ void CS_ProcessNewTablesDefinitionTable_Test_ResTablesTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewTablesDefinitionTable_Test_ResTablesTableHandle */
 
 void CS_ProcessNewTablesDefinitionTable_Test_ResAppTableHandle(void)
@@ -2034,7 +1993,6 @@ void CS_ProcessNewTablesDefinitionTable_Test_ResAppTableHandle(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewTablesDefinitionTable_Test_ResAppTableHandle */
 
 void CS_ProcessNewTablesDefinitionTable_Test_StateEmptyNoValidEntries(void)
@@ -2094,7 +2052,6 @@ void CS_ProcessNewTablesDefinitionTable_Test_StateEmptyNoValidEntries(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewTablesDefinitionTable_Test_StateEmptyNoValidEntries */
 
 void CS_ProcessNewTablesDefinitionTable_Test_LimitApplicationNameLength(void)
@@ -2139,7 +2096,6 @@ void CS_ProcessNewTablesDefinitionTable_Test_LimitApplicationNameLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewTablesDefinitionTable_Test_LimitApplicationNameLength */
 
 void CS_ProcessNewTablesDefinitionTable_Test_LimitTableNameLength(void)
@@ -2183,7 +2139,6 @@ void CS_ProcessNewTablesDefinitionTable_Test_LimitTableNameLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewTablesDefinitionTable_Test_LimitTableNameLength */
 
 void CS_ProcessNewTablesDefinitionTable_Test_MaxTableNameLength(void)
@@ -2227,7 +2182,6 @@ void CS_ProcessNewTablesDefinitionTable_Test_MaxTableNameLength(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewTablesDefinitionTable_Test_MaxTableNameLength */
 
 void CS_ProcessNewAppDefinitionTable_Test_Nominal(void)
@@ -2263,7 +2217,6 @@ void CS_ProcessNewAppDefinitionTable_Test_Nominal(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewAppDefinitionTable_Test_Nominal */
 
 void CS_ProcessNewAppDefinitionTable_Test_StateEmptyNoValidEntries(void)
@@ -2309,7 +2262,6 @@ void CS_ProcessNewAppDefinitionTable_Test_StateEmptyNoValidEntries(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_ProcessNewAppDefinitionTable_Test_StateEmptyNoValidEntries */
 
 void CS_TableInit_Test_DefaultDefinitionTableLoadErrorEEPROM(void)
@@ -2350,7 +2302,6 @@ void CS_TableInit_Test_DefaultDefinitionTableLoadErrorEEPROM(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_TableInit_Test_DefaultDefinitionTableLoadErrorEEPROM */
 
 void CS_TableInit_Test_DefinitionTableGetAddressErrorEEPROM(void)
@@ -2394,7 +2345,6 @@ void CS_TableInit_Test_DefinitionTableGetAddressErrorEEPROM(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_TableInit_Test_DefinitionTableGetAddressErrorEEPROM */
 
 void CS_TableInit_Test_DefinitionTableGetAddressErrorMemory(void)
@@ -2438,7 +2388,6 @@ void CS_TableInit_Test_DefinitionTableGetAddressErrorMemory(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_TableInit_Test_DefinitionTableGetAddressErrorMemory */
 
 void CS_TableInit_Test_DefinitionTableGetAddressErrorTables(void)
@@ -2482,7 +2431,6 @@ void CS_TableInit_Test_DefinitionTableGetAddressErrorTables(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_TableInit_Test_DefinitionTableGetAddressErrorTables */
 
 void CS_TableInit_Test_DefinitionTableGetAddressErrorApps(void)
@@ -2525,7 +2473,6 @@ void CS_TableInit_Test_DefinitionTableGetAddressErrorApps(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_TableInit_Test_DefinitionTableGetAddressErrorApps */
 
 void CS_TableInit_Test_EepromTableAndNotLoadedFromMemory(void)
@@ -2558,7 +2505,6 @@ void CS_TableInit_Test_EepromTableAndNotLoadedFromMemory(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-
 } /* end CS_TableInit_Test_EepromTableAndNotLoadedFromMemory */
 
 void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableRegisterError(void)
@@ -2596,7 +2542,6 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableRegisterEr
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableRegisterError */
 
 void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableGetAddressError(void)
@@ -2631,7 +2576,6 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableGetAddress
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableGetAddressError */
 
 void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableRegisterError(void)
@@ -2669,7 +2613,6 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableRegiste
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableRegisterError */
 
 void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableFileLoadError(void)
@@ -2705,7 +2648,6 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableFileLoa
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableFileLoadError */
 
 void CS_TableInit_Test_MemoryTableAndNotLoadedFromMemory(void)
@@ -2738,7 +2680,6 @@ void CS_TableInit_Test_MemoryTableAndNotLoadedFromMemory(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-
 } /* end CS_TableInit_Test_MemoryTableAndNotLoadedFromMemory */
 
 void CS_TableInit_Test_MemoryTableAndLoadedFromMemory(void)
@@ -2776,7 +2717,6 @@ void CS_TableInit_Test_MemoryTableAndLoadedFromMemory(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_TableInit_Test_MemoryTableAndLoadedFromMemory */
 
 void CS_TableInit_Test_AppTableAndNotLoadedFromMemory(void)
@@ -2808,7 +2748,6 @@ void CS_TableInit_Test_AppTableAndNotLoadedFromMemory(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-
 } /* end CS_TableInit_Test_AppTableAndNotLoadedFromMemory */
 
 void CS_TableInit_Test_AppTableAndLoadedFromMemory(void)
@@ -2845,7 +2784,6 @@ void CS_TableInit_Test_AppTableAndLoadedFromMemory(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_TableInit_Test_AppTableAndLoadedFromMemory */
 
 void CS_TableInit_Test_TablesTableAndNotLoadedFromMemory(void)
@@ -2878,7 +2816,6 @@ void CS_TableInit_Test_TablesTableAndNotLoadedFromMemory(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-
 } /* end CS_TableInit_Test_TablesTableAndNotLoadedFromMemory */
 
 void CS_TableInit_Test_TablesTableAndLoadedFromMemory(void)
@@ -2916,7 +2853,6 @@ void CS_TableInit_Test_TablesTableAndLoadedFromMemory(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_TableInit_Test_TablesTableAndLoadedFromMemory */
 
 void CS_TableInit_Test_DefaultAndLoadedFromMemory(void)
@@ -2954,7 +2890,6 @@ void CS_TableInit_Test_DefaultAndLoadedFromMemory(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_TableInit_Test_DefaultAndLoadedFromMemory */
 
 void CS_TableInit_Test_OpenCreateError(void)
@@ -2994,7 +2929,6 @@ void CS_TableInit_Test_OpenCreateError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_TableInit_Test_OpenCreateError */
 
 void CS_HandleTableUpdate_Test_ProcessNewTablesDefinitionTable(void)
@@ -3026,7 +2960,6 @@ void CS_HandleTableUpdate_Test_ProcessNewTablesDefinitionTable(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-
 } /* end CS_HandleTableUpdate_Test_ProcessNewTablesDefinitionTable */
 
 void CS_HandleTableUpdate_Test_ProcessNewAppDefinitionTable(void)
@@ -3056,7 +2989,6 @@ void CS_HandleTableUpdate_Test_ProcessNewAppDefinitionTable(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-
 } /* end CS_HandleTableUpdate_Test_ProcessNewAppDefinitionTable */
 
 void CS_HandleTableUpdate_Test_ProcessNewEepromMemoryDefinitionTable(void)
@@ -3086,7 +3018,6 @@ void CS_HandleTableUpdate_Test_ProcessNewEepromMemoryDefinitionTable(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-
 } /* end CS_HandleTableUpdate_Test_ProcessNewEepromMemoryDefinitionTable */
 
 void CS_HandleTableUpdate_Test_ResultsTableGetAddressErrorEEPROM(void)
@@ -3130,7 +3061,6 @@ void CS_HandleTableUpdate_Test_ResultsTableGetAddressErrorEEPROM(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-
 } /* end CS_HandleTableUpdate_Test_ResultsTableGetAddressErrorEEPROM */
 
 void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorEEPROM(void)
@@ -3175,7 +3105,6 @@ void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorEEPROM(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-
 } /* end CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorEEPROM */
 
 void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorMemory(void)
@@ -3220,7 +3149,6 @@ void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorMemory(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-
 } /* end CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorMemory */
 
 void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorTables(void)
@@ -3265,7 +3193,6 @@ void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorTables(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-
 } /* end CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorTables */
 
 void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorApps(void)
@@ -3310,7 +3237,6 @@ void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorApps(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 error message we don't care about in this test */
-
 } /* end CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorApp */
 
 void CS_HandleTableUpdate_Test_BadTableHandle(void)
@@ -3342,7 +3268,6 @@ void CS_HandleTableUpdate_Test_BadTableHandle(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-
 } /* end CS_HandleTableUpdate_Test_BadTableHandle */
 
 void CS_HandleTableUpdate_Test_CsOwner(void)
@@ -3374,7 +3299,6 @@ void CS_HandleTableUpdate_Test_CsOwner(void)
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
                   call_count_CFE_EVS_SendEvent);
     /* Generates 1 event message we don't care about in this test */
-
 } /* end CS_HandleTableUpdate_Test_CsOwner */
 
 void CS_HandleTableUpdate_Test_GetAddressError(void)
@@ -3403,7 +3327,6 @@ void CS_HandleTableUpdate_Test_GetAddressError(void)
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 0, "CFE_EVS_SendEvent was called %u time(s), expected 0",
                   call_count_CFE_EVS_SendEvent);
-
 } /* end CS_HandleTableUpdate_Test_GetAddressError */
 
 void UtTest_Setup(void)
@@ -3568,7 +3491,6 @@ void UtTest_Setup(void)
     UtTest_Add(CS_HandleTableUpdate_Test_CsOwner, CS_Test_Setup, CS_Test_TearDown, "CS_HandleTableUpdate_Test_CsOwner");
     UtTest_Add(CS_HandleTableUpdate_Test_GetAddressError, CS_Test_Setup, CS_Test_TearDown,
                "CS_HandleTableUpdate_Test_GetAddressError");
-
 } /* end UtTest_Setup */
 
 /************************/

--- a/unit-test/cs_utils_tests.c
+++ b/unit-test/cs_utils_tests.c
@@ -194,7 +194,6 @@ void CS_GetAppResTblEntryByName_Test(void)
 
 void CS_GetAppDefTblEntryByName_Test(void)
 {
-
     CS_Def_App_Table_Entry_t *EntryPtr = NULL;
 
     /* Empty name, enabled state */
@@ -333,7 +332,6 @@ void CS_VerifyCmdLength_Test(void)
 
 void CS_BackgroundCfeCore_Test(void)
 {
-
     /* Entirely disabled */
     CS_AppData.HkPacket.CfeCoreCSState = CS_STATE_DISABLED;
     UtAssert_BOOL_FALSE(CS_BackgroundCfeCore());
@@ -582,7 +580,6 @@ void CS_ResetTablesTblResultEntry_Test(void)
 
 void CS_HandleRoutineTableUpdates_Test(void)
 {
-
     uint16 ChildTaskTable[] = {CS_CFECORE, CS_EEPROM_TABLE, CS_MEMORY_TABLE, CS_APP_TABLE, CS_TABLES_TABLE};
     uint16 TblMax           = sizeof(ChildTaskTable) / sizeof(ChildTaskTable[0]);
     uint16 i;
@@ -684,7 +681,6 @@ void CS_AttemptTableReshare_Test(void)
 
 void CS_CheckRecomputeOneShot_Test(void)
 {
-
     /* Set up for false return */
     CS_AppData.HkPacket.RecomputeInProgress = false;
     CS_AppData.HkPacket.OneShotInProgress   = false;

--- a/unit-test/utilities/cs_test_utils.c
+++ b/unit-test/utilities/cs_test_utils.c
@@ -99,13 +99,9 @@ void CS_Test_Setup(void)
     memset(CS_DefaultMemoryResTable, 0, sizeof(CS_DefaultMemoryResTable));
     memset(CS_DefaultTablesResTable, 0, sizeof(CS_DefaultTablesResTable));
     memset(CS_DefaultAppResTable, 0, sizeof(CS_DefaultAppResTable));
-} /* end CS_Test_Setup */
+}
 
 void CS_Test_TearDown(void)
 {
     /* cleanup test environment */
-} /* end CS_Test_TearDown */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/unit-test/utilities/cs_test_utils.c
+++ b/unit-test/utilities/cs_test_utils.c
@@ -99,7 +99,6 @@ void CS_Test_Setup(void)
     memset(CS_DefaultMemoryResTable, 0, sizeof(CS_DefaultMemoryResTable));
     memset(CS_DefaultTablesResTable, 0, sizeof(CS_DefaultTablesResTable));
     memset(CS_DefaultAppResTable, 0, sizeof(CS_DefaultAppResTable));
-
 } /* end CS_Test_Setup */
 
 void CS_Test_TearDown(void)


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #50
Removes redundant and inconsistent comments (e.g. `/* end of function */`, `/* end if */`, function name in function header comments).
There were also a few cases of unnecessary empty lines (e.g. on the last line before the closing brace of a function) and also missing empty lines (e.g. between functions) which were corrected. Some of these empty lines trigger the CI format checks.
I've left the commits separated for now to make life easier for whoever reviews this. I can squash them if/when this is ready for merge.

**Testing performed**
None (comment and whitespace changes only).

**Expected behavior changes**
No impact on behavior.
These updates will reduce clutter and inconsistency in the code, improving readability.

**Contributor Info**
@thnkslprpt 