### PR TITLE
Fix #76, Move function prototypes out of `cs_app.c`

### DIFF
--- a/fsw/src/cs_app.c
+++ b/fsw/src/cs_app.c
@@ -46,90 +46,10 @@
 
 /*************************************************************************
 **
-** Exported data
+** CS global application data
 **
 **************************************************************************/
 CS_AppData_t CS_AppData;
-
-/**
- * \brief Initialize the Checksum CFS application
- *
- *  \par Description
- *       Checksum application initialization routine. This
- *       function performs all the required startup steps to
- *       get the application registered with the cFE services so
- *       it can begin to receive command messages and begin
- *       background checksumming.
- *
- *  \par Assumptions, External Events, and Notes:
- *       None
- *
- * \return Execution status, see \ref CFEReturnCodes
- * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
- */
-int32 CS_AppInit(void);
-
-/**
- * \brief Process a command pipe message
- *
- *  \par Description
- *       Processes a single software bus command pipe message. Checks
- *       the message and command IDs and calls the appropriate routine
- *       to handle the command.
- *
- *  \par Assumptions, External Events, and Notes:
- *       None
- *
- *  \param [in]   BufPtr   A #CFE_SB_Buffer_t* pointer that
- *                         references the software bus message.  The
- *                         calling function verifies that BufPtr is
- *                         non-null.
- *
- * \return Execution status, see \ref CFEReturnCodes
- * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
- */
-int32 CS_AppPipe(const CFE_SB_Buffer_t *BufPtr);
-
-/**
- * \brief Process housekeeping request
- *
- *  \par Description
- *       Processes an on-board housekeeping request message.
- *
- *  \par Assumptions, External Events, and Notes:
- *       This command does not affect the command execution counter
- *
- *  \param[in] CmdPtr Command pointer, verified non-null in CS_AppMain
- */
-void CS_HousekeepingCmd(const CS_NoArgsCmd_t *CmdPtr);
-
-/**
- * \brief Command packet processor
- *
- * \par Description
- *      Processes all CS commands
- *
- * \param [in] BufPtr A CFE_SB_Buffer_t* pointer that
- *                    references the software bus pointer. The
- *                    BufPtr is verified non-null in CS_AppMain.
- */
-void CS_ProcessCmd(const CFE_SB_Buffer_t *BufPtr);
-
-#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-/**
- * \brief Restore tables states from CDS if enabled
- *
- *  \par Description
- *       Restore CS state of tables from CDS
- *
- *  \par Assumptions, External Events, and Notes:
- *       None
- *
- * \return Execution status, see \ref CFEReturnCodes
- * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
- */
-int32 CS_CreateRestoreStatesFromCDS(void);
-#endif
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */

--- a/fsw/src/cs_app.h
+++ b/fsw/src/cs_app.h
@@ -221,4 +221,84 @@ void CS_UpdateCDS(void);
 
 #endif
 
+/**
+ * \brief Initialize the Checksum CFS application
+ *
+ *  \par Description
+ *       Checksum application initialization routine. This
+ *       function performs all the required startup steps to
+ *       get the application registered with the cFE services so
+ *       it can begin to receive command messages and begin
+ *       background checksumming.
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *       None
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
+ */
+int32 CS_AppInit(void);
+
+/**
+ * \brief Process a command pipe message
+ *
+ *  \par Description
+ *       Processes a single software bus command pipe message. Checks
+ *       the message and command IDs and calls the appropriate routine
+ *       to handle the command.
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *       None
+ *
+ *  \param [in]   BufPtr   A #CFE_SB_Buffer_t* pointer that
+ *                         references the software bus message.  The
+ *                         calling function verifies that BufPtr is
+ *                         non-null.
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
+ */
+int32 CS_AppPipe(const CFE_SB_Buffer_t *BufPtr);
+
+/**
+ * \brief Process housekeeping request
+ *
+ *  \par Description
+ *       Processes an on-board housekeeping request message.
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *       This command does not affect the command execution counter
+ *
+ *  \param[in] CmdPtr Command pointer, verified non-null in CS_AppMain
+ */
+void CS_HousekeepingCmd(const CS_NoArgsCmd_t *CmdPtr);
+
+/**
+ * \brief Command packet processor
+ *
+ * \par Description
+ *      Processes all CS commands
+ *
+ * \param [in] BufPtr A CFE_SB_Buffer_t* pointer that
+ *                    references the software bus pointer. The
+ *                    BufPtr is verified non-null in CS_AppMain.
+ */
+void CS_ProcessCmd(const CFE_SB_Buffer_t *BufPtr);
+
+#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
+/**
+ * \brief Restore tables states from CDS if enabled
+ *
+ *  \par Description
+ *       Restore CS state of tables from CDS
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *       None
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
+ */
+int32 CS_CreateRestoreStatesFromCDS(void);
+#endif
+
 #endif

--- a/unit-test/cs_app_tests.c
+++ b/unit-test/cs_app_tests.c
@@ -82,14 +82,6 @@ void CS_APP_TEST_CFE_ES_RestoreFromCDS_Handler(void *UserObj, UT_EntryKey_t Func
     DataStoreBuffer[5] = CS_STATE_ENABLED;
 }
 
-int32 CS_AppInit(void);
-
-int32 CS_AppPipe(CFE_SB_Buffer_t *BufPtr);
-
-void CS_HousekeepingCmd(const CS_NoArgsCmd_t *CmdPtr);
-
-int32 CS_CreateRestoreStatesFromCDS(void);
-
 void CS_App_TestCmdTlmAlign(void)
 {
     /* Ensures the command and telemetry structures are padded to and aligned to 32-bits */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #76
  - Moves the function prototypes that were in `cs_app.c` over into the `cs_app.h` header file.

Moving them to the header file also means they don't need to be separately declared in the test files:
https://github.com/nasa/CS/blob/591d0823eaf1240eafaff67b8f7398a4efd1e956/unit-test/cs_app_tests.c#L85-L93

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change to app behavior.
CS now more consistent with the other cFS apps.

**Contributor Info**
Avi Weiss @thnkslprpt