### PR TITLE
Fix #52, Apply consistent Event ID names to common events

### DIFF
--- a/fsw/inc/cs_events.h
+++ b/fsw/inc/cs_events.h
@@ -54,13 +54,13 @@
 /**
  * \brief CS Reset Counters Command Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  This event message is issued when a reset counters command has been received.
  */
-#define CS_RESET_DBG_EID 3
+#define CS_RESET_INF_EID 3
 
 /**
  * \brief CS Disable Checksumming Command Event ID
@@ -451,7 +451,7 @@
  *  This event message is issued when a software bus message is received
  *  with an invalid command code.
  */
-#define CS_CC1_ERR_EID 34
+#define CS_CC_ERR_EID 34
 
 /**
  * \brief CS App Termination Event ID
@@ -475,7 +475,7 @@
  *  This event message is issued when command message is received with a message
  *  length that doesn't match the expected value.
  */
-#define CS_LEN_ERR_EID 36
+#define CS_CMD_LEN_ERR_EID 36
 
 /**********************************************************************/
 /*EEPROM Commands                                                     */
@@ -1466,7 +1466,7 @@
  *
  *  This event message is issued when CFE_SB_CreatePipe fails for the command pipe
  */
-#define CS_INIT_SB_CREATE_ERR_EID 112
+#define CS_CR_PIPE_ERR_EID 112
 
 /**
  * \brief CS Software Bus Subscribe To Housekeeping Failed Event ID

--- a/fsw/inc/cs_msgdefs.h
+++ b/fsw/inc/cs_msgdefs.h
@@ -54,7 +54,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -77,7 +77,7 @@
  *       the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdCounter will be cleared
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will be cleared
- *       - The #CS_RESET_DBG_EID informational event message will be
+ *       - The #CS_RESET_INF_EID informational event message will be
  *         generated when the command is executed
  *
  *  \par Error Conditions
@@ -86,7 +86,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -128,7 +128,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_ONESHOT_MEMVALIDATE_ERR_EID
  *       - Error specific event message #CS_ONESHOT_CHDTASK_ERR_EID
  *       - Error specific event message #CS_ONESHOT_CREATE_CHDTASK_ERR_EID
@@ -170,7 +170,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_ONESHOT_CANCEL_NO_CHDTASK_ERR_EID
  *       - Error specific event message #CS_ONESHOT_CANCEL_DELETE_CHDTASK_ERR_EID
  *
@@ -204,7 +204,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -236,7 +236,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -268,7 +268,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -300,7 +300,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -334,7 +334,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -369,7 +369,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_CFECORE_CREATE_CHDTASK_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_CFECORE_CHDTASK_ERR_EID
  *
@@ -407,7 +407,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - #CS_HkPacket_Payload_t.OSCSState set to #CS_STATE_ENABLED
  *
  *  \par Criticality
@@ -440,7 +440,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -474,7 +474,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -508,7 +508,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_OS_CREATE_CHDTASK_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_OS_CHDTASK_ERR_EID
  *
@@ -546,7 +546,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -578,7 +578,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -613,7 +613,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_BASELINE_INVALID_ENTRY_EEPROM_ERR_EID
  *
  *  \par Criticality
@@ -653,7 +653,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_INVALID_ENTRY_EEPROM_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_EEPROM_CREATE_CHDTASK_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_EEPROM_CHDTASK_ERR_EID
@@ -693,7 +693,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_ENABLE_EEPROM_INVALID_ENTRY_ERR_EID
  *
  *  \par Criticality
@@ -726,7 +726,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_DISABLE_EEPROM_INVALID_ENTRY_ERR_EID
  *
  *  \par Criticality
@@ -760,7 +760,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_GET_ENTRY_ID_EEPROM_NOT_FOUND_INF_EID
  *
  *  \par Criticality
@@ -791,7 +791,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -823,7 +823,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -858,7 +858,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_BASELINE_INVALID_ENTRY_MEMORY_ERR_EID
  *
  *  \par Criticality
@@ -897,7 +897,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_INVALID_ENTRY_MEMORY_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_MEMORY_CREATE_CHDTASK_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_MEMORY_CHDTASK_ERR_EID
@@ -937,7 +937,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_ENABLE_MEMORY_INVALID_ENTRY_ERR_EID
  *
  *  \par Criticality
@@ -970,7 +970,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_DISABLE_MEMORY_INVALID_ENTRY_ERR_EID
  *
  *  \par Criticality
@@ -1004,7 +1004,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_GET_ENTRY_ID_MEMORY_NOT_FOUND_INF_EID
  *
  *  \par Criticality
@@ -1036,7 +1036,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -1068,7 +1068,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -1103,7 +1103,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_BASELINE_INVALID_NAME_TABLES_ERR_EID
  *
  *  \par Criticality
@@ -1148,7 +1148,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_UNKNOWN_NAME_TABLES_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_TABLES_CREATE_CHDTASK_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_TABLES_CHDTASK_ERR_EID
@@ -1188,7 +1188,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_ENABLE_TABLES_UNKNOWN_NAME_ERR_EID
  *
  *  \par Criticality
@@ -1254,7 +1254,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -1286,7 +1286,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
  *       None
@@ -1321,7 +1321,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_BASELINE_INVALID_NAME_APP_ERR_EID
  *
  *  \par Criticality
@@ -1360,7 +1360,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_UNKNOWN_NAME_APP_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_APP_CREATE_CHDTASK_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_APP_CHDTASK_ERR_EID
@@ -1400,7 +1400,7 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_LEN_ERR_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_ENABLE_APP_UNKNOWN_NAME_ERR_EID
  *
  *  \par Criticality

--- a/fsw/src/cs_app.c
+++ b/fsw/src/cs_app.c
@@ -561,7 +561,7 @@ void CS_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
             break;
 
         default:
-            CFE_EVS_SendEvent(CS_CC1_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CS_CC_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Invalid ground command code: ID = 0x%08lX, CC = %d",
                               (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode);
 
@@ -591,7 +591,7 @@ void CS_HousekeepingCmd(const CS_NoArgsCmd_t *CmdPtr)
         CFE_MSG_GetMsgId(CFE_MSG_PTR(CmdPtr->CommandHeader), &MessageID);
         CFE_MSG_GetFcnCode(CFE_MSG_PTR(CmdPtr->CommandHeader), &CommandCode);
 
-        CFE_EVS_SendEvent(CS_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CS_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Invalid msg length: ID = 0x%08lX, CC = %d, Len = %lu, Expected = %lu",
                           (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode, (unsigned long)ActualLength,
                           (unsigned long)ExpectedLength);

--- a/fsw/src/cs_cmds.c
+++ b/fsw/src/cs_cmds.c
@@ -72,7 +72,7 @@ void CS_ResetCmd(const CS_NoArgsCmd_t *CmdPtr)
     CS_AppData.HkPacket.Payload.OSCSErrCounter      = 0;
     CS_AppData.HkPacket.Payload.PassCounter         = 0;
 
-    CFE_EVS_SendEvent(CS_RESET_DBG_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command recieved");
+    CFE_EVS_SendEvent(CS_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command recieved");
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -98,7 +98,7 @@ void CS_BackgroundCheckCycle(const CS_NoArgsCmd_t *CmdPtr)
         CFE_MSG_GetMsgId(CFE_MSG_PTR(CmdPtr->CommandHeader), &MessageID);
         CFE_MSG_GetFcnCode(CFE_MSG_PTR(CmdPtr->CommandHeader), &CommandCode);
 
-        CFE_EVS_SendEvent(CS_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CS_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Invalid msg length: ID = 0x%08lX, CC = %d, Len = %lu, Expected = %lu",
                           (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode, (unsigned long)ActualLength,
                           (unsigned long)ExpectedLength);

--- a/fsw/src/cs_init.c
+++ b/fsw/src/cs_init.c
@@ -54,7 +54,7 @@ CFE_Status_t CS_SbInit(void)
     Result = CFE_SB_CreatePipe(&CS_AppData.CmdPipe, CS_AppData.PipeDepth, CS_AppData.PipeName);
     if (Result != CFE_SUCCESS)
     {
-        CFE_EVS_SendEvent(CS_INIT_SB_CREATE_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CS_CR_PIPE_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Software Bus Create Pipe for command returned: 0x%08X", (unsigned int)Result);
     }
     else

--- a/fsw/src/cs_utils.c
+++ b/fsw/src/cs_utils.c
@@ -459,7 +459,7 @@ bool CS_VerifyCmdLength(const CFE_MSG_Message_t *msg, size_t ExpectedLength)
         CFE_MSG_GetMsgId(msg, &MessageID);
         CFE_MSG_GetFcnCode(msg, &CommandCode);
 
-        CFE_EVS_SendEvent(CS_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CS_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Invalid msg length: ID = 0x%08lX, CC = %d, Len = %lu, Expected = %lu",
                           (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode, (unsigned long)ActualLength,
                           (unsigned long)ExpectedLength);

--- a/fsw/src/cs_utils.h
+++ b/fsw/src/cs_utils.h
@@ -355,7 +355,7 @@ bool CS_FindEnabledAppEntry(uint16 *EnabledEntry);
  *  \retval true  Message length matches ExpectedLength
  *  \retval false Message length ExpectedLength mismatch
  *
- *  \sa #CS_LEN_ERR_EID
+ *  \sa #CS_CMD_LEN_ERR_EID
  */
 bool CS_VerifyCmdLength(const CFE_MSG_Message_t *msg, size_t ExpectedLength);
 

