### PR TITLE
Fix #67, Combine consecutive, mutually-exclusive status checks

### DIFF
--- a/fsw/inc/cs_events.h
+++ b/fsw/inc/cs_events.h
@@ -19,7 +19,7 @@
 
 /**
  * @file
- *   Specification for the CFS Checksum event identifers.
+ *   Specification for the CFS Checksum event identifiers.
  */
 #ifndef CS_EVENTS_H
 #define CS_EVENTS_H
@@ -489,7 +489,7 @@
  *  \par Cause:
  *
  *  This event message is issued when disable checksumming
- *  for the Eeprom table command has been received.
+ *  for the EEPROM table command has been received.
  */
 #define CS_DISABLE_EEPROM_INF_EID 37
 
@@ -501,7 +501,7 @@
  *  \par Cause:
  *
  *  This event message is issued when enable checksumming
- *  for the Eeprom table command has been received.
+ *  for the EEPROM table command has been received.
  */
 #define CS_ENABLE_EEPROM_INF_EID 38
 
@@ -513,7 +513,7 @@
  *  \par Cause:
  *
  *  This event message is issued when a report baseline
- *  for the Eeprom entry specifiedcommand has been received
+ *  for the EEPROM entry specifiedcommand has been received
  *  and there is a baseline computed to report.
  */
 #define CS_BASELINE_EEPROM_INF_EID 39
@@ -552,7 +552,7 @@
  *  \par Cause:
  *
  *  This event message is issued when a recompute baseline
- *  for the specified Eeprom Entry ID command has been received and the
+ *  for the specified EEPROM Entry ID command has been received and the
  *  recompute task has been started.
  */
 #define CS_RECOMPUTE_EEPROM_STARTED_DBG_EID 42
@@ -565,7 +565,7 @@
  *  \par Cause:
  *
  *  This event message is issued when a recompute baseline
- *  for the specified Eeprom Entry ID command has been
+ *  for the specified EEPROM Entry ID command has been
  *  received and the recompute failed because
  *  CFE_ES_CreateChildTask returned an error.
  */
@@ -605,7 +605,7 @@
  *
  *  \par Cause:invalid
  *
- *  This event message is issued when an enable Eeprom Entry ID
+ *  This event message is issued when an enable EEPROM Entry ID
  *  command is accepted.
  */
 #define CS_ENABLE_EEPROM_ENTRY_INF_EID 46
@@ -617,7 +617,7 @@
  *
  *  \par Cause:
  *
- *  This event message is issued when an enable Eeprom Entry ID
+ *  This event message is issued when an enable EEPROM Entry ID
  *  command is received, but has an invalid Entry ID.
  */
 #define CS_ENABLE_EEPROM_INVALID_ENTRY_ERR_EID 47
@@ -629,7 +629,7 @@
  *
  *  \par Cause:
  *
- *  This event message is issued when a disable Eeprom Entry ID
+ *  This event message is issued when a disable EEPROM Entry ID
  *  command is accepted.
  */
 #define CS_DISABLE_EEPROM_ENTRY_INF_EID 48
@@ -641,7 +641,7 @@
  *
  *  \par Cause:
  *
- *  This event message is issued when a disable Eeprom Entry ID
+ *  This event message is issued when a disable EEPROM Entry ID
  *  command is received, but has an invalid Entry ID.
  */
 #define CS_DISABLE_EEPROM_INVALID_ENTRY_ERR_EID 49
@@ -653,9 +653,9 @@
  *
  *  \par Cause:
  *
- *  This event message is issued when a Get Entry ID Eeprom
+ *  This event message is issued when a Get Entry ID EEPROM
  *  command is received and the command specified address
- *  is found in the Eeprom table.
+ *  is found in the EEPROM table.
  *
  *  Note that more than one of these event messages can
  *  be sent per command (if the address is in several
@@ -671,8 +671,8 @@
  *  \par Cause:
  *
  *  This event message is issued when the command specified
- *  address in a Get Entry ID Eeprom command cannot be found
- *  in the Eeprom table.
+ *  address in a Get Entry ID EEPROM command cannot be found
+ *  in the EEPROM table.
  */
 #define CS_GET_ENTRY_ID_EEPROM_NOT_FOUND_INF_EID 51
 
@@ -1043,7 +1043,7 @@
  *
  *  \par Cause:
  *
- *  This event message is issued when a disable able name
+ *  This event message is issued when a disable name
  *  command is received, but has an unknown name
  *  or is marked as #CS_STATE_EMPTY.
  */
@@ -1244,7 +1244,7 @@
  *
  *  \par Cause:
  *
- *  This event message is issued when an table cannot be found when checksumming.
+ *  This event message is issued when a table cannot be found when checksumming.
  */
 
 #define CS_COMPUTE_TABLES_NOT_FOUND_ERR_EID 94
@@ -1256,8 +1256,8 @@
  *
  *  \par Cause:
  *
- *  This event message is issued when a recompute entry for Eeprom or Memory
- *  has finished succesessfully.
+ *  This event message is issued when a recompute entry for EEPROM or Memory
+ *  has finished successfully.
  */
 #define CS_RECOMPUTE_FINISH_EEPROM_MEMORY_INF_EID 95
 
@@ -1293,7 +1293,7 @@
  *  \par Cause:
  *
  *  This event message is issued when a recompute entry for a Table
- *  has finished succesessfully.
+ *  has finished successfully.
  *
  *  For the CS Table Definitions Table only, the checksum
  *  value will be incorrect. This is because all entries in this
@@ -1312,7 +1312,7 @@
  *  \par Cause:
  *
  *  This event message is issued when a recompute entry for an app
- *  has finished succesessfully.
+ *  has finished successfully.
  */
 #define CS_RECOMPUTE_FINISH_APP_INF_EID 99
 
@@ -1338,7 +1338,7 @@
  *
  *  \par Cause:
  *
- *  This event message is issued when the Eeprom table validation function detects an illegal state
+ *  This event message is issued when the EEPROM table validation function detects an illegal state
  */
 #define CS_VAL_EEPROM_STATE_ERR_EID 101
 
@@ -1349,7 +1349,7 @@
  *
  *  \par Cause:
  *
- *  This event message is issued when the Eeprom table validation function detects an illegal checksum range
+ *  This event message is issued when the EEPROM table validation function detects an illegal checksum range
  */
 #define CS_VAL_EEPROM_RANGE_ERR_EID 102
 
@@ -1481,7 +1481,7 @@
 #define CS_INIT_SB_SUBSCRIBE_HK_ERR_EID 113
 
 /**
- * \brief CS Software Bus Subscribe To Backtround Cycle Failed Event ID
+ * \brief CS Software Bus Subscribe To Background Cycle Failed Event ID
  *
  *  \par Type: ERROR
  *
@@ -1694,7 +1694,7 @@
 #define CS_ENABLE_APP_DEF_NOT_FOUND_DBG_EID 131
 
 /**
- * \brief CS App Disable Checksum Unable To Find Entry In Defintion Table Event ID
+ * \brief CS App Disable Checksum Unable To Find Entry In Definition Table Event ID
  *
  *  \par Type: DEBUG
  *
@@ -1740,7 +1740,7 @@
  *  \par Cause:
  *
  *  This event message is issued when CS successfully disables an entry (specified
- *  by name) in the Eeprom results table but identifies the corresponding entry in
+ *  by name) in the EEPROM results table but identifies the corresponding entry in
  *  the definitions table to be set to #CS_STATE_EMPTY.
  */
 #define CS_DISABLE_EEPROM_DEF_EMPTY_DBG_EID 135
@@ -1753,7 +1753,7 @@
  *  \par Cause:
  *
  *  This event message is issued when CS successfully enables an entry (specified
- *  by name) in the Eeprom results table but identifies the corresponding entry in
+ *  by name) in the EEPROM results table but identifies the corresponding entry in
  *  the definitions table to be set to #CS_STATE_EMPTY.
  */
 #define CS_ENABLE_EEPROM_DEF_EMPTY_DBG_EID 136
@@ -1853,13 +1853,13 @@
 #define CS_VAL_MEMORY_INF_EID 143
 
 /**
- * \brief CS Eeprom Table Verification Results Event ID
+ * \brief CS EEPROM Table Verification Results Event ID
  *
  *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
- *  This event message when CS completes validation of the Eeprom definition table.  This message
+ *  This event message when CS completes validation of the EEPROM definition table.  This message
  *  reports the number of successful (#CS_STATE_ENABLED or #CS_STATE_DISABLED) entries, the number of
  *  bad entries (due to invalid state definitions or bad range), and the number of entries
  *  marked as #CS_STATE_EMPTY.

--- a/fsw/inc/cs_mission_cfg.h
+++ b/fsw/inc/cs_mission_cfg.h
@@ -41,7 +41,7 @@
  *
  *  \par Limits:
  *         This parameter is limited to either #CFE_MISSION_ES_DEFAULT_CRC,
- *         or  #CFE_MISSION_ES_CRC_16
+ *         or  #CFE_ES_CrcType_CRC_16
  */
 #define CS_DEFAULT_ALGORITHM CFE_MISSION_ES_DEFAULT_CRC
 

