### PR TITLE
Fix #78, Convert `int32` return codes and variables to `CFE_Status_t`

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -3,7 +3,7 @@ name: CodeQl Analysis
 on:
   push:
   pull_request:
-  
+
 
 jobs:
   codeql:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -9,4 +9,3 @@ jobs:
   format-check:
     name: Run format check
     uses: nasa/cFS/.github/workflows/format-check.yml@main
-    

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,4 +10,4 @@ jobs:
     name: Run cppcheck
     uses: nasa/cFS/.github/workflows/static-analysis.yml@main
     with:
-      strict-dir-list: './fsw'    
+      strict-dir-list: './fsw'

--- a/fsw/inc/cs_tbldefs.h
+++ b/fsw/inc/cs_tbldefs.h
@@ -162,7 +162,7 @@ typedef struct
  *  \retval #CFE_SUCCESS    \copydoc CFE_SUCCESS
  *  \retval #CS_TABLE_ERROR \copydoc CS_TABLE_ERROR
  */
-int32 CS_ValidateEepromChecksumDefinitionTable(void *TblPtr);
+CFE_Status_t CS_ValidateEepromChecksumDefinitionTable(void *TblPtr);
 
 /**
  * \brief Validate Memory definition table
@@ -180,7 +180,7 @@ int32 CS_ValidateEepromChecksumDefinitionTable(void *TblPtr);
  *  \retval #CFE_SUCCESS    \copydoc CFE_SUCCESS
  *  \retval #CS_TABLE_ERROR \copydoc CS_TABLE_ERROR
  */
-int32 CS_ValidateMemoryChecksumDefinitionTable(void *TblPtr);
+CFE_Status_t CS_ValidateMemoryChecksumDefinitionTable(void *TblPtr);
 
 /**
  * \brief Validate Tables definition table
@@ -198,7 +198,7 @@ int32 CS_ValidateMemoryChecksumDefinitionTable(void *TblPtr);
  *  \retval #CFE_SUCCESS    \copydoc CFE_SUCCESS
  *  \retval #CS_TABLE_ERROR \copydoc CS_TABLE_ERROR
  */
-int32 CS_ValidateTablesChecksumDefinitionTable(void *TblPtr);
+CFE_Status_t CS_ValidateTablesChecksumDefinitionTable(void *TblPtr);
 
 /**
  * \brief Validate App definition table
@@ -216,7 +216,7 @@ int32 CS_ValidateTablesChecksumDefinitionTable(void *TblPtr);
  *  \retval #CFE_SUCCESS    \copydoc CFE_SUCCESS
  *  \retval #CS_TABLE_ERROR \copydoc CS_TABLE_ERROR
  */
-int32 CS_ValidateAppChecksumDefinitionTable(void *TblPtr);
+CFE_Status_t CS_ValidateAppChecksumDefinitionTable(void *TblPtr);
 
 /**
  * \brief Processes a new definition table for EEPROM or Memory tables
@@ -363,11 +363,12 @@ void CS_ProcessNewAppDefinitionTable(const CS_Def_App_Table_Entry_t *DefinitionT
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handle_t *ResultsTableHandle,
-                   void *DefinitionTblPtr, void *ResultsTblPtr, const uint16 Table, const char *DefinitionTableName,
-                   const char *ResultsTableName, const uint16 NumEntries, const char *DefinitionTableFileName,
-                   const void *DefaultDefTableAddress, const uint16 SizeofDefinitionTableEntry,
-                   const uint16 SizeofResultsTableEntry, const CFE_TBL_CallbackFuncPtr_t CallBackFunction);
+CFE_Status_t CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handle_t *ResultsTableHandle,
+                          void *DefinitionTblPtr, void *ResultsTblPtr, const uint16 Table,
+                          const char *DefinitionTableName, const char *ResultsTableName, const uint16 NumEntries,
+                          const char *DefinitionTableFileName, const void *DefaultDefTableAddress,
+                          const uint16 SizeofDefinitionTableEntry, const uint16 SizeofResultsTableEntry,
+                          const CFE_TBL_CallbackFuncPtr_t CallBackFunction);
 
 /**
  * \brief Handles table updates for all CS tables
@@ -398,7 +399,9 @@ int32 CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handle_t *Re
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 CS_HandleTableUpdate(void *DefinitionTblPtr, void *ResultsTblPtr, const CFE_TBL_Handle_t DefinitionTableHandle,
-                           const CFE_TBL_Handle_t ResultsTableHandle, const uint16 Table, const uint16 NumEntries);
+CFE_Status_t CS_HandleTableUpdate(void *DefinitionTblPtr, void *ResultsTblPtr,
+                                  const CFE_TBL_Handle_t DefinitionTableHandle,
+                                  const CFE_TBL_Handle_t ResultsTableHandle, const uint16 Table,
+                                  const uint16 NumEntries);
 
 #endif

--- a/fsw/src/cs_app.c
+++ b/fsw/src/cs_app.c
@@ -58,7 +58,7 @@ CS_AppData_t CS_AppData;
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_AppMain(void)
 {
-    int32            Result = 0;
+    CFE_Status_t     Result = 0;
     CFE_SB_Buffer_t *BufPtr = NULL;
 
     /* Performance Log (start time counter) */
@@ -145,9 +145,9 @@ void CS_AppMain(void)
 /* CS Application initialization function                          */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CS_AppInit(void)
+CFE_Status_t CS_AppInit(void)
 {
-    int32 Result = CFE_SUCCESS;
+    CFE_Status_t Result = CFE_SUCCESS;
 
     /* Register for event services */
     Result = CFE_EVS_Register(NULL, 0, 0);
@@ -219,10 +219,10 @@ int32 CS_AppInit(void)
 /* CS's command pipe processing                                    */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CS_AppPipe(const CFE_SB_Buffer_t *BufPtr)
+CFE_Status_t CS_AppPipe(const CFE_SB_Buffer_t *BufPtr)
 {
     CFE_SB_MsgId_t MessageID = CFE_SB_INVALID_MSG_ID;
-    int32          Result    = CFE_SUCCESS;
+    CFE_Status_t   Result    = CFE_SUCCESS;
 
     CFE_MSG_GetMsgId(&BufPtr->Msg, &MessageID);
 
@@ -492,12 +492,12 @@ void CS_HousekeepingCmd(const CS_NoArgsCmd_t *CmdPtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 CS_CreateRestoreStatesFromCDS(void)
+CFE_Status_t CS_CreateRestoreStatesFromCDS(void)
 {
     /* Store task ena/dis state of tables in CDS */
-    uint8 DataStoreBuffer[CS_NUM_DATA_STORE_STATES];
-    int32 Result;
-    int32 EventId = 0;
+    uint8        DataStoreBuffer[CS_NUM_DATA_STORE_STATES];
+    CFE_Status_t Result;
+    int32        EventId = 0;
 
     memset(DataStoreBuffer, 0, sizeof(DataStoreBuffer));
 
@@ -589,8 +589,8 @@ int32 CS_CreateRestoreStatesFromCDS(void)
 void CS_UpdateCDS(void)
 {
     /* Store table ena/dis state in CDS */
-    uint8 DataStoreBuffer[CS_NUM_DATA_STORE_STATES];
-    int32 Result;
+    uint8        DataStoreBuffer[CS_NUM_DATA_STORE_STATES];
+    CFE_Status_t Result;
 
     /*
     ** Handle is defined when CDS is active...

--- a/fsw/src/cs_app.h
+++ b/fsw/src/cs_app.h
@@ -52,7 +52,6 @@
  * \name CS Error Codes
  * \{
  */
-#define CS_SUCCESS       0    /**< \brief Success return code when a checksum compare did not fail */
 #define CS_ERROR         (-1) /**< \brief Error code returned when a checksum compare failed */
 #define CS_ERR_NOT_FOUND (-2) /**< \brief Error code returned the app or table requested could not be found */
 #define CS_TABLE_ERROR   (-3) /**< \brief Error code returned on table validation error */
@@ -237,7 +236,7 @@ void CS_UpdateCDS(void);
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 CS_AppInit(void);
+CFE_Status_t CS_AppInit(void);
 
 /**
  * \brief Process a command pipe message
@@ -258,7 +257,7 @@ int32 CS_AppInit(void);
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 CS_AppPipe(const CFE_SB_Buffer_t *BufPtr);
+CFE_Status_t CS_AppPipe(const CFE_SB_Buffer_t *BufPtr);
 
 /**
  * \brief Process housekeeping request
@@ -298,7 +297,7 @@ void CS_ProcessCmd(const CFE_SB_Buffer_t *BufPtr);
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 CS_CreateRestoreStatesFromCDS(void);
+CFE_Status_t CS_CreateRestoreStatesFromCDS(void);
 #endif
 
 #endif

--- a/fsw/src/cs_app_cmds.c
+++ b/fsw/src/cs_app_cmds.c
@@ -149,7 +149,7 @@ void CS_RecomputeBaselineAppCmd(const CS_AppNameCmd_t *CmdPtr)
     size_t ExpectedLength = sizeof(CS_AppNameCmd_t);
 
     CFE_ES_TaskId_t           ChildTaskID;
-    int32                     Status;
+    CFE_Status_t              Status;
     CS_Res_App_Table_Entry_t *ResultsEntry;
     char                      Name[OS_MAX_API_NAME];
 

--- a/fsw/src/cs_cmds.c
+++ b/fsw/src/cs_cmds.c
@@ -421,7 +421,7 @@ void CS_RecomputeBaselineCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
     /* command verification variables */
     size_t          ExpectedLength = sizeof(CS_NoArgsCmd_t);
     CFE_ES_TaskId_t ChildTaskID;
-    int32           Status;
+    CFE_Status_t    Status;
 
     /* Verify command packet length... */
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))
@@ -475,7 +475,7 @@ void CS_RecomputeBaselineOSCmd(const CS_NoArgsCmd_t *CmdPtr)
     /* command verification variables */
     size_t          ExpectedLength = sizeof(CS_NoArgsCmd_t);
     CFE_ES_TaskId_t ChildTaskID;
-    int32           Status;
+    CFE_Status_t    Status;
 
     /* Verify command packet length... */
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))
@@ -527,7 +527,7 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
     /* command verification variables */
     size_t          ExpectedLength = sizeof(CS_OneShotCmd_t);
     CFE_ES_TaskId_t ChildTaskID;
-    int32           Status;
+    CFE_Status_t    Status;
 
     /* Verify command packet length... */
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))
@@ -606,8 +606,8 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
 void CS_CancelOneShotCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
     /* command verification variables */