--- a/unit-test/cs_app_tests.c
+++ b/unit-test/cs_app_tests.c
@@ -2117,7 +2117,7 @@ void CS_AppPipe_Test_InvalidCCError(void)
     /* Verify results */
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_CC1_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_CC_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -2275,7 +2275,7 @@ void CS_HousekeepingCmd_Test_InvalidMsgLength(void)
 
     /* Verify results */
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_CMD_LEN_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);

--- a/unit-test/cs_cmds_tests.c
+++ b/unit-test/cs_cmds_tests.c
@@ -113,7 +113,7 @@ void CS_ResetCmd_Test(void)
     UtAssert_True(CS_AppData.HkPacket.Payload.OSCSErrCounter == 0, "CS_AppData.HkPacket.Payload.OSCSErrCounter == 0");
     UtAssert_True(CS_AppData.HkPacket.Payload.PassCounter == 0, "CS_AppData.HkPacket.Payload.PassCounter == 0");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RESET_DBG_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RESET_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -158,7 +158,7 @@ void CS_BackgroundCheckCycle_Test_InvalidMsgLength(void)
     CS_BackgroundCheckCycle(&CmdPacket);
 
     /* Verify results */
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_CMD_LEN_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);

--- a/unit-test/cs_init_tests.c
+++ b/unit-test/cs_init_tests.c
@@ -48,7 +48,7 @@ void CS_Init_Test_SBCreatePipeError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Software Bus Create Pipe for command returned: 0x%%08X");
 