--- a/fsw/inc/cs_msg.h
+++ b/fsw/inc/cs_msg.h
@@ -42,7 +42,7 @@ typedef struct
     uint8   CmdCounter;                  /**< \brief CS Application Command Counter */
     uint8   CmdErrCounter;               /**< \brief CS Application Command Error Counter */
     uint8   ChecksumState;               /**< \brief CS Application global checksum state */
-    uint8   EepromCSState;               /**< \brief CS Eeprom table checksum state */
+    uint8   EepromCSState;               /**< \brief CS EEPROM table checksum state */
     uint8   MemoryCSState;               /**< \brief CS Memory table checksum state */
     uint8   AppCSState;                  /**< \brief CS App table checksum state */
     uint8   TablesCSState;               /**< \brief CS Tables table checksum state */
@@ -51,7 +51,7 @@ typedef struct
     uint8   RecomputeInProgress;         /**< \brief CS "Recompute In Progress" flag */
     uint8   OneShotInProgress;           /**< \brief CS "OneShot In Progress" flag */
     uint8   Filler8;                     /**< \brief 8 bit padding */
-    uint16  EepromCSErrCounter;          /**< \brief Eeprom miscompare counter */
+    uint16  EepromCSErrCounter;          /**< \brief EEPROM miscompare counter */
     uint16  MemoryCSErrCounter;          /**< \brief Memory miscompare counter */
     uint16  AppCSErrCounter;             /**< \brief App miscompare counter */
     uint16  TablesCSErrCounter;          /**< \brief Tables miscompare counter */
@@ -59,7 +59,7 @@ typedef struct
     uint16  OSCSErrCounter;              /**< \brief OS code segment miscopmare counter */
     uint16  CurrentCSTable;              /**< \brief Current table being checksummed */
     uint16  CurrentEntryInTable;         /**< \brief Current entry ID in table being checksummed */
-    uint32  EepromBaseline;              /**< \brief Baseline checksum for all of Eeprom */
+    uint32  EepromBaseline;              /**< \brief Baseline checksum for all of EEPROM */
     uint32  OSBaseline;                  /**< \brief Baseline checksum for the OS code segment */
     uint32  CfeCoreBaseline;             /**< \brief Basline checksum for the cFE core */
     cpuaddr LastOneShotAddress;          /**< \brief Address used in last one shot checksum command */