-    size_t ExpectedLength = sizeof(CS_NoArgsCmd_t);
-    int32  Status;
+    size_t       ExpectedLength = sizeof(CS_NoArgsCmd_t);
+    CFE_Status_t Status;
 
     /* Verify command packet length... */
     if (CS_VerifyCmdLength(&CmdPtr->CmdHeader.Msg, ExpectedLength))

--- a/fsw/src/cs_compute.c
+++ b/fsw/src/cs_compute.c
@@ -45,16 +45,16 @@
 /* and cFE core code segments                                      */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CS_ComputeEepromMemory(CS_Res_EepromMemory_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue,
-                             bool *DoneWithEntry)
+CFE_Status_t CS_ComputeEepromMemory(CS_Res_EepromMemory_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue,
+                                    bool *DoneWithEntry)
 {
-    uint32  OffsetIntoCurrEntry     = 0;
-    cpuaddr FirstAddrThisCycle      = 0;
-    uint32  NumBytesThisCycle       = 0;
-    int32   NumBytesRemainingCycles = 0;
-    uint32  NewChecksumValue        = 0;
-    int32   Status                  = CS_SUCCESS;
-    *DoneWithEntry                  = false;
+    uint32       OffsetIntoCurrEntry     = 0;
+    cpuaddr      FirstAddrThisCycle      = 0;
+    uint32       NumBytesThisCycle       = 0;
+    int32        NumBytesRemainingCycles = 0;
+    uint32       NewChecksumValue        = 0;
+    CFE_Status_t Status                  = CFE_SUCCESS;
+    *DoneWithEntry                       = false;
 
     /* By the time we get here, we know we have an enabled entry */
 
@@ -116,18 +116,18 @@ int32 CS_ComputeEepromMemory(CS_Res_EepromMemory_Table_Entry_t *ResultsEntry, ui
 /* CS function that computes the checksum for Tables               */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CS_ComputeTables(CS_Res_Tables_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue, bool *DoneWithEntry)
+CFE_Status_t CS_ComputeTables(CS_Res_Tables_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue, bool *DoneWithEntry)
 {
-    uint32  OffsetIntoCurrEntry     = 0;
-    cpuaddr FirstAddrThisCycle      = 0;
-    uint32  NumBytesThisCycle       = 0;
-    int32   NumBytesRemainingCycles = 0;
-    uint32  NewChecksumValue        = 0;
-    int32   Status                  = CS_SUCCESS;
-    int32   Result                  = CS_SUCCESS;
-    int32   ResultShare             = 0;
-    int32   ResultGetInfo           = 0;
-    int32   ResultGetAddress        = 0;
+    uint32       OffsetIntoCurrEntry     = 0;
+    cpuaddr      FirstAddrThisCycle      = 0;
+    uint32       NumBytesThisCycle       = 0;
+    int32        NumBytesRemainingCycles = 0;
+    uint32       NewChecksumValue        = 0;
+    CFE_Status_t Status                  = CFE_SUCCESS;
+    CFE_Status_t Result                  = CFE_SUCCESS;
+    CFE_Status_t ResultShare             = 0;
+    CFE_Status_t ResultGetInfo           = 0;
+    CFE_Status_t ResultGetAddress        = 0;
 
     /* variables to get the table address */
     CFE_TBL_Handle_t LocalTblHandle = CFE_TBL_BAD_TABLE_HANDLE;
@@ -304,18 +304,18 @@ int32 CS_ComputeTables(CS_Res_Tables_Table_Entry_t *ResultsEntry, uint32 *Comput
 /* CS function that computes the checksum for Apps                 */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CS_ComputeApp(CS_Res_App_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue, bool *DoneWithEntry)
+CFE_Status_t CS_ComputeApp(CS_Res_App_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue, bool *DoneWithEntry)
 {
-    uint32  OffsetIntoCurrEntry     = 0;
-    cpuaddr FirstAddrThisCycle      = 0;
-    uint32  NumBytesThisCycle       = 0;
-    int32   NumBytesRemainingCycles = 0;
-    uint32  NewChecksumValue        = 0;
-    int32   Status                  = CS_SUCCESS;
-    int32   Result;
-    int32   ResultGetResourceID   = CS_ERROR;
-    int32   ResultGetResourceInfo = CS_ERROR;
-    int32   ResultAddressValid    = false;
+    uint32       OffsetIntoCurrEntry     = 0;
+    cpuaddr      FirstAddrThisCycle      = 0;
+    uint32       NumBytesThisCycle       = 0;
+    int32        NumBytesRemainingCycles = 0;
+    uint32       NewChecksumValue        = 0;
+    CFE_Status_t Status                  = CFE_SUCCESS;
+    CFE_Status_t Result;
+    CFE_Status_t ResultGetResourceID   = CS_ERROR;
+    CFE_Status_t ResultGetResourceInfo = CS_ERROR;
+    int32        ResultAddressValid    = false;
 
     /* variables to get applications address */
     CFE_ResourceId_t ResourceID = CFE_RESOURCEID_UNDEFINED;
@@ -573,7 +573,7 @@ void CS_RecomputeAppChildTask(void)
     CS_Res_App_Table_Entry_t *ResultsEntry     = NULL;
     uint16                    PreviousState    = CS_STATE_EMPTY;
     bool                      DoneWithEntry    = false;
-    int32                     Status           = CS_ERROR;
+    CFE_Status_t              Status           = CS_ERROR;
     uint16                    PreviousDefState = CS_STATE_EMPTY;
     bool                      DefEntryFound    = false;
     uint16                    DefEntryID       = 0;
@@ -679,7 +679,7 @@ void CS_RecomputeTablesChildTask(void)
     CS_Res_Tables_Table_Entry_t *ResultsEntry     = NULL;
     uint16                       PreviousState    = CS_STATE_EMPTY;
     bool                         DoneWithEntry    = false;
-    int32                        Status           = CS_ERROR;
+    CFE_Status_t                 Status           = CS_ERROR;
     uint16                       PreviousDefState = CS_STATE_EMPTY;
     bool                         DefEntryFound    = false;
     uint16                       DefEntryID       = 0;

--- a/fsw/src/cs_compute.h
+++ b/fsw/src/cs_compute.h
@@ -57,11 +57,11 @@
  *                                     completed during this call.
  *
  * \return Execution status
- * \retval #CS_SUCCESS \copybrief CS_SUCCESS
+ * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  * \retval #CS_ERROR   \copybrief CS_ERROR
  */
-int32 CS_ComputeEepromMemory(CS_Res_EepromMemory_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue,
-                             bool *DoneWithEntry);
+CFE_Status_t CS_ComputeEepromMemory(CS_Res_EepromMemory_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue,
+                                    bool *DoneWithEntry);
 
 /**
  * \brief Computes checksums on tables
@@ -86,11 +86,11 @@ int32 CS_ComputeEepromMemory(CS_Res_EepromMemory_Table_Entry_t *ResultsEntry, ui
  *                                     completed during this call.
  *
  * \return Execution status
- * \retval #CS_SUCCESS       \copybrief CS_SUCCESS
+ * \retval #CFE_SUCCESS       \copybrief CFE_SUCCESS
  * \retval #CS_ERROR         \copybrief CS_ERROR
  * \retval #CS_ERR_NOT_FOUND \copydoc CS_ERR_NOT_FOUND
  */
-int32 CS_ComputeTables(CS_Res_Tables_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue, bool *DoneWithEntry);
+CFE_Status_t CS_ComputeTables(CS_Res_Tables_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue, bool *DoneWithEntry);
 
 /**
  * \brief Computes checksums on applications
@@ -115,11 +115,11 @@ int32 CS_ComputeTables(CS_Res_Tables_Table_Entry_t *ResultsEntry, uint32 *Comput
  *                                     completed during this call.
  *
  * \return Execution status
- * \retval #CS_SUCCESS       \copybrief CS_SUCCESS
+ * \retval #CFE_SUCCESS       \copybrief CFE_SUCCESS
  * \retval #CS_ERROR         \copybrief CS_ERROR
  * \retval #CS_ERR_NOT_FOUND \copydoc CS_ERR_NOT_FOUND
  */
-int32 CS_ComputeApp(CS_Res_App_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue, bool *DoneWithEntry);
+CFE_Status_t CS_ComputeApp(CS_Res_App_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue, bool *DoneWithEntry);
 
 /**
  * \brief Child task main function for recomputing  baselines for

--- a/fsw/src/cs_eeprom_cmds.c
+++ b/fsw/src/cs_eeprom_cmds.c
@@ -169,7 +169,7 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
     size_t ExpectedLength = sizeof(CS_EntryCmd_t);
 
     CFE_ES_TaskId_t ChildTaskID = CFE_ES_TASKID_UNDEFINED;
-    int32           Status      = CS_ERROR;
+    CFE_Status_t    Status      = CS_ERROR;
     uint16          EntryID     = 0;
     uint16          State       = CS_STATE_EMPTY;
 

--- a/fsw/src/cs_init.c
+++ b/fsw/src/cs_init.c
@@ -37,9 +37,9 @@
 /* CS Software Bus Setup                                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CS_SbInit(void)
+CFE_Status_t CS_SbInit(void)
 {
-    int32 Result = CFE_SUCCESS;
+    CFE_Status_t Result = CFE_SUCCESS;
 
     /* Initialize app configuration data */
     strncpy(CS_AppData.PipeName, CS_CMD_PIPE_NAME, CS_CMD_PIPE_NAME_LEN);
@@ -97,9 +97,9 @@ int32 CS_SbInit(void)
 /* CS Table Initialization                                         */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CS_InitAllTables(void)
+CFE_Status_t CS_InitAllTables(void)
 {
-    int32 ResultInit = CFE_SUCCESS;
+    CFE_Status_t ResultInit = CFE_SUCCESS;
 
     ResultInit = CS_TableInit(&CS_AppData.DefEepromTableHandle, &CS_AppData.ResEepromTableHandle,
                               (void *)&CS_AppData.DefEepromTblPtr, (void *)&CS_AppData.ResEepromTblPtr, CS_EEPROM_TABLE,

--- a/fsw/src/cs_init.h
+++ b/fsw/src/cs_init.h
@@ -44,7 +44,7 @@
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 CS_SbInit(void);
+CFE_Status_t CS_SbInit(void);
 
 /**
  * \brief Initializes the tables for the Checksum Application
@@ -58,7 +58,7 @@ int32 CS_SbInit(void);
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 CS_InitAllTables(void);
+CFE_Status_t CS_InitAllTables(void);
 
 /**
  * \brief Initializes the cFE and OS segments for the Checksum Application

--- a/fsw/src/cs_memory_cmds.c
+++ b/fsw/src/cs_memory_cmds.c
@@ -167,7 +167,7 @@ void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
     /* command verification variables */
     size_t          ExpectedLength = sizeof(CS_EntryCmd_t);
     CFE_ES_TaskId_t ChildTaskID    = CFE_ES_TASKID_UNDEFINED;
-    int32           Status         = CS_ERROR;
+    CFE_Status_t    Status         = CS_ERROR;
     uint16          EntryID        = 0;
     uint16          State          = CS_STATE_EMPTY;
 

--- a/fsw/src/cs_table_cmds.c
+++ b/fsw/src/cs_table_cmds.c
@@ -151,7 +151,7 @@ void CS_RecomputeBaselineTablesCmd(const CS_TableNameCmd_t *CmdPtr)
     size_t ExpectedLength = sizeof(CS_TableNameCmd_t);
 
     CFE_ES_TaskId_t              ChildTaskID;
-    int32                        Status;
+    CFE_Status_t                 Status;
     CS_Res_Tables_Table_Entry_t *ResultsEntry;
     char                         Name[CFE_TBL_MAX_FULL_NAME_LEN];
 

--- a/fsw/src/cs_table_processing.c
+++ b/fsw/src/cs_table_processing.c
@@ -45,10 +45,10 @@
 /* CS Validation Callback function for EEPROM Table                */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CS_ValidateEepromChecksumDefinitionTable(void *TblPtr)
+CFE_Status_t CS_ValidateEepromChecksumDefinitionTable(void *TblPtr)
 {
-    int32                              Result       = CFE_SUCCESS;
-    int32                              Status       = OS_ERROR;
+    CFE_Status_t                       Result       = CFE_SUCCESS;
+    CFE_Status_t                       Status       = OS_ERROR;
     CS_Def_EepromMemory_Table_Entry_t *StartOfTable = NULL;
     CS_Def_EepromMemory_Table_Entry_t *OuterEntry   = NULL;
     int32                              OuterLoop    = 0;
@@ -125,10 +125,10 @@ int32 CS_ValidateEepromChecksumDefinitionTable(void *TblPtr)
 /* CS Validation Callback function for Memory Table                */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CS_ValidateMemoryChecksumDefinitionTable(void *TblPtr)
+CFE_Status_t CS_ValidateMemoryChecksumDefinitionTable(void *TblPtr)
 {
-    int32                              Result       = CFE_SUCCESS;
-    int32                              Status       = OS_ERROR;
+    CFE_Status_t                       Result       = CFE_SUCCESS;
+    CFE_Status_t                       Status       = OS_ERROR;
     CS_Def_EepromMemory_Table_Entry_t *StartOfTable = NULL;
     CS_Def_EepromMemory_Table_Entry_t *OuterEntry   = NULL;
     int32                              OuterLoop    = 0;
@@ -209,9 +209,9 @@ int32 CS_ValidateMemoryChecksumDefinitionTable(void *TblPtr)
 /* CS Validation Callback function for Tables Table                */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CS_ValidateTablesChecksumDefinitionTable(void *TblPtr)
+CFE_Status_t CS_ValidateTablesChecksumDefinitionTable(void *TblPtr)
 {
-    int32                        Result         = CFE_SUCCESS;
+    CFE_Status_t                 Result         = CFE_SUCCESS;
     CS_Def_Tables_Table_Entry_t *StartOfTable   = NULL;
     CS_Def_Tables_Table_Entry_t *OuterEntry     = NULL;
     int32                        OuterLoop      = 0;
@@ -325,9 +325,9 @@ int32 CS_ValidateTablesChecksumDefinitionTable(void *TblPtr)
 /* CS Validation Callback function for App Table                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CS_ValidateAppChecksumDefinitionTable(void *TblPtr)
+CFE_Status_t CS_ValidateAppChecksumDefinitionTable(void *TblPtr)
 {
-    int32                     Result = CFE_SUCCESS;
+    CFE_Status_t              Result = CFE_SUCCESS;
     CS_Def_App_Table_Entry_t *StartOfTable;
     CS_Def_App_Table_Entry_t *OuterEntry;
     int32                     OuterLoop;
@@ -810,20 +810,20 @@ void CS_ProcessNewAppDefinitionTable(const CS_Def_App_Table_Entry_t *DefinitionT
 /* CS  function for initializing new tables                        */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handle_t *ResultsTableHandle,
-                   void *DefinitionTblPtr, void *ResultsTblPtr, uint16 Table, const char *DefinitionTableName,
-                   const char *ResultsTableName, uint16 NumEntries, const char *DefinitionTableFileName,
-                   const void *DefaultDefTableAddress, uint16 SizeofDefinitionTableEntry,
-                   uint16 SizeofResultsTableEntry, CFE_TBL_CallbackFuncPtr_t CallBackFunction)
+CFE_Status_t CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handle_t *ResultsTableHandle,
+                          void *DefinitionTblPtr, void *ResultsTblPtr, uint16 Table, const char *DefinitionTableName,
+                          const char *ResultsTableName, uint16 NumEntries, const char *DefinitionTableFileName,
+                          const void *DefaultDefTableAddress, uint16 SizeofDefinitionTableEntry,
+                          uint16 SizeofResultsTableEntry, CFE_TBL_CallbackFuncPtr_t CallBackFunction)
 {
-    int32     Result           = CFE_SUCCESS;
-    int32     OS_Status        = -1;
-    int32     ResultFromLoad   = OS_ERROR;
-    int32     SizeOfTable      = 0;
-    bool      LoadedFromMemory = false;
-    bool      ValidFile        = false;
-    osal_id_t Fd               = OS_OBJECT_ID_UNDEFINED;
-    char      TableType[CS_TABLETYPE_NAME_SIZE];
+    CFE_Status_t Result           = CFE_SUCCESS;
+    int32        OS_Status        = -1;
+    CFE_Status_t ResultFromLoad   = OS_ERROR;
+    int32        SizeOfTable      = 0;
+    bool         LoadedFromMemory = false;
+    bool         ValidFile        = false;
+    osal_id_t    Fd               = OS_OBJECT_ID_UNDEFINED;
+    char         TableType[CS_TABLETYPE_NAME_SIZE];
 
     strncpy(TableType, "Undef Tbl", CS_TABLETYPE_NAME_SIZE); /* Init table type */
 
@@ -954,18 +954,18 @@ int32 CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handle_t *Re
 /* CS Handles table updates                                        */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CS_HandleTableUpdate(void *DefinitionTblPtr, void *ResultsTblPtr, CFE_TBL_Handle_t DefinitionTableHandle,
-                           CFE_TBL_Handle_t ResultsTableHandle, uint16 Table, uint16 NumEntries)
+CFE_Status_t CS_HandleTableUpdate(void *DefinitionTblPtr, void *ResultsTblPtr, CFE_TBL_Handle_t DefinitionTableHandle,
+                                  CFE_TBL_Handle_t ResultsTableHandle, uint16 Table, uint16 NumEntries)
 {
-    int32 ReleaseResult1 = CFE_SUCCESS;
-    int32 ManageResult1  = CFE_SUCCESS;
-    int32 GetResult1     = CFE_SUCCESS;
-    int32 ReleaseResult2 = CFE_SUCCESS;
-    int32 ManageResult2  = CFE_SUCCESS;
-    int32 GetResult2     = CFE_SUCCESS;
-    int32 Result         = CFE_SUCCESS;
-    int32 Loop           = 0;
-    char  TableType[CS_TABLETYPE_NAME_SIZE];
+    CFE_Status_t ReleaseResult1 = CFE_SUCCESS;
+    CFE_Status_t ManageResult1  = CFE_SUCCESS;
+    CFE_Status_t GetResult1     = CFE_SUCCESS;
+    CFE_Status_t ReleaseResult2 = CFE_SUCCESS;
+    CFE_Status_t ManageResult2  = CFE_SUCCESS;
+    CFE_Status_t GetResult2     = CFE_SUCCESS;
+    CFE_Status_t Result         = CFE_SUCCESS;
+    int32        Loop           = 0;
+    char         TableType[CS_TABLETYPE_NAME_SIZE];
 
     strncpy(TableType, "Undef Tbl", CS_TABLETYPE_NAME_SIZE); /* Init table type */
 

--- a/fsw/src/cs_utils.c
+++ b/fsw/src/cs_utils.c
@@ -480,7 +480,7 @@ bool CS_BackgroundCfeCore(void)
     bool                               DoneWithCycle   = false;
     bool                               DoneWithEntry   = false;
     uint32                             ComputedCSValue = 0;
-    int32                              Status;
+    CFE_Status_t                       Status;
 
     if (CS_AppData.HkPacket.CfeCoreCSState == CS_STATE_ENABLED)
     {
@@ -547,7 +547,7 @@ bool CS_BackgroundOS(void)
     bool                               DoneWithCycle   = false;
     bool                               DoneWithEntry   = false;
     uint32                             ComputedCSValue = 0;
-    int32                              Status;
+    CFE_Status_t                       Status;
 
     if (CS_AppData.HkPacket.OSCSState == CS_STATE_ENABLED)
     {
@@ -616,7 +616,7 @@ bool CS_BackgroundEeprom(void)
     int32                              Loop;
     uint32                             EntireEepromCS;
     uint16                             CurrEntry;
-    int32                              Status;
+    CFE_Status_t                       Status;
 
     if (CS_AppData.HkPacket.EepromCSState == CS_STATE_ENABLED)
     {
@@ -689,7 +689,7 @@ bool CS_BackgroundMemory(void)
     bool                               DoneWithEntry   = false;
     uint32                             ComputedCSValue = 0;
     uint16                             CurrEntry;
-    int32                              Status;
+    CFE_Status_t                       Status;
 
     if (CS_AppData.HkPacket.MemoryCSState == CS_STATE_ENABLED)
     {
@@ -758,7 +758,7 @@ bool CS_BackgroundTables(void)
     bool                         DoneWithEntry   = false;
     uint32                       ComputedCSValue = 0;
     uint16                       CurrEntry;
-    int32                        Status;
+    CFE_Status_t                 Status;
 
     if (CS_AppData.HkPacket.TablesCSState == CS_STATE_ENABLED)
     {
@@ -835,7 +835,7 @@ bool CS_BackgroundApp(void)
     bool                      DoneWithEntry   = false;
     uint32                    ComputedCSValue = 0;
     uint16                    CurrEntry;
-    int32                     Status;
+    CFE_Status_t              Status;
 
     if (CS_AppData.HkPacket.AppCSState == CS_STATE_ENABLED)
     {
@@ -917,10 +917,10 @@ void CS_ResetTablesTblResultEntry(CS_Res_Tables_Table_Entry_t *TablesTblResultEn
 /* Update all tables                                               */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CS_HandleRoutineTableUpdates(void)
+CFE_Status_t CS_HandleRoutineTableUpdates(void)
 {
-    int32 Result    = CFE_SUCCESS;
-    int32 ErrorCode = CFE_SUCCESS;
+    CFE_Status_t Result    = CFE_SUCCESS;
+    CFE_Status_t ErrorCode = CFE_SUCCESS;
 
     if (!((CS_AppData.HkPacket.RecomputeInProgress == true) && (CS_AppData.HkPacket.OneShotInProgress == false) &&
           (CS_AppData.ChildTaskTable == CS_EEPROM_TABLE)))
@@ -1001,10 +1001,10 @@ int32 CS_HandleRoutineTableUpdates(void)
     return ErrorCode;
 }
 
-int32 CS_AttemptTableReshare(CS_Res_Tables_Table_Entry_t *ResultsEntry, CFE_TBL_Handle_t *LocalTblHandle,
-                             CFE_TBL_Info_t *TblInfo, cpuaddr *LocalAddress, int32 *ResultGetInfo)
+CFE_Status_t CS_AttemptTableReshare(CS_Res_Tables_Table_Entry_t *ResultsEntry, CFE_TBL_Handle_t *LocalTblHandle,
+                                    CFE_TBL_Info_t *TblInfo, cpuaddr *LocalAddress, int32 *ResultGetInfo)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Maybe the table came back, try and reshare it */
     Result = CFE_TBL_Share(LocalTblHandle, ResultsEntry->Name);

--- a/fsw/src/cs_utils.h
+++ b/fsw/src/cs_utils.h
@@ -480,7 +480,7 @@ void CS_ResetTablesTblResultEntry(CS_Res_Tables_Table_Entry_t *TablesTblResultEn
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 CS_HandleRoutineTableUpdates(void);
+CFE_Status_t CS_HandleRoutineTableUpdates(void);
 
 /**
  * \brief Attempts to re-share a table
@@ -497,8 +497,8 @@ int32 CS_HandleRoutineTableUpdates(void);
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS \copybrief CFE_SUCCESS
  */
-int32 CS_AttemptTableReshare(CS_Res_Tables_Table_Entry_t *ResultsEntry, CFE_TBL_Handle_t *LocalTblHandle,
-                             CFE_TBL_Info_t *TblInfo, cpuaddr *LocalAddress, int32 *ResultGetInfo);
+CFE_Status_t CS_AttemptTableReshare(CS_Res_Tables_Table_Entry_t *ResultsEntry, CFE_TBL_Handle_t *LocalTblHandle,
+                                    CFE_TBL_Info_t *TblInfo, cpuaddr *LocalAddress, int32 *ResultGetInfo);
 
 bool CS_CheckRecomputeOneshot(void);
 

--- a/unit-test/cs_app_tests.c
+++ b/unit-test/cs_app_tests.c
@@ -61,8 +61,8 @@ uint8 call_count_CFE_EVS_SendEvent;
  * Function Definitions
  */
 
-int32 CS_APP_TEST_CFE_ES_RunLoop_Hook(void *UserObj, int32 StubRetcode, uint32 CallCount,
-                                      const UT_StubContext_t *Context)
+CFE_Status_t CS_APP_TEST_CFE_ES_RunLoop_Hook(void *UserObj, int32 StubRetcode, uint32 CallCount,
+                                             const UT_StubContext_t *Context)
 {
     CS_AppData.RunStatus = CFE_ES_RunStatus_SYS_EXCEPTION;
 
@@ -484,9 +484,9 @@ void CS_AppMain_Test_AppPipeError(void)
 
 void CS_AppInit_Test_Nominal(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "CS Initialized. Version %%d.%%d.%%d.%%d");
 
@@ -518,9 +518,9 @@ void CS_AppInit_Test_Nominal(void)
 
 void CS_AppInit_Test_NominalPowerOnReset(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "CS Initialized. Version %%d.%%d.%%d.%%d");
 
@@ -596,7 +596,7 @@ void CS_AppInit_Test_NominalProcReset(void)
 
 void CS_CreateRestoreStatesFromCDS_Test_NoExistingCDS(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     CS_AppData.HkPacket.EepromCSState  = 99;
     CS_AppData.HkPacket.MemoryCSState  = 99;
@@ -628,7 +628,7 @@ void CS_CreateRestoreStatesFromCDS_Test_NoExistingCDS(void)
 
 void CS_CreateRestoreStatesFromCDS_Test_CDSSuccess(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     CS_AppData.HkPacket.EepromCSState  = 99;
     CS_AppData.HkPacket.MemoryCSState  = 99;
@@ -670,10 +670,10 @@ void CS_CreateRestoreStatesFromCDS_Test_CDSSuccess(void)
 
 void CS_CreateRestoreStatesFromCDS_Test_CDSFail(void)
 {
-    int32 Result;
-    uint8 DataStoreBuffer[CS_NUM_DATA_STORE_STATES];
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    uint8        DataStoreBuffer[CS_NUM_DATA_STORE_STATES];
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Critical Data Store access error = 0x%%08X");
 
@@ -725,10 +725,10 @@ void CS_CreateRestoreStatesFromCDS_Test_CDSFail(void)
 
 void CS_CreateRestoreStatesFromCDS_Test_CopyToCDSFail(void)
 {
-    int32 Result;
-    uint8 DataStoreBuffer[CS_NUM_DATA_STORE_STATES];
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    uint8        DataStoreBuffer[CS_NUM_DATA_STORE_STATES];
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Critical Data Store access error = 0x%%08X");
 
@@ -782,10 +782,10 @@ void CS_CreateRestoreStatesFromCDS_Test_CopyToCDSFail(void)
 
 void CS_CreateRestoreStatesFromCDS_Test_RegisterCDSFail(void)
 {
-    int32 Result;
-    uint8 DataStoreBuffer[CS_NUM_DATA_STORE_STATES];
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    uint8        DataStoreBuffer[CS_NUM_DATA_STORE_STATES];
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Critical Data Store access error = 0x%%08X");
 
@@ -841,9 +841,9 @@ void CS_CreateRestoreStatesFromCDS_Test_RegisterCDSFail(void)
 
 void CS_AppInit_Test_EVSRegisterError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedSysLogString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedSysLogString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedSysLogString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS App: Error Registering For Event Services, RC = 0x%%08X\n");
@@ -869,7 +869,7 @@ void CS_AppInit_Test_EVSRegisterError(void)
 
 void CS_AppPipe_Test_TableUpdateErrors(void)
 {
-    int32          Result;
+    CFE_Status_t   Result;
     UT_CmdBuf_t    CmdBuf;
     CFE_SB_MsgId_t TestMsgId;
     size_t         MsgSize;
@@ -898,7 +898,7 @@ void CS_AppPipe_Test_TableUpdateErrors(void)
 
 void CS_AppPipe_Test_BackgroundCycle(void)
 {
-    int32          Result;
+    CFE_Status_t   Result;
     UT_CmdBuf_t    CmdBuf;
     CFE_SB_MsgId_t TestMsgId;
     size_t         MsgSize;
@@ -926,7 +926,7 @@ void CS_AppPipe_Test_BackgroundCycle(void)
 
 void CS_AppPipe_Test_NoopCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -955,7 +955,7 @@ void CS_AppPipe_Test_NoopCmd(void)
 
 void CS_AppPipe_Test_ResetCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -984,7 +984,7 @@ void CS_AppPipe_Test_ResetCmd(void)
 
 void CS_AppPipe_Test_OneShotCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1013,7 +1013,7 @@ void CS_AppPipe_Test_OneShotCmd(void)
 
 void CS_AppPipe_Test_CancelOneShotCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1042,7 +1042,7 @@ void CS_AppPipe_Test_CancelOneShotCmd(void)
 
 void CS_AppPipe_Test_EnableAllCSCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1071,7 +1071,7 @@ void CS_AppPipe_Test_EnableAllCSCmd(void)
 
 void CS_AppPipe_Test_DisableAllCSCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1100,7 +1100,7 @@ void CS_AppPipe_Test_DisableAllCSCmd(void)
 
 void CS_AppPipe_Test_EnableCfeCoreCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1129,7 +1129,7 @@ void CS_AppPipe_Test_EnableCfeCoreCmd(void)
 
 void CS_AppPipe_Test_DisableCfeCoreCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1158,7 +1158,7 @@ void CS_AppPipe_Test_DisableCfeCoreCmd(void)
 
 void CS_AppPipe_Test_ReportBaselineCfeCoreCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1187,7 +1187,7 @@ void CS_AppPipe_Test_ReportBaselineCfeCoreCmd(void)
 
 void CS_AppPipe_Test_RecomputeBaselineCfeCoreCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1216,7 +1216,7 @@ void CS_AppPipe_Test_RecomputeBaselineCfeCoreCmd(void)
 
 void CS_AppPipe_Test_EnableOSCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1245,7 +1245,7 @@ void CS_AppPipe_Test_EnableOSCmd(void)
 
 void CS_AppPipe_Test_DisableOSCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1274,7 +1274,7 @@ void CS_AppPipe_Test_DisableOSCmd(void)
 
 void CS_AppPipe_Test_ReportBaselineOSCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1303,7 +1303,7 @@ void CS_AppPipe_Test_ReportBaselineOSCmd(void)
 
 void CS_AppPipe_Test_RecomputeBaselineOSCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1332,7 +1332,7 @@ void CS_AppPipe_Test_RecomputeBaselineOSCmd(void)
 
 void CS_AppPipe_Test_EnableEepromCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1361,7 +1361,7 @@ void CS_AppPipe_Test_EnableEepromCmd(void)
 
 void CS_AppPipe_Test_DisableEepromCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1390,7 +1390,7 @@ void CS_AppPipe_Test_DisableEepromCmd(void)
 
 void CS_AppPipe_Test_ReportBaselineEntryIDEepromCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1419,7 +1419,7 @@ void CS_AppPipe_Test_ReportBaselineEntryIDEepromCmd(void)
 
 void CS_AppPipe_Test_RecomputeBaselineEepromCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1448,7 +1448,7 @@ void CS_AppPipe_Test_RecomputeBaselineEepromCmd(void)
 
 void CS_AppPipe_Test_EnableEntryIDEepromCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1477,7 +1477,7 @@ void CS_AppPipe_Test_EnableEntryIDEepromCmd(void)
 
 void CS_AppPipe_Test_DisableEntryIDEepromCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1506,7 +1506,7 @@ void CS_AppPipe_Test_DisableEntryIDEepromCmd(void)
 
 void CS_AppPipe_Test_GetEntryIDEepromCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1535,7 +1535,7 @@ void CS_AppPipe_Test_GetEntryIDEepromCmd(void)
 
 void CS_AppPipe_Test_EnableMemoryCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1564,7 +1564,7 @@ void CS_AppPipe_Test_EnableMemoryCmd(void)
 
 void CS_AppPipe_Test_DisableMemoryCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1593,7 +1593,7 @@ void CS_AppPipe_Test_DisableMemoryCmd(void)
 
 void CS_AppPipe_Test_ReportBaselineEntryIDMemoryCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1622,7 +1622,7 @@ void CS_AppPipe_Test_ReportBaselineEntryIDMemoryCmd(void)
 
 void CS_AppPipe_Test_RecomputeBaselineMemoryCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1651,7 +1651,7 @@ void CS_AppPipe_Test_RecomputeBaselineMemoryCmd(void)
 
 void CS_AppPipe_Test_EnableEntryIDMemoryCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1680,7 +1680,7 @@ void CS_AppPipe_Test_EnableEntryIDMemoryCmd(void)
 
 void CS_AppPipe_Test_DisableEntryIDMemoryCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1709,7 +1709,7 @@ void CS_AppPipe_Test_DisableEntryIDMemoryCmd(void)
 
 void CS_AppPipe_Test_GetEntryIDMemoryCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1738,7 +1738,7 @@ void CS_AppPipe_Test_GetEntryIDMemoryCmd(void)
 
 void CS_AppPipe_Test_EnableTablesCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1767,7 +1767,7 @@ void CS_AppPipe_Test_EnableTablesCmd(void)
 
 void CS_AppPipe_Test_DisableTablesCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1796,7 +1796,7 @@ void CS_AppPipe_Test_DisableTablesCmd(void)
 
 void CS_AppPipe_Test_ReportBaselineTablesCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1825,7 +1825,7 @@ void CS_AppPipe_Test_ReportBaselineTablesCmd(void)
 
 void CS_AppPipe_Test_RecomputeBaselineTablesCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1854,7 +1854,7 @@ void CS_AppPipe_Test_RecomputeBaselineTablesCmd(void)
 
 void CS_AppPipe_Test_EnableNameTablesCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1883,7 +1883,7 @@ void CS_AppPipe_Test_EnableNameTablesCmd(void)
 
 void CS_AppPipe_Test_DisableNameTablesCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1912,7 +1912,7 @@ void CS_AppPipe_Test_DisableNameTablesCmd(void)
 
 void CS_AppPipe_Test_EnableAppCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1941,7 +1941,7 @@ void CS_AppPipe_Test_EnableAppCmd(void)
 
 void CS_AppPipe_Test_DisableAppCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1970,7 +1970,7 @@ void CS_AppPipe_Test_DisableAppCmd(void)
 
 void CS_AppPipe_Test_ReportBaselineAppCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -1999,7 +1999,7 @@ void CS_AppPipe_Test_ReportBaselineAppCmd(void)
 
 void CS_AppPipe_Test_RecomputeBaselineAppCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -2028,7 +2028,7 @@ void CS_AppPipe_Test_RecomputeBaselineAppCmd(void)
 
 void CS_AppPipe_Test_EnableNameAppCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -2057,7 +2057,7 @@ void CS_AppPipe_Test_EnableNameAppCmd(void)
 
 void CS_AppPipe_Test_DisableNameAppCmd(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -2086,7 +2086,7 @@ void CS_AppPipe_Test_DisableNameAppCmd(void)
 
 void CS_AppPipe_Test_InvalidCCError(void)
 {
-    int32             Result;
+    CFE_Status_t      Result;
     UT_CmdBuf_t       CmdBuf;
     CFE_SB_MsgId_t    TestMsgId;
     CFE_MSG_FcnCode_t FcnCode;
@@ -2127,7 +2127,7 @@ void CS_AppPipe_Test_InvalidCCError(void)
 
 void CS_AppPipe_Test_InvalidMIDError(void)
 {
-    int32          Result;
+    CFE_Status_t   Result;
     UT_CmdBuf_t    CmdBuf;
     CFE_SB_MsgId_t TestMsgId;
     int32          strCmpResult;

--- a/unit-test/cs_cmds_tests.c
+++ b/unit-test/cs_cmds_tests.c
@@ -43,9 +43,9 @@ uint8 call_count_CFE_EVS_SendEvent;
  * Function Definitions
  */
 
-int32 CS_CMDS_TEST_CFE_ES_CreateChildTaskHook(uint32 *TaskIdPtr, const char *TaskName,
-                                              CFE_ES_ChildTaskMainFuncPtr_t FunctionPtr, uint32 *StackPtr,
-                                              uint32 StackSize, uint32 Priority, uint32 Flags)
+CFE_Status_t CS_CMDS_TEST_CFE_ES_CreateChildTaskHook(uint32 *TaskIdPtr, const char *TaskName,
+                                                     CFE_ES_ChildTaskMainFuncPtr_t FunctionPtr, uint32 *StackPtr,
+                                                     uint32 StackSize, uint32 Priority, uint32 Flags)
 {
     *TaskIdPtr = 5;
 

--- a/unit-test/cs_compute_tests.c
+++ b/unit-test/cs_compute_tests.c
@@ -43,16 +43,16 @@ uint8 call_count_CFE_EVS_SendEvent;
  * Function Definitions
  */
 
-int32 CS_COMPUTE_TEST_CFE_TBL_GetAddressHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
-                                             const UT_StubContext_t *Context)
+CFE_Status_t CS_COMPUTE_TEST_CFE_TBL_GetAddressHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
+                                                    const UT_StubContext_t *Context)
 {
     /* This function exists so that one return code can be set for the 1st run and a different for the 2nd run */
 
     return CFE_TBL_ERR_UNREGISTERED;
 }
 
-int32 CS_COMPUTE_TEST_CFE_TBL_GetInfoHook1(void *UserObj, int32 StubRetcode, uint32 CallCount,
-                                           const UT_StubContext_t *Context)
+CFE_Status_t CS_COMPUTE_TEST_CFE_TBL_GetInfoHook1(void *UserObj, int32 StubRetcode, uint32 CallCount,
+                                                  const UT_StubContext_t *Context)
 {
     CFE_TBL_Info_t *TblInfoPtr = (CFE_TBL_Info_t *)Context->ArgPtr[0];
 

--- a/unit-test/cs_init_tests.c
+++ b/unit-test/cs_init_tests.c
@@ -41,9 +41,9 @@ uint8 call_count_CFE_EVS_SendEvent;
 
 void CS_Init_Test_SBCreatePipeError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Software Bus Create Pipe for command returned: 0x%%08X");
@@ -73,7 +73,7 @@ void CS_Init_Test_SBCreatePipeError(void)
 
 void CS_Init_Test_SBSubscribeHKNominal(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Execute the function being tested */
     Result = CS_SbInit();
@@ -89,9 +89,9 @@ void CS_Init_Test_SBSubscribeHKNominal(void)
 
 void CS_Init_Test_SBSubscribeHKError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Software Bus subscribe to housekeeping returned: 0x%%08X");
@@ -121,9 +121,9 @@ void CS_Init_Test_SBSubscribeHKError(void)
 
 void CS_Init_Test_SBSubscribeBackgroundCycleError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Software Bus subscribe to background cycle returned: 0x%%08X");
@@ -152,9 +152,9 @@ void CS_Init_Test_SBSubscribeBackgroundCycleError(void)
 
 void CS_Init_Test_SBSubscribeCmdError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Software Bus subscribe to command returned: 0x%%08X");
@@ -183,7 +183,7 @@ void CS_Init_Test_SBSubscribeCmdError(void)
 
 void CS_Init_Test_TableInitNominal(void)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /* Execute the function being tested */
     Result = CS_InitAllTables();
@@ -200,9 +200,9 @@ void CS_Init_Test_TableInitNominal(void)
 
 void CS_Init_Test_TableInitErrorEEPROM(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Table initialization failed for EEPROM: 0x%%08X");
@@ -233,9 +233,9 @@ void CS_Init_Test_TableInitErrorEEPROM(void)
 
 void CS_Init_Test_TableInitErrorMemory(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Table initialization failed for Memory: 0x%%08X");
@@ -271,9 +271,9 @@ void CS_Init_Test_TableInitErrorMemory(void)
 
 void CS_Init_Test_TableInitErrorApps(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Table initialization failed for Apps: 0x%%08X");
 
@@ -308,9 +308,9 @@ void CS_Init_Test_TableInitErrorApps(void)
 
 void CS_Init_Test_TableInitErrorTables(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Table initialization failed for Tables: 0x%%08X");

--- a/unit-test/cs_table_processing_tests.c
+++ b/unit-test/cs_table_processing_tests.c
@@ -50,23 +50,23 @@ void CS_TABLE_PROCESSING_TEST_CFE_ES_GetAppNameHandler1(void *UserObj, UT_EntryK
     strncpy((char *)AppName, "CS", 3);
 }
 
-int32 CS_TABLE_PROCESSING_TEST_CFE_TBL_GetAddressHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
-                                                      const UT_StubContext_t *Context)
+CFE_Status_t CS_TABLE_PROCESSING_TEST_CFE_TBL_GetAddressHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
+                                                             const UT_StubContext_t *Context)
 {
     return CFE_SUCCESS;
 }
 
-int32 CS_TABLE_PROCESSING_TEST_CFE_TBL_LoadHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
-                                                const UT_StubContext_t *Context)
+CFE_Status_t CS_TABLE_PROCESSING_TEST_CFE_TBL_LoadHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
+                                                       const UT_StubContext_t *Context)
 {
     return CFE_SUCCESS;
 }
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_Nominal(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS EEPROM Table verification results: good = %%d, bad = %%d, unused = %%d");
@@ -95,9 +95,9 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_Nominal(void)
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnabled(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "EEPROM Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
@@ -142,9 +142,9 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnab
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisabled(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "EEPROM Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
@@ -189,9 +189,9 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisa
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalStateField(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "EEPROM Table Validate: Illegal State Field (0x%%04X) found in Entry ID %%d");
@@ -232,9 +232,9 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_IllegalStateField(void)
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_TableErrorResult(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "EEPROM Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
@@ -279,9 +279,9 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_TableErrorResult(void)
 
 void CS_ValidateEepromChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "EEPROM Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
@@ -326,9 +326,9 @@ void CS_ValidateEepromChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_Nominal(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Memory Table verification results: good = %%d, bad = %%d, unused = %%d");
@@ -357,9 +357,9 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_Nominal(void)
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnabled(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Memory Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
@@ -404,9 +404,9 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateEnab
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisabled(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Memory Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
@@ -451,9 +451,9 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalChecksumRangeStateDisa
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalStateField(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Memory Table Validate: Illegal State Field (0x%%04X) found in Entry ID %%d");
@@ -494,9 +494,9 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_IllegalStateField(void)
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_TableErrorResult(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Memory Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
@@ -541,9 +541,9 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_TableErrorResult(void)
 
 void CS_ValidateMemoryChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Memory Table Validate: Illegal checksum range found in Entry ID %%d, CFE_PSP_MemValidateRange returned: "
@@ -588,9 +588,9 @@ void CS_ValidateMemoryChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_Nominal(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Tables Table verification results: good = %%d, bad = %%d, unused = %%d");
@@ -621,9 +621,9 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_Nominal(void)
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEmpty(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Tables Table Validate: Duplicate Name (%%s) found at entries %%d and %%d");
@@ -667,9 +667,9 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEmpty(void)
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEnabled(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Tables Table Validate: Duplicate Name (%%s) found at entries %%d and %%d");
@@ -716,9 +716,9 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateEnabled(voi
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateDisabled(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Tables Table Validate: Duplicate Name (%%s) found at entries %%d and %%d");
@@ -765,9 +765,9 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_DuplicateNameStateDisabled(vo
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateField(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Tables Table Validate: Illegal State Field (0x%%04X) found with name %%s");
@@ -810,9 +810,9 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateField(void)
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateEmptyName(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Tables Table Validate: Illegal State (0x%%04X) with empty name at entry %%d");
@@ -853,9 +853,9 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_IllegalStateEmptyName(void)
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_TableErrorResult(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Tables Table Validate: Duplicate Name (%%s) found at entries %%d and %%d");
@@ -903,9 +903,9 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_TableErrorResult(void)
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Tables Table Validate: Duplicate Name (%%s) found at entries %%d and %%d");
@@ -951,9 +951,9 @@ void CS_ValidateTablesChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 
 void CS_ValidateTablesChecksumDefinitionTable_Test_CsTableError(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Tables Table Validate: Duplicate Name (%%s) found at entries %%d and %%d");
@@ -1014,9 +1014,9 @@ void CS_ValidateAppChecksumDefinitionTable_Test_Nominal(void)
 
 void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEmpty(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Apps Table Validate: Duplicate Name (%%s) found at entries %%d and %%d");
@@ -1060,9 +1060,9 @@ void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEmpty(void)
 
 void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEnabled(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Apps Table Validate: Duplicate Name (%%s) found at entries %%d and %%d");
@@ -1109,9 +1109,9 @@ void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateEnabled(void)
 
 void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateDisabled(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Apps Table Validate: Duplicate Name (%%s) found at entries %%d and %%d");
@@ -1158,9 +1158,9 @@ void CS_ValidateAppChecksumDefinitionTable_Test_DuplicateNameStateDisabled(void)
 
 void CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateField(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Apps Table Validate: Illegal State Field (0x%%04X) found with name %%s");
@@ -1203,9 +1203,9 @@ void CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateField(void)
 
 void CS_ValidateAppChecksumDefinitionTable_Test_IllegalStateEmptyName(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Apps Table Validate: Illegal State (0x%%04X) with empty name at entry %%d");
@@ -1261,9 +1261,9 @@ void CS_ValidateAppChecksumDefinitionTable_Test_LongName(void)
 
 void CS_ValidateAppChecksumDefinitionTable_Test_TableErrorResult(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Apps Table Validate: Duplicate Name (%%s) found at entries %%d and %%d");
@@ -1310,9 +1310,9 @@ void CS_ValidateAppChecksumDefinitionTable_Test_TableErrorResult(void)
 
 void CS_ValidateAppChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Apps Table Validate: Duplicate Name (%%s) found at entries %%d and %%d");
@@ -1358,9 +1358,9 @@ void CS_ValidateAppChecksumDefinitionTable_Test_UndefTableErrorResult(void)
 
 void CS_ValidateAppChecksumDefinitionTable_Test_EmptyNameTableResult(void)
 {
-    int32 Result;
-    int32 strCmpResult;
-    char  ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    CFE_Status_t Result;
+    int32        strCmpResult;
+    char         ExpectedEventString[2][CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
     snprintf(ExpectedEventString[0], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS Apps Table Validate: Illegal State (0x%%04X) with empty name at entry %%d");
@@ -2264,7 +2264,7 @@ void CS_ProcessNewAppDefinitionTable_Test_StateEmptyNoValidEntries(void)
 
 void CS_TableInit_Test_DefaultDefinitionTableLoadErrorEEPROM(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     int32            strCmpResult;
@@ -2304,7 +2304,7 @@ void CS_TableInit_Test_DefaultDefinitionTableLoadErrorEEPROM(void)
 
 void CS_TableInit_Test_DefinitionTableGetAddressErrorEEPROM(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     int32            strCmpResult;
@@ -2347,7 +2347,7 @@ void CS_TableInit_Test_DefinitionTableGetAddressErrorEEPROM(void)
 
 void CS_TableInit_Test_DefinitionTableGetAddressErrorMemory(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     int32            strCmpResult;
@@ -2390,7 +2390,7 @@ void CS_TableInit_Test_DefinitionTableGetAddressErrorMemory(void)
 
 void CS_TableInit_Test_DefinitionTableGetAddressErrorTables(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     int32            strCmpResult;
@@ -2433,7 +2433,7 @@ void CS_TableInit_Test_DefinitionTableGetAddressErrorTables(void)
 
 void CS_TableInit_Test_DefinitionTableGetAddressErrorApps(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     int32            strCmpResult;
@@ -2475,7 +2475,7 @@ void CS_TableInit_Test_DefinitionTableGetAddressErrorApps(void)
 
 void CS_TableInit_Test_EepromTableAndNotLoadedFromMemory(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
 
@@ -2507,7 +2507,7 @@ void CS_TableInit_Test_EepromTableAndNotLoadedFromMemory(void)
 
 void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableRegisterError(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
 
@@ -2544,7 +2544,7 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableRegisterEr
 
 void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableGetAddressError(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
 
@@ -2578,7 +2578,7 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableGetAddress
 
 void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableRegisterError(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
 
@@ -2615,7 +2615,7 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableRegiste
 
 void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableFileLoadError(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
 
@@ -2650,7 +2650,7 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableFileLoa
 
 void CS_TableInit_Test_MemoryTableAndNotLoadedFromMemory(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
 
@@ -2682,7 +2682,7 @@ void CS_TableInit_Test_MemoryTableAndNotLoadedFromMemory(void)
 
 void CS_TableInit_Test_MemoryTableAndLoadedFromMemory(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
 
@@ -2719,7 +2719,7 @@ void CS_TableInit_Test_MemoryTableAndLoadedFromMemory(void)
 
 void CS_TableInit_Test_AppTableAndNotLoadedFromMemory(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
 
@@ -2750,7 +2750,7 @@ void CS_TableInit_Test_AppTableAndNotLoadedFromMemory(void)
 
 void CS_TableInit_Test_AppTableAndLoadedFromMemory(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
 
@@ -2786,7 +2786,7 @@ void CS_TableInit_Test_AppTableAndLoadedFromMemory(void)
 
 void CS_TableInit_Test_TablesTableAndNotLoadedFromMemory(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
 
@@ -2818,7 +2818,7 @@ void CS_TableInit_Test_TablesTableAndNotLoadedFromMemory(void)
 
 void CS_TableInit_Test_TablesTableAndLoadedFromMemory(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
 
@@ -2855,7 +2855,7 @@ void CS_TableInit_Test_TablesTableAndLoadedFromMemory(void)
 
 void CS_TableInit_Test_DefaultAndLoadedFromMemory(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
 
@@ -2892,7 +2892,7 @@ void CS_TableInit_Test_DefaultAndLoadedFromMemory(void)
 
 void CS_TableInit_Test_OpenCreateError(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
 
@@ -2931,7 +2931,7 @@ void CS_TableInit_Test_OpenCreateError(void)
 
 void CS_HandleTableUpdate_Test_ProcessNewTablesDefinitionTable(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     uint16           Table                 = CS_TABLES_TABLE;
@@ -2962,7 +2962,7 @@ void CS_HandleTableUpdate_Test_ProcessNewTablesDefinitionTable(void)
 
 void CS_HandleTableUpdate_Test_ProcessNewAppDefinitionTable(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     uint16           Table                 = CS_APP_TABLE;
@@ -2991,7 +2991,7 @@ void CS_HandleTableUpdate_Test_ProcessNewAppDefinitionTable(void)
 
 void CS_HandleTableUpdate_Test_ProcessNewEepromMemoryDefinitionTable(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     uint16           Table                 = CS_EEPROM_TABLE;
@@ -3020,7 +3020,7 @@ void CS_HandleTableUpdate_Test_ProcessNewEepromMemoryDefinitionTable(void)
 
 void CS_HandleTableUpdate_Test_ResultsTableGetAddressErrorEEPROM(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     uint16           Table                 = CS_EEPROM_TABLE;
@@ -3063,7 +3063,7 @@ void CS_HandleTableUpdate_Test_ResultsTableGetAddressErrorEEPROM(void)
 
 void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorEEPROM(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     uint16           Table                 = CS_EEPROM_TABLE;
@@ -3107,7 +3107,7 @@ void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorEEPROM(void)
 
 void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorMemory(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     uint16           Table                 = CS_MEMORY_TABLE;
@@ -3151,7 +3151,7 @@ void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorMemory(void)
 
 void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorTables(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     uint16           Table                 = CS_TABLES_TABLE;
@@ -3195,7 +3195,7 @@ void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorTables(void)
 
 void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorApps(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     uint16           Table                 = CS_APP_TABLE;
@@ -3239,7 +3239,7 @@ void CS_HandleTableUpdate_Test_DefinitionTableGetAddressErrorApps(void)
 
 void CS_HandleTableUpdate_Test_BadTableHandle(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     uint16           Table                 = CS_TABLES_TABLE;
@@ -3270,7 +3270,7 @@ void CS_HandleTableUpdate_Test_BadTableHandle(void)
 
 void CS_HandleTableUpdate_Test_CsOwner(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     uint16           Table                 = CS_TABLES_TABLE;
@@ -3301,7 +3301,7 @@ void CS_HandleTableUpdate_Test_CsOwner(void)
 
 void CS_HandleTableUpdate_Test_GetAddressError(void)
 {
-    int32            Result;
+    CFE_Status_t     Result;
     CFE_TBL_Handle_t DefinitionTableHandle = 0;
     CFE_TBL_Handle_t ResultsTableHandle    = 0;
     uint16           Table                 = CS_TABLES_TABLE;

--- a/unit-test/cs_utils_tests.c
+++ b/unit-test/cs_utils_tests.c
@@ -654,7 +654,7 @@ void CS_AttemptTableReshare_Test(void)
     CFE_TBL_Handle_t            LocalTblHandle = CFE_TBL_BAD_TABLE_HANDLE;
     CFE_TBL_Info_t              TblInfo;
     cpuaddr                     LocalAddress;
-    int32                       ResultGetInfo = -1;
+    CFE_Status_t                ResultGetInfo = -1;
 
     memset(&TblEntry, 0, sizeof(TblEntry));
 

--- a/unit-test/stubs/cs_compute_stubs.c
+++ b/unit-test/stubs/cs_compute_stubs.c
@@ -28,8 +28,8 @@
 #include "utassert.h"
 #include "utstubs.h"
 
-int32 CS_ComputeEepromMemory(CS_Res_EepromMemory_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue,
-                             bool *DoneWithEntry)
+CFE_Status_t CS_ComputeEepromMemory(CS_Res_EepromMemory_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue,
+                                    bool *DoneWithEntry)
 {
     UT_Stub_RegisterContext(UT_KEY(CS_ComputeEepromMemory), ResultsEntry);
     UT_Stub_RegisterContext(UT_KEY(CS_ComputeEepromMemory), ComputedCSValue);
@@ -38,7 +38,7 @@ int32 CS_ComputeEepromMemory(CS_Res_EepromMemory_Table_Entry_t *ResultsEntry, ui
     return UT_DEFAULT_IMPL(CS_ComputeEepromMemory);
 }
 
-int32 CS_ComputeTables(CS_Res_Tables_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue, bool *DoneWithEntry)
+CFE_Status_t CS_ComputeTables(CS_Res_Tables_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue, bool *DoneWithEntry)
 {
     UT_Stub_RegisterContext(UT_KEY(CS_ComputeTables), ResultsEntry);
     UT_Stub_RegisterContext(UT_KEY(CS_ComputeTables), ComputedCSValue);
@@ -47,7 +47,7 @@ int32 CS_ComputeTables(CS_Res_Tables_Table_Entry_t *ResultsEntry, uint32 *Comput
     return UT_DEFAULT_IMPL(CS_ComputeTables);
 }
 
-int32 CS_ComputeApp(CS_Res_App_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue, bool *DoneWithEntry)
+CFE_Status_t CS_ComputeApp(CS_Res_App_Table_Entry_t *ResultsEntry, uint32 *ComputedCSValue, bool *DoneWithEntry)
 {
     UT_Stub_RegisterContext(UT_KEY(CS_ComputeApp), ResultsEntry);
     UT_Stub_RegisterContext(UT_KEY(CS_ComputeApp), ComputedCSValue);

--- a/unit-test/stubs/cs_init_stubs.c
+++ b/unit-test/stubs/cs_init_stubs.c
@@ -28,17 +28,17 @@
 #include "utassert.h"
 #include "utstubs.h"
 
-int32 CS_SbInit(void)
+CFE_Status_t CS_SbInit(void)
 {
     return UT_DEFAULT_IMPL(CS_SbInit);
 }
 
-int32 CS_InitAllTables(void)
+CFE_Status_t CS_InitAllTables(void)
 {
     return UT_DEFAULT_IMPL(CS_InitAllTables);
 }
 
-int32 CS_InitSegments(void)
+CFE_Status_t CS_InitSegments(void)
 {
     return UT_DEFAULT_IMPL(CS_InitAllTables);
 }

--- a/unit-test/stubs/cs_table_processing_stubs.c
+++ b/unit-test/stubs/cs_table_processing_stubs.c
@@ -28,28 +28,28 @@
 #include "utassert.h"
 #include "utstubs.h"
 
-int32 CS_ValidateEepromChecksumDefinitionTable(void *TblPtr)
+CFE_Status_t CS_ValidateEepromChecksumDefinitionTable(void *TblPtr)
 {
     UT_Stub_RegisterContext(UT_KEY(CS_ValidateEepromChecksumDefinitionTable), TblPtr);
 
     return UT_DEFAULT_IMPL(CS_ValidateEepromChecksumDefinitionTable);
 }
 
-int32 CS_ValidateMemoryChecksumDefinitionTable(void *TblPtr)
+CFE_Status_t CS_ValidateMemoryChecksumDefinitionTable(void *TblPtr)
 {
     UT_Stub_RegisterContext(UT_KEY(CS_ValidateMemoryChecksumDefinitionTable), TblPtr);
 
     return UT_DEFAULT_IMPL(CS_ValidateMemoryChecksumDefinitionTable);
 }
 
-int32 CS_ValidateTablesChecksumDefinitionTable(void *TblPtr)
+CFE_Status_t CS_ValidateTablesChecksumDefinitionTable(void *TblPtr)
 {
     UT_Stub_RegisterContext(UT_KEY(CS_ValidateTablesChecksumDefinitionTable), TblPtr);
 
     return UT_DEFAULT_IMPL(CS_ValidateTablesChecksumDefinitionTable);
 }
 
-int32 CS_ValidateAppChecksumDefinitionTable(void *TblPtr)
+CFE_Status_t CS_ValidateAppChecksumDefinitionTable(void *TblPtr)
 {
     UT_Stub_RegisterContext(UT_KEY(CS_ValidateAppChecksumDefinitionTable), TblPtr);
 
@@ -88,11 +88,12 @@ void CS_ProcessNewAppDefinitionTable(const CS_Def_App_Table_Entry_t *DefinitionT
     UT_DEFAULT_IMPL(CS_ProcessNewAppDefinitionTable);
 }
 
-int32 CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handle_t *ResultsTableHandle,
-                   void *DefinitionTblPtr, void *ResultsTblPtr, const uint16 Table, const char *DefinitionTableName,
-                   const char *ResultsTableName, const uint16 NumEntries, const char *DefinitionTableFileName,
-                   const void *DefaultDefTableAddress, const uint16 SizeofDefinitionTableEntry,
-                   const uint16 SizeofResultsTableEntry, const CFE_TBL_CallbackFuncPtr_t CallBackFunction)
+CFE_Status_t CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handle_t *ResultsTableHandle,
+                          void *DefinitionTblPtr, void *ResultsTblPtr, const uint16 Table,
+                          const char *DefinitionTableName, const char *ResultsTableName, const uint16 NumEntries,
+                          const char *DefinitionTableFileName, const void *DefaultDefTableAddress,
+                          const uint16 SizeofDefinitionTableEntry, const uint16 SizeofResultsTableEntry,
+                          const CFE_TBL_CallbackFuncPtr_t CallBackFunction)
 
 {
     UT_Stub_RegisterContext(UT_KEY(CS_TableInit), DefinitionTableHandle);
@@ -112,8 +113,10 @@ int32 CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handle_t *Re
     return UT_DEFAULT_IMPL(CS_TableInit);
 }
 
-int32 CS_HandleTableUpdate(void *DefinitionTblPtr, void *ResultsTblPtr, const CFE_TBL_Handle_t DefinitionTableHandle,
-                           const CFE_TBL_Handle_t ResultsTableHandle, const uint16 Table, const uint16 NumEntries)
+CFE_Status_t CS_HandleTableUpdate(void *DefinitionTblPtr, void *ResultsTblPtr,
+                                  const CFE_TBL_Handle_t DefinitionTableHandle,
+                                  const CFE_TBL_Handle_t ResultsTableHandle, const uint16 Table,
+                                  const uint16 NumEntries)
 {
     UT_Stub_RegisterContext(UT_KEY(CS_HandleTableUpdate), DefinitionTblPtr);
     UT_Stub_RegisterContext(UT_KEY(CS_HandleTableUpdate), ResultsTblPtr);

--- a/unit-test/stubs/cs_utils_stubs.c
+++ b/unit-test/stubs/cs_utils_stubs.c
@@ -169,13 +169,13 @@ void CS_ResetTablesTblResultEntry(CS_Res_Tables_Table_Entry_t *TablesTblResultEn
     UT_DEFAULT_IMPL(CS_ResetTablesTblResultEntry);
 }
 
-int32 CS_HandleRoutineTableUpdates(void)
+CFE_Status_t CS_HandleRoutineTableUpdates(void)
 {
     return UT_DEFAULT_IMPL(CS_HandleRoutineTableUpdates);
 }
 
-int32 CS_AttemptTableReshare(CS_Res_Tables_Table_Entry_t *ResultsEntry, CFE_TBL_Handle_t *LocalTblHandle,
-                             CFE_TBL_Info_t *TblInfo, cpuaddr *LocalAddress, int32 *ResultGetInfo)
+CFE_Status_t CS_AttemptTableReshare(CS_Res_Tables_Table_Entry_t *ResultsEntry, CFE_TBL_Handle_t *LocalTblHandle,
+                                    CFE_TBL_Info_t *TblInfo, cpuaddr *LocalAddress, int32 *ResultGetInfo)
 {
     UT_Stub_RegisterContext(UT_KEY(CS_AttemptTableReshare), ResultsEntry);
     UT_Stub_RegisterContext(UT_KEY(CS_AttemptTableReshare), LocalTblHandle);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #78 
  - `int32` return codes converted over to `CFE_Status_t` (incl. in the test code)
  - `int32` `status`/`return` variables holding cFE return codes converted to `CFE_Status_t` (incl. in the test code)
  - removed the `CS_SUCCESS` macro (and replaced with `CFE_SUCCESS)` which was in the "error codes" section (there were only a few uses anyway). It seems clearer to just use `CFE_SUCCESS` for all success returns in the app and from calls to CFE etc.
  - removed some trailing whitespace from the yaml files to avoid any future warnings

_Does `CS_SUCCESS` need to be deprecated even though it's equivelent to `CFE_SUCCESS,` i.e. `== 0`)?_

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change to behavior (no types have actually changed with this PR).
`CFE_Status_t` is more expressive and improves consistency with cFE/cFS.

**Contributor Info**
Avi Weiss @thnkslprpt