-    /* Set to generate error message CS_INIT_SB_CREATE_ERR_EID */
+    /* Set to generate error message CS_CR_PIPE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_CreatePipe), 1, -1);
 
     /* Execute the function being tested */
@@ -58,7 +58,7 @@ void CS_Init_Test_SBCreatePipeError(void)
 
     UtAssert_True(Result == -1, "Result == -1");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_INIT_SB_CREATE_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_CR_PIPE_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -242,7 +242,7 @@ void CS_Init_Test_TableInitErrorMemory(void)
 
     /* Set to prevent unintended error messages */
 
-    /* Set to generate error message CS_INIT_SB_CREATE_ERR_EID.
+    /* Set to generate error message CS_CR_PIPE_ERR_EID.
      * Combining a SetReturnCode and a SetFunctionHook in order to return CFE_SUCCESS all runs except the one specified
      */
 

--- a/unit-test/cs_utils_tests.c
+++ b/unit-test/cs_utils_tests.c
@@ -327,7 +327,7 @@ void CS_VerifyCmdLength_Test(void)
     UtAssert_BOOL_FALSE(CS_VerifyCmdLength((CFE_MSG_Message_t *)(&CmdPacket), MsgSize - 1));
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_LEN_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_CMD_LEN_ERR_EID);
 }
 
 void CS_BackgroundCfeCore_Test(void)


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #52
  - Consistent event IDs have been applied to the inconsistent cases to align them with a common Event ID naming convention.

**Testing performed**
Only GitHub CI actions.

**Expected behavior changes**
No impact on code behavior (no logic changes).
Consistent Event ID names for the events which are common to all/most cFS components and apps will improve consistency and ease make code review/debugging easier.

**Contributor Info**
Avi Weiss @thnkslprpt