@@ -102,7 +102,7 @@ typedef struct
 } CS_GetEntryIDCmd_t;
 
 /**
- * \brief Command type for commands using Memory or Eeprom tables
+ * \brief Command type for commands using Memory or EEPROM tables
  *
  *  For command details see #CS_ENABLE_ENTRY_EEPROM_CC, #CS_DISABLE_ENTRY_EEPROM_CC,
  * #CS_ENABLE_ENTRY_MEMORY_CC, #CS_DISABLE_ENTRY_MEMORY_CC

--- a/fsw/inc/cs_msgdefs.h
+++ b/fsw/inc/cs_msgdefs.h
@@ -524,10 +524,10 @@
 #define CS_RECOMPUTE_BASELINE_OS_CC 13
 
 /**
- * \brief Enable checksumming for Eeprom table
+ * \brief Enable checksumming for EEPROM table
  *
  *  \par Description
- *       Allow the Eeprom table to checksummed in the background
+ *       Allow the EEPROM table to checksummed in the background
  *
  *  \par Command Structure
  *       #CS_NoArgsCmd_t
@@ -556,10 +556,10 @@
 #define CS_ENABLE_EEPROM_CC 14
 
 /**
- * \brief Disable checksumming for Eeprom table
+ * \brief Disable checksumming for EEPROM table
  *
  *  \par Description
- *       Disable the Eeprom table background checksumming
+ *       Disable the EEPROM table background checksumming
  *
  *  \par Command Structure
  *       #CS_NoArgsCmd_t
@@ -588,10 +588,10 @@
 #define CS_DISABLE_EEPROM_CC 15
 
 /**
- * \brief Report Baseline checksum of Eeprom Entry
+ * \brief Report Baseline checksum of EEPROM Entry
  *
  *  \par Description
- *       Reports the baseline checksum of the Eeprom
+ *       Reports the baseline checksum of the EEPROM
  *       table entry that has already been calculated.
  *
  *  \par Command Structure
@@ -623,10 +623,10 @@
 #define CS_REPORT_BASELINE_EEPROM_CC 16
 
 /**
- * \brief Recompute Baseline checksum of Eeprom Entry
+ * \brief Recompute Baseline checksum of EEPROM Entry
  *
  *  \par Description
- *       Recompute the baseline checksum of the Eeprom
+ *       Recompute the baseline checksum of the EEPROM
  *       table entry and use that value as the new baseline.
  *       This command spawns a child task to do the recompute.
  *
@@ -671,10 +671,10 @@
 #define CS_RECOMPUTE_BASELINE_EEPROM_CC 17
 
 /**
- * \brief Enable checksumming for an Eeprom entry
+ * \brief Enable checksumming for an EEPROM entry
  *
  *  \par Description
- *       Allow the Eeprom entry to checksummed in the background
+ *       Allow the EEPROM entry to checksummed in the background
  *
  *  \par Command Structure
  *       #CS_EntryCmd_t
@@ -704,10 +704,10 @@
 #define CS_ENABLE_ENTRY_EEPROM_CC 18
 
 /**
- * \brief Disable checksumming for an Eeprom entry
+ * \brief Disable checksumming for an EEPROM entry
  *
  *  \par Description
- *      Disable the Eeprom entry background checksumming
+ *      Disable the EEPROM entry background checksumming
  *
  *  \par Command Structure
  *       #CS_EntryCmd_t
@@ -737,10 +737,10 @@
 #define CS_DISABLE_ENTRY_EEPROM_CC 19
 
 /**
- * \brief Get the Entry ID for a given Eeprom address
+ * \brief Get the Entry ID for a given EEPROM address
  *
  *  \par Description
- *     Gets the Entry ID of an Eeprom address to use in
+ *     Gets the Entry ID of an EEPROM address to use in
  *     subsequent commands.
  *
  *  \par Command Structure
@@ -1296,7 +1296,7 @@
 #define CS_DISABLE_APPS_CC 35
 
 /**
- * \brief Report Baseline checksum of a app
+ * \brief Report Baseline checksum of an app
  *
  *  \par Description
  *       Reports the baseline checksum of the
@@ -1330,7 +1330,7 @@
 #define CS_REPORT_BASELINE_APP_CC 36
 
 /**
- * \brief Recompute Baseline checksum of a app
+ * \brief Recompute Baseline checksum of an app
  *
  *  \par Description
  *       Recompute the baseline checksum of the
@@ -1378,7 +1378,7 @@
 #define CS_RECOMPUTE_BASELINE_APP_CC 37
 
 /**
- * \brief Enable checksumming for a app
+ * \brief Enable checksumming for an app
  *
  *  \par Description
  *       Allow the app to checksummed in the background
@@ -1411,7 +1411,7 @@
 #define CS_ENABLE_NAME_APP_CC 38
 
 /**
- * \brief Disable checksumming for a app
+ * \brief Disable checksumming for an app
  *
  *  \par Description
  *       Disable background checking of the app

--- a/fsw/inc/cs_platform_cfg.h
+++ b/fsw/inc/cs_platform_cfg.h
@@ -100,11 +100,11 @@
 #define CS_PIPE_DEPTH (3 * CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT)
 
 /**
- * \brief  Maximum number of entries in the Eeprom table to checksum
+ * \brief  Maximum number of entries in the EEPROM table to checksum
  *
  *  \par  Description:
  *        Maximum number of entries that can be in the table of
- *        Eeprom areas to checksum.
+ *        EEPROM areas to checksum.
  *
  *  \par Limits:
  *     This parameter is limited by the  uint16 datatype that defines it.

--- a/fsw/inc/cs_tbldefs.h
+++ b/fsw/inc/cs_tbldefs.h
@@ -64,7 +64,7 @@
  **************************************************************************/
 
 /**
- * \brief Data structure for the Eeprom or Memory definition table
+ * \brief Data structure for the EEPROM or Memory definition table
  */
 typedef struct
 {
@@ -147,7 +147,7 @@ typedef struct
  **************************************************************************/
 
 /**
- * \brief Validate Eeprom definition table
+ * \brief Validate EEPROM definition table
  *
  *  \par Description
  *       This function is a callback to cFE Table Services that gets called
@@ -219,7 +219,7 @@ int32 CS_ValidateTablesChecksumDefinitionTable(void *TblPtr);
 int32 CS_ValidateAppChecksumDefinitionTable(void *TblPtr);
 
 /**
- * \brief Processes a new definition table for Eeprom or Memory tables
+ * \brief Processes a new definition table for EEPROM or Memory tables
  *
  *  \par Description
  *       Copies data from the definition table to the results table

--- a/fsw/src/cs_app.c
+++ b/fsw/src/cs_app.c
@@ -19,8 +19,8 @@
 
 /**
  * @file
- *   CFS Checksum (CS) Applications provides the service of background
- *   checksumming user defined objects in the CFS
+ *   CFS Checksum (CS) Application provides the service of background
+ *   checksumming user-defined objects in the CFS
  */
 #include <string.h>
 #include "cfe.h"
@@ -107,7 +107,7 @@ void CS_HousekeepingCmd(const CS_NoArgsCmd_t *CmdPtr);
  * \brief Command packet processor
  *
  * \par Description
- *      Proccesses all CS commands
+ *      Processes all CS commands
  *
  * \param [in] BufPtr A CFE_SB_Buffer_t* pointer that
  *                    references the software bus pointer. The
@@ -144,7 +144,7 @@ void CS_AppMain(void)
     /* Performance Log (start time counter) */
     CFE_ES_PerfLogEntry(CS_APPMAIN_PERF_ID);
 
-    /* Perform application specific initialization */
+    /* Perform application-specific initialization */
     Result = CS_AppInit();
 
     /* Check for start-up error */
@@ -236,8 +236,7 @@ int32 CS_AppInit(void)
     {
         CFE_ES_WriteToSysLog("CS App: Error Registering For Event Services, RC = 0x%08X\n", (unsigned int)Result);
     }
-
-    if (Result == CFE_SUCCESS)
+    else
     {
         /* Zero out all data in CS_AppData, including the housekeeping data*/
         memset(&CS_AppData, 0, sizeof(CS_AppData));
@@ -413,7 +412,7 @@ void CS_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
             CS_RecomputeBaselineOSCmd((CS_NoArgsCmd_t *)BufPtr);
             break;
 
-        /* Eeprom Commands */
+        /* EEPROM Commands */
         case CS_ENABLE_EEPROM_CC:
             CS_EnableEepromCmd((CS_NoArgsCmd_t *)BufPtr);
             break;

--- a/fsw/src/cs_app.h
+++ b/fsw/src/cs_app.h
@@ -120,7 +120,7 @@ typedef struct
     uint32 RunStatus; /**< \brief Application run status */
 
     CS_Res_EepromMemory_Table_Entry_t *RecomputeEepromMemoryEntryPtr; /**< \brief Pointer to an entry to recompute in
-                                                                         the Eeprom or Memory table */
+                                                                         the EEPROM or Memory table */
 
     CS_Res_App_Table_Entry_t *RecomputeAppEntryPtr;       /**< \brief Pointer to an entry to recompute in the
                                                                       Application table */
@@ -129,8 +129,8 @@ typedef struct
 
     CFE_SB_PipeId_t CmdPipe; /**< \brief Command pipe ID */
 
-    CFE_TBL_Handle_t DefEepromTableHandle; /**< \brief Handle to the Eeprom definition table */
-    CFE_TBL_Handle_t ResEepromTableHandle; /**< \brief Handle to the Eeprom results table */
+    CFE_TBL_Handle_t DefEepromTableHandle; /**< \brief Handle to the EEPROM definition table */
+    CFE_TBL_Handle_t ResEepromTableHandle; /**< \brief Handle to the EEPROM results table */
 
     CFE_TBL_Handle_t DefMemoryTableHandle; /**< \brief Handle to the Memory definition table */
     CFE_TBL_Handle_t ResMemoryTableHandle; /**< \brief Handle to the Memory results table */
@@ -141,8 +141,8 @@ typedef struct
     CFE_TBL_Handle_t DefAppTableHandle; /**< \brief Handle to the Apps definition table */
     CFE_TBL_Handle_t ResAppTableHandle; /**< \brief Hanlde to the Apps results table */
 
-    CS_Def_EepromMemory_Table_Entry_t *DefEepromTblPtr; /**< \brief Pointer to the Eeprom definition table */
-    CS_Res_EepromMemory_Table_Entry_t *ResEepromTblPtr; /**< \brief Pointer to the Eeprom results table */
+    CS_Def_EepromMemory_Table_Entry_t *DefEepromTblPtr; /**< \brief Pointer to the EEPROM definition table */
+    CS_Res_EepromMemory_Table_Entry_t *ResEepromTblPtr; /**< \brief Pointer to the EEPROM results table */
 
     CS_Def_EepromMemory_Table_Entry_t *DefMemoryTblPtr; /**< \brief Pointer to the Memory definition table */
     CS_Res_EepromMemory_Table_Entry_t *ResMemoryTblPtr; /**< \brief Pointer to the Memory results table */
@@ -157,7 +157,7 @@ typedef struct
     CS_Res_EepromMemory_Table_Entry_t CfeCoreCodeSeg; /**< \brief cFE core code segment 'table' */
 
     CS_Def_EepromMemory_Table_Entry_t
-        DefaultEepromDefTable[CS_MAX_NUM_EEPROM_TABLE_ENTRIES]; /**< \brief Default Eeprom definition table */
+        DefaultEepromDefTable[CS_MAX_NUM_EEPROM_TABLE_ENTRIES]; /**< \brief Default EEPROM definition table */
     CS_Def_EepromMemory_Table_Entry_t
         DefaultMemoryDefTable[CS_MAX_NUM_MEMORY_TABLE_ENTRIES]; /**< \brief Default Memory definition table */
     CS_Def_Tables_Table_Entry_t

--- a/fsw/src/cs_app_cmds.h
+++ b/fsw/src/cs_app_cmds.h
@@ -41,7 +41,7 @@
  *
  *  \par Assumptions, External Events, and Notes:
  *       In order for background checking of individual areas
- *       to checksum (OS code segment, cFE core, Eeprom, Memory,
+ *       to checksum (OS code segment, cFE core, EEPROM, Memory,
  *       Tables, and App) to occur, the table must be enabled
  *       and overall checksumming must be enabled.
  *
@@ -60,7 +60,7 @@ void CS_DisableAppCmd(const CS_NoArgsCmd_t *CmdPtr);
  *
  *  \par Assumptions, External Events, and Notes:
  *       In order for background checking of individual areas
- *       to checksum (OS code segment, cFE core, Eeprom, Memory,
+ *       to checksum (OS code segment, cFE core, EEPROM, Memory,
  *       Tables, and App) to occur, the table must be enabled
  *       and overall checksumming must be enabled.
  *
@@ -71,7 +71,7 @@ void CS_DisableAppCmd(const CS_NoArgsCmd_t *CmdPtr);
 void CS_EnableAppCmd(const CS_NoArgsCmd_t *CmdPtr);
 
 /**
- * \brief Proccess a report baseline of a App command
+ * \brief Process a report baseline of an App command
  *
  *  \par Description
  *        Reports the baseline checksum of the specified app
@@ -87,10 +87,10 @@ void CS_EnableAppCmd(const CS_NoArgsCmd_t *CmdPtr);
 void CS_ReportBaselineAppCmd(const CS_AppNameCmd_t *CmdPtr);
 
 /**
- * \brief Process a recopmute baseline of a app command
+ * \brief Process a recopmute baseline of an app command
  *
  *  \par Description
- *        Recomputes the checksum of a app and use that
+ *        Recomputes the checksum of an app and use that
  *        value as the new baseline for that entry.
  *
  *  \par Assumptions, External Events, and Notes:

--- a/fsw/src/cs_cmds.h
+++ b/fsw/src/cs_cmds.h
@@ -94,7 +94,7 @@ void CS_BackgroundCheckCycle(const CS_NoArgsCmd_t *CmdPtr);
 void CS_DisableAllCSCmd(const CS_NoArgsCmd_t *CmdPtr);
 
 /**
- * \brief Process a enable overall background checking command
+ * \brief Process an enable overall background checking command
  *
  *  \par Description
  *       Allows background checking to take place.
@@ -117,7 +117,7 @@ void CS_EnableAllCSCmd(const CS_NoArgsCmd_t *CmdPtr);
  *
  *  \par Assumptions, External Events, and Notes:
  *       In order for background checking of individual areas
- *       to checksum (OS code segment, cFE core, Eeprom, Memory,
+ *       to checksum (OS code segment, cFE core, EEPROM, Memory,
  *       Apps, and Tables) to occurr, the table must be enabled
  *       and overall checksumming must be enabled.
  *
@@ -128,7 +128,7 @@ void CS_EnableAllCSCmd(const CS_NoArgsCmd_t *CmdPtr);
 void CS_DisableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr);
 
 /**
- * \brief Process a enable background checking for the cFE core code
+ * \brief Process an enable background checking for the cFE core code
  *        segment command
  *
  *  \par Description
@@ -136,7 +136,7 @@ void CS_DisableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr);
  *
  *  \par Assumptions, External Events, and Notes:
  *       In order for background checking of individual areas
- *       to checksum (OS code segment, cFE core, Eeprom, Memory,
+ *       to checksum (OS code segment, cFE core, EEPROM, Memory,
  *       Apps, and Tables) to occurr, the table must be enabled
  *       and overall checksumming must be enabled.
  *
@@ -155,7 +155,7 @@ void CS_EnableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr);
  *
  *  \par Assumptions, External Events, and Notes:
  *       In order for background checking of individual areas
- *       to checksum (OS code segment, cFE core, Eeprom, Memory,
+ *       to checksum (OS code segment, cFE core, EEPROM, Memory,
  *       Apps, and Tables) to occurr, the table must be enabled
  *       and overall checksumming must be enabled.
  *
@@ -166,7 +166,7 @@ void CS_EnableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr);
 void CS_DisableOSCmd(const CS_NoArgsCmd_t *CmdPtr);
 
 /**
- * \brief Process a enable background checking for the OS code
+ * \brief Process an enable background checking for the OS code
  *        segment command
  *
  *  \par Description
@@ -174,7 +174,7 @@ void CS_DisableOSCmd(const CS_NoArgsCmd_t *CmdPtr);
  *
  *  \par Assumptions, External Events, and Notes:
  *       In order for background checking of individual areas
- *       to checksum (OS code segment, cFE core, Eeprom, Memory,
+ *       to checksum (OS code segment, cFE core, EEPROM, Memory,
  *       Apps, and Tables) to occurr, the table must be enabled
  *       and overall checksumming must be enabled.
  *
@@ -201,7 +201,7 @@ void CS_EnableOSCmd(const CS_NoArgsCmd_t *CmdPtr);
 void CS_ReportBaselineCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr);
 
 /**
- * \brief Proccess a report baseline of the OS command
+ * \brief Process a report baseline of the OS command
  *
  *  \par Description
  *        Reports the baseline checksum of the OS code segment

--- a/fsw/src/cs_compute.c
+++ b/fsw/src/cs_compute.c
@@ -41,7 +41,7 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS function that computes the checksum for Eeprom, Memory, OS   */
+/* CS function that computes the checksum for EEPROM, Memory, OS   */
 /* and cFE core code segments                                      */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -161,7 +161,7 @@ int32 CS_ComputeTables(CS_Res_Tables_Table_Entry_t *ResultsEntry, uint32 *Comput
     {
         ResultGetInfo = CFE_TBL_GetInfo(&TblInfo, ResultsEntry->Name);
 
-        /* We want to try to to get the address even if the GetInfo fails. This
+        /* We want to try to get the address even if the GetInfo fails. This
         provides the CFE_TBL_UNREGISTERED if the table has gone away */
         ResultGetAddress = CFE_TBL_GetAddress((void *)&LocalAddress, LocalTblHandle);
         Result           = ResultGetAddress;
@@ -434,7 +434,7 @@ int32 CS_ComputeApp(CS_Res_App_Table_Entry_t *ResultsEntry, uint32 *ComputedCSVa
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS child task for recomputing Eeprom and Memory entry baselines */
+/* CS child task for recomputing EEPROM and Memory entry baselines */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_RecomputeEepromMemoryChildTask(void)
@@ -537,7 +537,7 @@ void CS_RecomputeEepromMemoryChildTask(void)
 
     if (Table == CS_EEPROM_TABLE)
     {
-        strncpy(TableType, "Eeprom", CS_TABLETYPE_NAME_SIZE);
+        strncpy(TableType, "EEPROM", CS_TABLETYPE_NAME_SIZE);
     }
     if (Table == CS_MEMORY_TABLE)
     {
@@ -776,7 +776,7 @@ void CS_RecomputeTablesChildTask(void)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS child task for getting the checksum on a area of memory      */
+/* CS child task for getting the checksum on an area of memory      */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_OneShotChildTask(void)

--- a/fsw/src/cs_compute.h
+++ b/fsw/src/cs_compute.h
@@ -33,11 +33,11 @@
 #include "cs_tbldefs.h"
 
 /**
- * \brief Computes checksums on Eeprom or Memory types
+ * \brief Computes checksums on EEPROM or Memory types
  *
  *  \par Description
  *       Computes checksums up to MaxBytesPerCycle bytes every call. This
- *       function is used to compute checksums for Eeprom, Memory, the
+ *       function is used to compute checksums for EEPROM, Memory, the
  *       OS code segment and the cFE core code segment
  *
  *
@@ -123,11 +123,11 @@ int32 CS_ComputeApp(CS_Res_App_Table_Entry_t *ResultsEntry, uint32 *ComputedCSVa
 
 /**
  * \brief Child task main function for recomputing  baselines for
- *        Eeprom and Memory types
+ *        EEPROM and Memory types
  *
  *  \par Description
  *       Child task main function that is spawned when a recompute
- *       baseline command is received for Eeprom, Memory, OS code segment
+ *       baseline command is received for EEPROM, Memory, OS code segment
  *       or cFE core code segment.
  *
  *  \par Assumptions, External Events, and Notes:

--- a/fsw/src/cs_eeprom_cmds.c
+++ b/fsw/src/cs_eeprom_cmds.c
@@ -19,7 +19,7 @@
 
 /**
  * @file
- *   The CFS Checksum (CS) Application's commands for checking Eeprom
+ *   The CFS Checksum (CS) Application's commands for checking EEPROM
  */
 
 /**************************************************************************
@@ -43,7 +43,7 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Disable background checking of Eeprom command                */
+/* CS Disable background checking of EEPROM command                */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
@@ -64,7 +64,7 @@ void CS_DisableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
 #endif
 
             CFE_EVS_SendEvent(CS_DISABLE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of Eeprom is Disabled");
+                              "Checksumming of EEPROM is Disabled");
 
             CS_AppData.HkPacket.CmdCounter++;
         }
@@ -73,7 +73,7 @@ void CS_DisableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Enable background checking of Eeprom command                 */
+/* CS Enable background checking of EEPROM command                 */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
@@ -93,7 +93,7 @@ void CS_EnableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
 #endif
 
             CFE_EVS_SendEvent(CS_ENABLE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of Eeprom is Enabled");
+                              "Checksumming of EEPROM is Enabled");
 
             CS_AppData.HkPacket.CmdCounter++;
         }
@@ -102,7 +102,7 @@ void CS_EnableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Report the baseline checksum of an entry in the Eeprom table */
+/* CS Report the baseline checksum of an entry in the EEPROM table */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_ReportBaselineEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
@@ -130,12 +130,12 @@ void CS_ReportBaselineEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 Baseline = ResultsEntry.ComparisonValue;
 
                 CFE_EVS_SendEvent(CS_BASELINE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Report baseline of Eeprom Entry %d is 0x%08X", EntryID, (unsigned int)Baseline);
+                                  "Report baseline of EEPROM Entry %d is 0x%08X", EntryID, (unsigned int)Baseline);
             }
             else
             {
                 CFE_EVS_SendEvent(CS_NO_BASELINE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Report baseline of Eeprom Entry %d has not been computed yet", EntryID);
+                                  "Report baseline of EEPROM Entry %d has not been computed yet", EntryID);
             }
             CS_AppData.HkPacket.CmdCounter++;
         }
@@ -151,7 +151,7 @@ void CS_ReportBaselineEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
             }
 
             CFE_EVS_SendEvent(CS_BASELINE_INVALID_ENTRY_EEPROM_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Eeprom report baseline failed, Entry ID invalid: %d, State: %d Max ID: %d", EntryID,
+                              "EEPROM report baseline failed, Entry ID invalid: %d, State: %d Max ID: %d", EntryID,
                               State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
             CS_AppData.HkPacket.CmdErrCounter++;
         }
@@ -160,7 +160,7 @@ void CS_ReportBaselineEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Recompute the baseline of an entry in the Eeprom table cmd   */
+/* CS Recompute the baseline of an entry in the EEPROM table cmd   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
@@ -199,14 +199,14 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 if (Status == CFE_SUCCESS)
                 {
                     CFE_EVS_SendEvent(CS_RECOMPUTE_EEPROM_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "Recompute baseline of Eeprom Entry ID %d started", EntryID);
+                                      "Recompute baseline of EEPROM Entry ID %d started", EntryID);
                     CS_AppData.HkPacket.CmdCounter++;
                 }
                 else /* child task creation failed */
                 {
                     CFE_EVS_SendEvent(
                         CS_RECOMPUTE_EEPROM_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
-                        "Recompute baseline of Eeprom Entry ID %d failed, CFE_ES_CreateChildTask returned:  0x%08X",
+                        "Recompute baseline of EEPROM Entry ID %d failed, CFE_ES_CreateChildTask returned:  0x%08X",
                         EntryID, (unsigned int)Status);
                     CS_AppData.HkPacket.CmdErrCounter++;
                     CS_AppData.HkPacket.RecomputeInProgress = false;
@@ -225,7 +225,7 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
 
                 CFE_EVS_SendEvent(
                     CS_RECOMPUTE_INVALID_ENTRY_EEPROM_ERR_EID, CFE_EVS_EventType_ERROR,
-                    "Eeprom recompute baseline of entry failed, Entry ID invalid: %d, State: %d, Max ID: %d", EntryID,
+                    "EEPROM recompute baseline of entry failed, Entry ID invalid: %d, State: %d, Max ID: %d", EntryID,
                     State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
 
                 CS_AppData.HkPacket.CmdErrCounter++;
@@ -235,7 +235,7 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
         {
             /*send event that we can't start another task right now */
             CFE_EVS_SendEvent(CS_RECOMPUTE_EEPROM_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Recompute baseline of Eeprom Entry ID %d failed: child task in use", EntryID);
+                              "Recompute baseline of EEPROM Entry ID %d failed: child task in use", EntryID);
             CS_AppData.HkPacket.CmdErrCounter++;
         }
     }
@@ -243,7 +243,7 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Enable a specific entry in the Eeprom table command          */
+/* CS Enable a specific entry in the EEPROM table command          */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
@@ -270,7 +270,7 @@ void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 ResultsEntry->State = CS_STATE_ENABLED;
 
                 CFE_EVS_SendEvent(CS_ENABLE_EEPROM_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of Eeprom Entry ID %d is Enabled", EntryID);
+                                  "Checksumming of EEPROM Entry ID %d is Enabled", EntryID);
 
                 if (CS_AppData.DefEepromTblPtr[EntryID].State != CS_STATE_EMPTY)
                 {
@@ -281,7 +281,7 @@ void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 else
                 {
                     CFE_EVS_SendEvent(CS_ENABLE_EEPROM_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update Eeprom definition table for entry %d, State: %d", EntryID,
+                                      "CS unable to update EEPROM definition table for entry %d, State: %d", EntryID,
                                       State);
                 }
 
@@ -299,7 +299,7 @@ void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 }
 
                 CFE_EVS_SendEvent(CS_ENABLE_EEPROM_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Enable Eeprom entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
+                                  "Enable EEPROM entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
                                   State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
                 CS_AppData.HkPacket.CmdErrCounter++;
             }
@@ -309,7 +309,7 @@ void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Disable a specific entry in the Eeprom table command         */
+/* CS Disable a specific entry in the EEPROM table command         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
@@ -338,7 +338,7 @@ void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 ResultsEntry->ByteOffset        = 0;
 
                 CFE_EVS_SendEvent(CS_DISABLE_EEPROM_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of Eeprom Entry ID %d is Disabled", EntryID);
+                                  "Checksumming of EEPROM Entry ID %d is Disabled", EntryID);
 
                 if (CS_AppData.DefEepromTblPtr[EntryID].State != CS_STATE_EMPTY)
                 {
@@ -349,7 +349,7 @@ void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 else
                 {
                     CFE_EVS_SendEvent(CS_DISABLE_EEPROM_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update Eeprom definition table for entry %d, State: %d", EntryID,
+                                      "CS unable to update EEPROM definition table for entry %d, State: %d", EntryID,
                                       State);
                 }
 
@@ -367,7 +367,7 @@ void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 }
 
                 CFE_EVS_SendEvent(CS_DISABLE_EEPROM_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Disable Eeprom entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
+                                  "Disable EEPROM entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
                                   State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
 
                 CS_AppData.HkPacket.CmdErrCounter++;
@@ -378,7 +378,7 @@ void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Retrieve an EntryID based on Address from Eeprom table cmd   */
+/* CS Retrieve an EntryID based on Address from EEPROM table cmd   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_GetEntryIDEepromCmd(const CS_GetEntryIDCmd_t *CmdPtr)
@@ -405,7 +405,7 @@ void CS_GetEntryIDEepromCmd(const CS_GetEntryIDCmd_t *CmdPtr)
                 ResultsEntry.State != CS_STATE_EMPTY)
             {
                 CFE_EVS_SendEvent(CS_GET_ENTRY_ID_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Eeprom Found Address 0x%08X in Entry ID %d", (unsigned int)(CmdPtr->Address), Loop);
+                                  "EEPROM Found Address 0x%08X in Entry ID %d", (unsigned int)(CmdPtr->Address), Loop);
                 EntryFound = true;
             }
         }
@@ -413,7 +413,7 @@ void CS_GetEntryIDEepromCmd(const CS_GetEntryIDCmd_t *CmdPtr)
         if (EntryFound == false)
         {
             CFE_EVS_SendEvent(CS_GET_ENTRY_ID_EEPROM_NOT_FOUND_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Address 0x%08X was not found in Eeprom table", (unsigned int)(CmdPtr->Address));
+                              "Address 0x%08X was not found in EEPROM table", (unsigned int)(CmdPtr->Address));
         }
         CS_AppData.HkPacket.CmdCounter++;
     }

--- a/fsw/src/cs_eeprom_cmds.h
+++ b/fsw/src/cs_eeprom_cmds.h
@@ -33,15 +33,15 @@
 #include "cs_msg.h"
 
 /**
- * \brief Process a disable background checking for the Eeprom
+ * \brief Process a disable background checking for the EEPROM
  *        table command
  *
  *  \par Description
- *       Disables background checking for the Eeprom table
+ *       Disables background checking for the EEPROM table
  *
  *  \par Assumptions, External Events, and Notes:
  *       In order for background checking of individual areas
- *       to checksum (OS code segment, cFE core, Eeprom, Memory,
+ *       to checksum (OS code segment, cFE core, EEPROM, Memory,
  *       Apps, and Tables) to occur, the table must be enabled
  *       and overall checksumming must be enabled.
  *
@@ -52,15 +52,15 @@
 void CS_DisableEepromCmd(const CS_NoArgsCmd_t *CmdPtr);
 
 /**
- * \brief Process an enable background checking for the Eeprom
+ * \brief Process an enable background checking for the EEPROM
  *        table command
  *
  *  \par Description
- *       Allows the Eeprom table to be background checksummed.
+ *       Allows the EEPROM table to be background checksummed.
  *
  *  \par Assumptions, External Events, and Notes:
  *       In order for background checking of individual areas
- *       to checksum (OS code segment, cFE core, Eeprom, Memory,
+ *       to checksum (OS code segment, cFE core, EEPROM, Memory,
  *       Apps, and Tables) to occur, the table must be enabled
  *       and overall checksumming must be enabled.
  *
@@ -71,10 +71,10 @@ void CS_DisableEepromCmd(const CS_NoArgsCmd_t *CmdPtr);
 void CS_EnableEepromCmd(const CS_NoArgsCmd_t *CmdPtr);
 
 /**
- * \brief Proccess a report baseline of a Eeprom Entry command
+ * \brief Proccess a report baseline of an EEPROM Entry command
  *
  *  \par Description
- *        Reports the baseline checksum of the specified Eeprom table
+ *        Reports the baseline checksum of the specified EEPROM table
  *        entry if it has already been computed
  *
  *  \par Assumptions, External Events, and Notes:
@@ -87,11 +87,11 @@ void CS_EnableEepromCmd(const CS_NoArgsCmd_t *CmdPtr);
 void CS_ReportBaselineEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr);
 
 /**
- * \brief Process a disable background checking for an Eeprom
+ * \brief Process a disable background checking for an EEPROM
  *        entry command
  *
  *  \par Description
- *       Disables the specified Eeprom entry to be background checksummed.
+ *       Disables the specified EEPROM entry to be background checksummed.
  *
  *  \par Assumptions, External Events, and Notes:
  *       In order for background checking of individual entries
@@ -110,10 +110,10 @@ void CS_ReportBaselineEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr);
 void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr);
 
 /**
- * \brief Process a recopmute baseline of a Eeprom table entry command
+ * \brief Process a recopmute baseline of an EEPROM table entry command
  *
  *  \par Description
- *        Recomputes the checksum of a Eeprom table entry and use that
+ *        Recomputes the checksum of an EEPROM table entry and use that
  *        value as the new baseline for that entry.
  *
  *  \par Assumptions, External Events, and Notes:
@@ -126,11 +126,11 @@ void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr);
 void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr);
 
 /**
- * \brief Process an enable background checking for an Eeprom
+ * \brief Process an enable background checking for an EEPROM
  *        entry command
  *
  *  \par Description
- *       Allows the specified Eeprom entry to be background checksummed.
+ *       Allows the specified EEPROM entry to be background checksummed.
  *
  *  \par Assumptions, External Events, and Notes:
  *       In order for background checking of individual entries
@@ -149,7 +149,7 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr);
 void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr);
 
 /**
- * \brief Process a get Eeprom Entry by Address command
+ * \brief Process a get EEPROM Entry by Address command
  *
  *  \par Description
  *       Send the entry ID of the specified address in an event message

--- a/fsw/src/cs_init.c
+++ b/fsw/src/cs_init.c
@@ -66,8 +66,7 @@ int32 CS_SbInit(void)
             CFE_EVS_SendEvent(CS_INIT_SB_SUBSCRIBE_HK_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Software Bus subscribe to housekeeping returned: 0x%08X", (unsigned int)Result);
         }
-
-        if (Result == CFE_SUCCESS)
+        else
         {
             /* Subscribe to background checking schedule */
             Result = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CS_BACKGROUND_CYCLE_MID), CS_AppData.CmdPipe);
@@ -113,10 +112,9 @@ int32 CS_InitAllTables(void)
     {
         CS_AppData.HkPacket.EepromCSState = CS_STATE_DISABLED;
         CFE_EVS_SendEvent(CS_INIT_EEPROM_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Table initialization failed for Eeprom: 0x%08X", (unsigned int)ResultInit);
+                          "Table initialization failed for EEPROM: 0x%08X", (unsigned int)ResultInit);
     }
-
-    if (ResultInit == CFE_SUCCESS)
+    else
     {
         ResultInit = CS_TableInit(&CS_AppData.DefMemoryTableHandle, &CS_AppData.ResMemoryTableHandle,
                                   (void *)&CS_AppData.DefMemoryTblPtr, (void *)&CS_AppData.ResMemoryTblPtr,

--- a/fsw/src/cs_memory_cmds.h
+++ b/fsw/src/cs_memory_cmds.h
@@ -41,7 +41,7 @@
  *
  *  \par Assumptions, External Events, and Notes:
  *       In order for background checking of individual areas
- *       to checksum (OS code segment, cFE core, Eeprom, Memory,
+ *       to checksum (OS code segment, cFE core, EEPROM, Memory,
  *       Apps, and Tables) to occur, the table must be enabled
  *       and overall checksumming must be enabled.
  *
@@ -60,7 +60,7 @@ void CS_DisableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr);
  *
  *  \par Assumptions, External Events, and Notes:
  *       In order for background checking of individual areas
- *       to checksum (OS code segment, cFE core, Eeprom, Memory,
+ *       to checksum (OS code segment, cFE core, EEPROM, Memory,
  *       Apps, and Tables) to occur, the table must be enabled
  *       and overall checksumming must be enabled.
  *
@@ -87,7 +87,7 @@ void CS_EnableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr);
 void CS_ReportBaselineEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr);
 
 /**
- * \brief Process a disable background checking for an Memory
+ * \brief Process a disable background checking for a Memory
  *        entry command
  *
  *  \par Description
@@ -126,7 +126,7 @@ void CS_DisableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr);
 void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr);
 
 /**
- * \brief Process an enable background checking for an Memory
+ * \brief Process an enable background checking for a Memory
  *        entry command
  *
  *  \par Description

--- a/fsw/src/cs_table_cmds.h
+++ b/fsw/src/cs_table_cmds.h
@@ -41,7 +41,7 @@
  *
  *  \par Assumptions, External Events, and Notes:
  *       In order for background checking of individual areas
- *       to checksum (OS code segment, cFE core, Eeprom, Memory,
+ *       to checksum (OS code segment, cFE core, EEPROM, Memory,
  *       Apps, and Tables) to occur, the table must be enabled
  *       and overall checksumming must be enabled.
  *
@@ -60,7 +60,7 @@ void CS_DisableTablesCmd(const CS_NoArgsCmd_t *CmdPtr);
  *
  *  \par Assumptions, External Events, and Notes:
  *       In order for background checking of individual areas
- *       to checksum (OS code segment, cFE core, Eeprom, Memory,
+ *       to checksum (OS code segment, cFE core, EEPROM, Memory,
  *       Apps, and Tables) to occur, the table must be enabled
  *       and overall checksumming must be enabled.
  *

--- a/fsw/src/cs_table_processing.c
+++ b/fsw/src/cs_table_processing.c
@@ -42,7 +42,7 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Validation Callback function for Eeprom Table                */
+/* CS Validation Callback function for EEPROM Table                */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 int32 CS_ValidateEepromChecksumDefinitionTable(void *TblPtr)
@@ -81,7 +81,7 @@ int32 CS_ValidateEepromChecksumDefinitionTable(void *TblPtr)
                     if (Result != CS_TABLE_ERROR)
                     {
                         CFE_EVS_SendEvent(CS_VAL_EEPROM_RANGE_ERR_EID, CFE_EVS_EventType_ERROR,
-                                          "Eeprom Table Validate: Illegal checksum range found in Entry ID %d, "
+                                          "EEPROM Table Validate: Illegal checksum range found in Entry ID %d, "
                                           "CFE_PSP_MemValidateRange returned: 0x%08X",
                                           (int)OuterLoop, (unsigned int)Status);
                         Result = CS_TABLE_ERROR;
@@ -106,7 +106,7 @@ int32 CS_ValidateEepromChecksumDefinitionTable(void *TblPtr)
             if (Result != CS_TABLE_ERROR)
             {
                 CFE_EVS_SendEvent(CS_VAL_EEPROM_STATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Eeprom Table Validate: Illegal State Field (0x%04X) found in Entry ID %d",
+                                  "EEPROM Table Validate: Illegal State Field (0x%04X) found in Entry ID %d",
                                   (unsigned short)StateField, (int)OuterLoop);
                 Result = CS_TABLE_ERROR;
             }
@@ -114,7 +114,7 @@ int32 CS_ValidateEepromChecksumDefinitionTable(void *TblPtr)
     } /* for (OuterLoop = 0; OuterLoop < CS_MAX_NUM_EEPROM_TABLE_ENTRIES; OuterLoop++) */
 
     CFE_EVS_SendEvent(CS_VAL_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
-                      "CS Eeprom Table verification results: good = %d, bad = %d, unused = %d", (int)GoodCount,
+                      "CS EEPROM Table verification results: good = %d, bad = %d, unused = %d", (int)GoodCount,
                       (int)BadCount, (int)EmptyCount);
 
     return Result;
@@ -437,7 +437,7 @@ int32 CS_ValidateAppChecksumDefinitionTable(void *TblPtr)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS  processing new definition tables for Eeprom or Memory       */
+/* CS  processing new definition tables for EEPROM or Memory       */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_ProcessNewEepromMemoryDefinitionTable(const CS_Def_EepromMemory_Table_Entry_t *DefinitionTblPtr,
@@ -518,7 +518,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable(const CS_Def_EepromMemory_Table_En
     {
         if (Table == CS_EEPROM_TABLE)
         {
-            strncpy(&TableType[0], "Eeprom", CS_TABLETYPE_NAME_SIZE);
+            strncpy(&TableType[0], "EEPROM", CS_TABLETYPE_NAME_SIZE);
         }
         if (Table == CS_MEMORY_TABLE)
         {
@@ -892,7 +892,7 @@ int32 CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handle_t *Re
     {
         if (Table == CS_EEPROM_TABLE)
         {
-            strncpy(TableType, "Eeprom", CS_TABLETYPE_NAME_SIZE);
+            strncpy(TableType, "EEPROM", CS_TABLETYPE_NAME_SIZE);
         }
         if (Table == CS_MEMORY_TABLE)
         {
@@ -1019,7 +1019,7 @@ int32 CS_HandleTableUpdate(void *DefinitionTblPtr, void *ResultsTblPtr, CFE_TBL_
         {
             if (Table == CS_EEPROM_TABLE)
             {
-                strncpy(TableType, "Eeprom", CS_TABLETYPE_NAME_SIZE);
+                strncpy(TableType, "EEPROM", CS_TABLETYPE_NAME_SIZE);
             }
             if (Table == CS_MEMORY_TABLE)
             {

--- a/fsw/src/cs_utils.c
+++ b/fsw/src/cs_utils.c
@@ -41,7 +41,7 @@
  **************************************************************************/
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Zero out the temp chcksum values of Eeprom                   */
+/* CS Zero out the temp chcksum values of EEPROM                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_ZeroEepromTempValues(void)
@@ -215,7 +215,7 @@ bool CS_GetTableResTblEntryByName(CS_Res_Tables_Table_Entry_t **EntryPtr, const 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Get the Defintion Table Entry info of a table by its name      */
+/* CS Get the Definition Table Entry info of a table by its name      */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool CS_GetTableDefTblEntryByName(CS_Def_Tables_Table_Entry_t **EntryPtr, const char *Name)
@@ -603,7 +603,7 @@ bool CS_BackgroundOS(void)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* Background check Eeprom                                         */
+/* Background check EEPROM                                         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 bool CS_BackgroundEeprom(void)
@@ -641,7 +641,7 @@ bool CS_BackgroundEeprom(void)
                 CS_AppData.HkPacket.EepromCSErrCounter++;
 
                 CFE_EVS_SendEvent(CS_EEPROM_MISCOMPARE_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Checksum Failure: Entry %d in Eeprom Table, Expected: 0x%08X, Calculated: 0x%08X",
+                                  "Checksum Failure: Entry %d in EEPROM Table, Expected: 0x%08X, Calculated: 0x%08X",
                                   CurrEntry, (unsigned int)(ResultsEntry->ComparisonValue),
                                   (unsigned int)ComputedCSValue);
             }
@@ -654,7 +654,7 @@ bool CS_BackgroundEeprom(void)
 
         if (CS_AppData.HkPacket.CurrentEntryInTable >= CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
         {
-            /* Since we are done CS'ing the entire Eeprom table, update the baseline
+            /* Since we are done CS'ing the entire EEPROM table, update the baseline
              number for telemetry */
             EntireEepromCS = 0;
             for (Loop = 0; Loop < CS_MAX_NUM_EEPROM_TABLE_ENTRIES; Loop++)
@@ -933,7 +933,7 @@ int32 CS_HandleRoutineTableUpdates(void)
         {
             CS_AppData.HkPacket.EepromCSState = CS_STATE_DISABLED;
             Result                            = CFE_EVS_SendEvent(CS_UPDATE_EEPROM_ERR_EID, CFE_EVS_EventType_ERROR,
-                                       "Table update failed for Eeprom: 0x%08X, checksumming Eeprom is disabled",
+                                       "Table update failed for EEPROM: 0x%08X, checksumming EEPROM is disabled",
                                        (unsigned int)Result);
             ErrorCode                         = Result;
         }

--- a/fsw/src/cs_utils.h
+++ b/fsw/src/cs_utils.h
@@ -33,7 +33,7 @@
 #include "cs_tbldefs.h"
 
 /**
- * \brief Zeros out temporary checksum values of Eeprom table entries
+ * \brief Zeros out temporary checksum values of EEPROM table entries
  *
  *  \par Description
  *       Zeros the TempChecksumValue and the byte offset for every entry
@@ -113,7 +113,7 @@ void CS_ZeroOSTempValues(void);
  *
  *  \par Description
  *       Sets all of the entries in the default definitions tables for
- *       Eeprom,Memory, Tables, and Apps to zero and sets theri states
+ *       EEPROM,Memory, Tables, and Apps to zero and sets theri states
  *       to 'empty'.
  *
  *  \par Assumptions, External Events, and Notes:
@@ -185,7 +185,7 @@ bool CS_GetTableResTblEntryByName(CS_Res_Tables_Table_Entry_t **EntryPtr, const 
 bool CS_GetTableDefTblEntryByName(CS_Def_Tables_Table_Entry_t **EntryPtr, const char *Name);
 
 /**
- * \brief Gets a pointer to the results entry given a app name
+ * \brief Gets a pointer to the results entry given an app name
  *
  *  \par Description
  *       This routine will look through the App Results table
@@ -211,7 +211,7 @@ bool CS_GetTableDefTblEntryByName(CS_Def_Tables_Table_Entry_t **EntryPtr, const 
 bool CS_GetAppResTblEntryByName(CS_Res_App_Table_Entry_t **EntryPtr, const char *Name);
 
 /**
- * \brief Gets a pointer to the definition entry given a app name
+ * \brief Gets a pointer to the definition entry given an app name
  *
  *  \par Description
  *       This routine will look through the App Definition table
@@ -237,7 +237,7 @@ bool CS_GetAppResTblEntryByName(CS_Res_App_Table_Entry_t **EntryPtr, const char 
 bool CS_GetAppDefTblEntryByName(CS_Def_App_Table_Entry_t **EntryPtr, const char *Name);
 
 /**
- * \brief Find an enabled Eeprom entry
+ * \brief Find an enabled EEPROM entry
  *
  *  \par Description
  *       This routine will look from the current position to the end of
@@ -390,7 +390,7 @@ bool CS_BackgroundOS(void);
 bool CS_BackgroundCfeCore(void);
 
 /**
- * \brief Compute a background check cycle on Eeprom
+ * \brief Compute a background check cycle on EEPROM
  *
  *  \par Description
  *       This routine will try and complete a cycle of background checking

--- a/unit-test/cs_eeprom_cmds_tests.c
+++ b/unit-test/cs_eeprom_cmds_tests.c
@@ -49,7 +49,7 @@ void CS_DisableEepromCmd_Test(void)
     int32          strCmpResult;
     char           ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Checksumming of Eeprom is Disabled");
+    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Checksumming of EEPROM is Disabled");
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -118,7 +118,7 @@ void CS_EnableEepromCmd_Test(void)
     int32          strCmpResult;
     char           ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Checksumming of Eeprom is Enabled");
+    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Checksumming of EEPROM is Enabled");
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -187,7 +187,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_Computed(void)
     int32         strCmpResult;
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Report baseline of Eeprom Entry %%d is 0x%%08X");
+    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Report baseline of EEPROM Entry %%d is 0x%%08X");
 
     CmdPacket.EntryID = 1;
 
@@ -223,7 +223,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_NotYetComputed(void)
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Report baseline of Eeprom Entry %%d has not been computed yet");
+             "Report baseline of EEPROM Entry %%d has not been computed yet");
 
     CmdPacket.EntryID = 1;
 
@@ -259,7 +259,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Eeprom report baseline failed, Entry ID invalid: %%d, State: %%d Max ID: %%d");
+             "EEPROM report baseline failed, Entry ID invalid: %%d, State: %%d Max ID: %%d");
 
     CmdPacket.EntryID = CS_MAX_NUM_EEPROM_TABLE_ENTRIES;
 
@@ -291,7 +291,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Eeprom report baseline failed, Entry ID invalid: %%d, State: %%d Max ID: %%d");
+             "EEPROM report baseline failed, Entry ID invalid: %%d, State: %%d Max ID: %%d");
 
     CmdPacket.EntryID = 1;
 
@@ -343,7 +343,7 @@ void CS_RecomputeBaselineEepromCmd_Test_Nominal(void)
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Recompute baseline of Eeprom Entry ID %%d started");
+             "Recompute baseline of EEPROM Entry ID %%d started");
 
     CmdPacket.EntryID = 1;
 
@@ -385,7 +385,7 @@ void CS_RecomputeBaselineEepromCmd_Test_CreateChildTaskError(void)
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Recompute baseline of Eeprom Entry ID %%d failed, CFE_ES_CreateChildTask returned:  0x%%08X");
+             "Recompute baseline of EEPROM Entry ID %%d failed, CFE_ES_CreateChildTask returned:  0x%%08X");
 
     CmdPacket.EntryID = 1;
 
@@ -430,7 +430,7 @@ void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Eeprom recompute baseline of entry failed, Entry ID invalid: %%d, State: %%d, Max ID: %%d");
+             "EEPROM recompute baseline of entry failed, Entry ID invalid: %%d, State: %%d, Max ID: %%d");
 
     CmdPacket.EntryID = CS_MAX_NUM_EEPROM_TABLE_ENTRIES;
 
@@ -462,7 +462,7 @@ void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Eeprom recompute baseline of entry failed, Entry ID invalid: %%d, State: %%d, Max ID: %%d");
+             "EEPROM recompute baseline of entry failed, Entry ID invalid: %%d, State: %%d, Max ID: %%d");
 
     CmdPacket.EntryID = 1;
 
@@ -496,7 +496,7 @@ void CS_RecomputeBaselineEepromCmd_Test_RecomputeInProgress(void)
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Recompute baseline of Eeprom Entry ID %%d failed: child task in use");
+             "Recompute baseline of EEPROM Entry ID %%d failed: child task in use");
 
     CmdPacket.EntryID = 1;
 
@@ -548,7 +548,7 @@ void CS_RecomputeBaselineEepromCmd_Test_OneShot(void)
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Recompute baseline of Eeprom Entry ID %%d failed: child task in use");
+             "Recompute baseline of EEPROM Entry ID %%d failed: child task in use");
 
     CmdPacket.EntryID = 1;
 
@@ -582,7 +582,7 @@ void CS_EnableEntryIDEepromCmd_Test_Nominal(void)
     int32         strCmpResult;
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Checksumming of Eeprom Entry ID %%d is Enabled");
+    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Checksumming of EEPROM Entry ID %%d is Enabled");
 
     CmdPacket.EntryID = 1;
 
@@ -623,10 +623,10 @@ void CS_EnableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
     char          ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Checksumming of Eeprom Entry ID %%d is Enabled");
+             "Checksumming of EEPROM Entry ID %%d is Enabled");
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CS unable to update Eeprom definition table for entry %%d, State: %%d");
+             "CS unable to update EEPROM definition table for entry %%d, State: %%d");
 
     CmdPacket.EntryID = 1;
 
@@ -673,7 +673,7 @@ void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Enable Eeprom entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
+             "Enable EEPROM entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
 
     CmdPacket.EntryID = CS_MAX_NUM_EEPROM_TABLE_ENTRIES;
 
@@ -705,7 +705,7 @@ void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Enable Eeprom entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
+             "Enable EEPROM entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
 
     CmdPacket.EntryID = 1;
 
@@ -776,7 +776,7 @@ void CS_DisableEntryIDEepromCmd_Test_Nominal(void)
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Checksumming of Eeprom Entry ID %%d is Disabled");
+             "Checksumming of EEPROM Entry ID %%d is Disabled");
 
     CmdPacket.EntryID = 1;
 
@@ -821,10 +821,10 @@ void CS_DisableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
     char          ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Checksumming of Eeprom Entry ID %%d is Disabled");
+             "Checksumming of EEPROM Entry ID %%d is Disabled");
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CS unable to update Eeprom definition table for entry %%d, State: %%d");
+             "CS unable to update EEPROM definition table for entry %%d, State: %%d");
 
     CmdPacket.EntryID = 1;
 
@@ -875,7 +875,7 @@ void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Disable Eeprom entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
+             "Disable EEPROM entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
 
     CmdPacket.EntryID = CS_MAX_NUM_EEPROM_TABLE_ENTRIES;
 
@@ -907,7 +907,7 @@ void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
     char          ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Disable Eeprom entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
+             "Disable EEPROM entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
 
     CmdPacket.EntryID = 1;
 
@@ -977,7 +977,7 @@ void CS_GetEntryIDEepromCmd_Test_Nominal(void)
     int32              strCmpResult;
     char               ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Eeprom Found Address 0x%%08X in Entry ID %%d");
+    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "EEPROM Found Address 0x%%08X in Entry ID %%d");
 
     int16 EntryID = 1;
 
@@ -1013,7 +1013,7 @@ void CS_GetEntryIDEepromCmd_Test_AddressNotFound(void)
     int32              strCmpResult;
     char               ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Address 0x%%08X was not found in Eeprom table");
+    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Address 0x%%08X was not found in EEPROM table");
 
     CmdPacket.Address = 0xFFFFFFFF;
 
@@ -1044,7 +1044,7 @@ void CS_GetEntryIDEepromCmd_Test_AddressPtr(void)
     int32              strCmpResult;
     char               ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Address 0x%%08X was not found in Eeprom table");
+    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Address 0x%%08X was not found in EEPROM table");
 
     int16 EntryID = 1;
 
@@ -1080,7 +1080,7 @@ void CS_GetEntryIDEepromCmd_Test_State(void)
     int32              strCmpResult;
     char               ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Address 0x%%08X was not found in Eeprom table");
+    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Address 0x%%08X was not found in EEPROM table");
 
     int16 EntryID = 1;
 

--- a/unit-test/cs_init_tests.c
+++ b/unit-test/cs_init_tests.c
@@ -205,7 +205,7 @@ void CS_Init_Test_TableInitErrorEEPROM(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Table initialization failed for Eeprom: 0x%%08X");
+             "Table initialization failed for EEPROM: 0x%%08X");
 
     /* Set to generate error message CS_INIT_EEPROM_ERR_EID */
 

--- a/unit-test/cs_table_processing_tests.c
+++ b/unit-test/cs_table_processing_tests.c
@@ -69,7 +69,7 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_Nominal(void)
     char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CS Eeprom Table verification results: good = %%d, bad = %%d, unused = %%d");
+             "CS EEPROM Table verification results: good = %%d, bad = %%d, unused = %%d");
 
     CS_AppData.DefEepromTblPtr[0].State = CS_STATE_ENABLED; /* All other states are empty by default, and so this test
                                                                also covers CS_STATE_EMPTY branch */
@@ -100,11 +100,11 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnab
     char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Eeprom Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
+             "EEPROM Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
              "0x%%08X");
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CS Eeprom Table verification results: good = %%d, bad = %%d, unused = %%d");
+             "CS EEPROM Table verification results: good = %%d, bad = %%d, unused = %%d");
 
     CS_AppData.DefEepromTblPtr[0].State = CS_STATE_ENABLED;
 
@@ -147,11 +147,11 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisa
     char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Eeprom Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
+             "EEPROM Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
              "0x%%08X");
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CS Eeprom Table verification results: good = %%d, bad = %%d, unused = %%d");
+             "CS EEPROM Table verification results: good = %%d, bad = %%d, unused = %%d");
 
     CS_AppData.DefEepromTblPtr[0].State = CS_STATE_DISABLED;
 
@@ -194,10 +194,10 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalStateField(void)
     char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Eeprom Table Validate: Illegal State Field (0x%%04X) found in Entry ID %%d");
+             "EEPROM Table Validate: Illegal State Field (0x%%04X) found in Entry ID %%d");
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CS Eeprom Table verification results: good = %%d, bad = %%d, unused = %%d");
+             "CS EEPROM Table verification results: good = %%d, bad = %%d, unused = %%d");
 
     CS_AppData.DefEepromTblPtr[0].State = 0xFFFF;
 
@@ -237,11 +237,11 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_TableErrorResult(void)
     char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Eeprom Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
+             "EEPROM Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
              "0x%%08X");
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CS Eeprom Table verification results: good = %%d, bad = %%d, unused = %%d");
+             "CS EEPROM Table verification results: good = %%d, bad = %%d, unused = %%d");
 
     CS_AppData.DefEepromTblPtr[0].State = CS_STATE_DISABLED;
     CS_AppData.DefEepromTblPtr[1].State = CS_STATE_DISABLED;
@@ -284,11 +284,11 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_UndefTableErrorResult(void)
     char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "Eeprom Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
+             "EEPROM Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
              "0x%%08X");
 
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CS Eeprom Table verification results: good = %%d, bad = %%d, unused = %%d");
+             "CS EEPROM Table verification results: good = %%d, bad = %%d, unused = %%d");
 
     CS_AppData.DefEepromTblPtr[0].State = CS_STATE_DISABLED;
     CS_AppData.DefEepromTblPtr[1].State = CS_STATE_UNDEFINED;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #67 
  - 3 separate pairs of consecutive, mutually-exclusive status checks combined into `if`/`else` constructs.
  - Code changes are in cs_app.c and cs_init.c
  - Some typos corrected as a piggy-back on this PR.
  - Also capitalised EEPROM in all text (was inconsistently capitalised previously).

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No change to logic.
Single evaluation instead of twice in these if blocks now.

**Contributor Info**
Avi Weiss @thnkslprpt