### PR TITLE
Fix #71, table processing fixes

### DIFF
--- a/fsw/inc/cs_events.h
+++ b/fsw/inc/cs_events.h
@@ -1974,6 +1974,18 @@
  */
 #define CS_BKGND_COMPUTE_PROG_INF_EID 153
 
+/**
+ * \brief CS Apps Table Validate Failed Illegal State With Long Name Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  This event message is issued when CS validation for the Apps definition table finds an entry
+ *  that contains a non-terminated name field.
+ */
+#define CS_VAL_APP_DEF_TBL_LONG_NAME_ERR_EID 154
+
 /**@}*/
 
 #endif


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
First check that table name is null-terminated before comparing any strings, then the normal strcmp() can be safely used.  This reverses the direction of the inner check loop, so it is reading entries that have been already validated otherwise, rather than reading entries that have not yet been checked at all.

Fixes #61
Fixes #71

**Testing performed**
Build and run CS and all tests

**Expected behavior changes**
Un-terminated/Long table names will be detected as part of validation.  Importantly, the code no longer invokes `strlen()` on a string that has not been checked for null termination.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
