### PR TITLE
Fix #82, Convert integers holding boolean truth values to `bool`

### DIFF
--- a/fsw/src/cs_compute.c
+++ b/fsw/src/cs_compute.c
@@ -315,7 +315,7 @@ CFE_Status_t CS_ComputeApp(CS_Res_App_Table_Entry_t *ResultsEntry, uint32 *Compu
     CFE_Status_t Result;
     CFE_Status_t ResultGetResourceID   = CS_ERROR;
     CFE_Status_t ResultGetResourceInfo = CS_ERROR;
-    int32        ResultAddressValid    = false;
+    bool         ResultAddressValid    = false;
 
     /* variables to get applications address */
     CFE_ResourceId_t ResourceID = CFE_RESOURCEID_UNDEFINED;
@@ -350,8 +350,7 @@ CFE_Status_t CS_ComputeApp(CS_Res_App_Table_Entry_t *ResultsEntry, uint32 *Compu
         {
             CFE_EVS_SendEvent(CS_COMPUTE_APP_PLATFORM_DBG_EID, CFE_EVS_EventType_DEBUG,
                               "CS cannot get a valid address for %s, due to the platform", ResultsEntry->Name);
-            ResultAddressValid = false;
-            Result             = CS_ERROR;
+            Result = CS_ERROR;
         }
         else
         {


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #82
  - 1 integer variable which only ever holds boolean truth values has been converted to `bool`

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change to behavior.
- intent of these variables is more clear
- improved type-safety
- eases future maintainability

**Contributor Info**
Avi Weiss @thnkslprpt