### PR TITLE
Fix #71, table processing fixes

### DIFF
--- a/fsw/inc/cs_events.h
+++ b/fsw/inc/cs_events.h
@@ -1974,6 +1974,18 @@
  */
 #define CS_BKGND_COMPUTE_PROG_INF_EID 153
 
+/**
+ * \brief CS Apps Table Validate Failed Illegal State With Long Name Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  This event message is issued when CS validation for the Apps definition table finds an entry
+ *  that contains a non-terminated name field.
+ */
+#define CS_VAL_APP_DEF_TBL_LONG_NAME_ERR_EID 154
+
 /**@}*/
 
 #endif

--- a/fsw/src/cs_table_processing.c
+++ b/fsw/src/cs_table_processing.c
@@ -343,11 +343,26 @@ int32 CS_ValidateAppChecksumDefinitionTable(void *TblPtr)
     for (OuterLoop = 0; OuterLoop < CS_MAX_NUM_APP_TABLE_ENTRIES; OuterLoop++)
     {
         OuterEntry = &StartOfTable[OuterLoop];
+    }
+
+    for (OuterLoop = 0; OuterLoop < CS_MAX_NUM_APP_TABLE_ENTRIES; OuterLoop++)
+    {
+        OuterEntry = &StartOfTable[OuterLoop];
 
         StateField = OuterEntry->State;
 
-        /* Check for non-zero length for table name */
-        if (strlen(OuterEntry->Name) != 0)
+        if (memchr(OuterEntry->Name, 0, sizeof(OuterEntry->Name)) == NULL)
+        {
+            /* Not null-terminated, name is too long */
+            if (Result != CS_TABLE_ERROR)
+            {
+                CFE_EVS_SendEvent(CS_VAL_APP_DEF_TBL_LONG_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
+                                  "CS Apps Table Validate: Unterminated Name found at entry %d", (int)OuterLoop);
+                Result = CS_TABLE_ERROR;
+            }
+            BadCount++;
+        }
+        else if (strlen(OuterEntry->Name) != 0)
         {
             /* Verify valid state definition */
             if (((StateField == CS_STATE_EMPTY) || (StateField == CS_STATE_ENABLED) ||
@@ -356,9 +371,9 @@ int32 CS_ValidateAppChecksumDefinitionTable(void *TblPtr)
                 DuplicateFound = false;
 
                 /* Verify the name field is not duplicated */
-                for (InnerLoop = OuterLoop + 1; InnerLoop < CS_MAX_NUM_APP_TABLE_ENTRIES; InnerLoop++)
+                for (InnerLoop = 0; InnerLoop < OuterLoop; InnerLoop++)
                 {
-                    if (strncmp(OuterEntry->Name, (&StartOfTable[InnerLoop])->Name, CFE_TBL_MAX_FULL_NAME_LEN) == 0)
+                    if (strcmp(OuterEntry->Name, StartOfTable[InnerLoop].Name) == 0)
                     {
                         if (DuplicateFound != true)
                         {

--- a/unit-test/cs_table_processing_tests.c
+++ b/unit-test/cs_table_processing_tests.c
@@ -1261,6 +1261,21 @@ void CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateEmptyName(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
+void CS_ValidateAppChecksumDefinitionTable_Test_LongName(void)
+{
+    memset(CS_AppData.DefAppTblPtr[0].Name, 'x', sizeof(CS_AppData.DefAppTblPtr[0].Name));
+    memset(CS_AppData.DefAppTblPtr[1].Name, 'y', sizeof(CS_AppData.DefAppTblPtr[1].Name));
+
+    UtAssert_INT32_EQ(CS_ValidateAppChecksumDefinitionTable(CS_AppData.DefAppTblPtr), CS_TABLE_ERROR);
+
+    /* Verify results */
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_VAL_APP_DEF_TBL_LONG_NAME_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_VAL_APP_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_INFORMATION);
+}
+
 void CS_ValidateAppChecksumDefinitionTable_Test_TableErrorResult(void)
 {
     int32 Result;
@@ -3388,6 +3403,8 @@ void UtTest_Setup(void)
                "CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateField");
     UtTest_Add(CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateEmptyName, CS_Test_Setup, CS_Test_TearDown,
                "CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateEmptyName");
+    UtTest_Add(CS_ValidateAppChecksumDefinitionTable_Test_LongName, CS_Test_Setup, CS_Test_TearDown,
+               "CS_ValidateAppChecksumDefinitionTable_Test_LongName");
     UtTest_Add(CS_ValidateAppChecksumDefinitionTable_Test_TableErrorResult, CS_Test_Setup, CS_Test_TearDown,
                "CS_ValidateAppChecksumDefinitionTable_Test_TableErrorResult");
     UtTest_Add(CS_ValidateAppChecksumDefinitionTable_Test_UndefTableErrorResult, CS_Test_Setup, CS_Test_TearDown,


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
First check that table name is null-terminated before comparing any strings, then the normal strcmp() can be safely used.  This reverses the direction of the inner check loop, so it is reading entries that have been already validated otherwise, rather than reading entries that have not yet been checked at all.

**Testing performed**
Build and run CS, run all tests.  Confirm table validation working as expected.

**Expected behavior changes**
Un-terminated/Long table names will be detected as part of validation.  Importantly, the code no longer invokes `strlen()` on a string that has not been checked for null termination.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
