### PR TITLE
Fix #44, Update function key in CS_RecomputeAppChildTask_Test_DefEntryId

### DIFF
--- a/unit-test/cs_compute_tests.c
+++ b/unit-test/cs_compute_tests.c
@@ -1536,7 +1536,7 @@ void CS_RecomputeAppChildTask_Test_DefEntryId(void)
 
     /* Sets AppInfo.CodeSize = 5, sets AppInfo.CodeAddress = 1, AppInfo.AddressesAreValid = true, and returns
      * CFE_SUCCESS */
-    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetAppInfo), CS_COMPUTE_TEST_CFE_ES_GetModuleInfoHandler1, NULL);
+    UT_SetHandlerFunction(UT_KEY(CFE_ES_GetModuleInfo), CS_COMPUTE_TEST_CFE_ES_GetModuleInfoHandler1, NULL);
 
     /* Execute the function being tested */
     CS_RecomputeAppChildTask();


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #44 
`CS_COMPUTE_TEST_CFE_ES_GetModuleInfoHandler1` handler function key updated from `CFE_ES_GetAppInfo` to `CFE_ES_GetModuleInfo`.

Tests back to 100% passing and full coverage:
```
  lines......: 100.0% (2241 of 2241 lines)
  functions..: 100.0% (98 of 98 functions)
  branches...: 100.0% (927 of 927 branches)
```

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
Tests should pass at 100%

**Contributor Info**
Avi Weiss @thnkslprpt