### PR TITLE
Fix #26, Use `CFE_ES_MemAddress_t` instead of `cpuaddr` in tables/tlm/cmd structs

### DIFF
--- a/fsw/inc/cs_msg.h
+++ b/fsw/inc/cs_msg.h
@@ -37,34 +37,34 @@
  */
 typedef struct
 {
-    uint8   CmdCounter;                  /**< \brief CS Application Command Counter */
-    uint8   CmdErrCounter;               /**< \brief CS Application Command Error Counter */
-    uint8   ChecksumState;               /**< \brief CS Application global checksum state */
-    uint8   EepromCSState;               /**< \brief CS EEPROM table checksum state */
-    uint8   MemoryCSState;               /**< \brief CS Memory table checksum state */
-    uint8   AppCSState;                  /**< \brief CS App table checksum state */
-    uint8   TablesCSState;               /**< \brief CS Tables table checksum state */
-    uint8   OSCSState;                   /**< \brief OS code segment checksum state */
-    uint8   CfeCoreCSState;              /**< \brief cFE Core code segment checksum stat e*/
-    uint8   RecomputeInProgress;         /**< \brief CS "Recompute In Progress" flag */
-    uint8   OneShotInProgress;           /**< \brief CS "OneShot In Progress" flag */
-    uint8   Filler8;                     /**< \brief 8 bit padding */
-    uint16  EepromCSErrCounter;          /**< \brief EEPROM miscompare counter */
-    uint16  MemoryCSErrCounter;          /**< \brief Memory miscompare counter */
-    uint16  AppCSErrCounter;             /**< \brief App miscompare counter */
-    uint16  TablesCSErrCounter;          /**< \brief Tables miscompare counter */
-    uint16  CfeCoreCSErrCounter;         /**< \brief cFE core miscompare counter */
-    uint16  OSCSErrCounter;              /**< \brief OS code segment miscopmare counter */
-    uint16  CurrentCSTable;              /**< \brief Current table being checksummed */
-    uint16  CurrentEntryInTable;         /**< \brief Current entry ID in table being checksummed */
-    uint32  EepromBaseline;              /**< \brief Baseline checksum for all of EEPROM */
-    uint32  OSBaseline;                  /**< \brief Baseline checksum for the OS code segment */
-    uint32  CfeCoreBaseline;             /**< \brief Basline checksum for the cFE core */
-    cpuaddr LastOneShotAddress;          /**< \brief Address used in last one shot checksum command */
-    uint32  LastOneShotSize;             /**< \brief Size used in the last one shot checksum command */
-    uint32  LastOneShotMaxBytesPerCycle; /**< \brief Max bytes per cycle for last one shot checksum command */
-    uint32  LastOneShotChecksum;         /**< \brief Checksum of the last one shot checksum command */
-    uint32  PassCounter;                 /**< \brief Number of times CS has passed through all of its tables */
+    uint8               CmdCounter;          /**< \brief CS Application Command Counter */
+    uint8               CmdErrCounter;       /**< \brief CS Application Command Error Counter */
+    uint8               ChecksumState;       /**< \brief CS Application global checksum state */
+    uint8               EepromCSState;       /**< \brief CS EEPROM table checksum state */
+    uint8               MemoryCSState;       /**< \brief CS Memory table checksum state */
+    uint8               AppCSState;          /**< \brief CS App table checksum state */
+    uint8               TablesCSState;       /**< \brief CS Tables table checksum state */
+    uint8               OSCSState;           /**< \brief OS code segment checksum state */
+    uint8               CfeCoreCSState;      /**< \brief cFE Core code segment checksum stat e*/
+    uint8               RecomputeInProgress; /**< \brief CS "Recompute In Progress" flag */
+    uint8               OneShotInProgress;   /**< \brief CS "OneShot In Progress" flag */
+    uint8               Filler8;             /**< \brief 8 bit padding */
+    uint16              EepromCSErrCounter;  /**< \brief EEPROM miscompare counter */
+    uint16              MemoryCSErrCounter;  /**< \brief Memory miscompare counter */
+    uint16              AppCSErrCounter;     /**< \brief App miscompare counter */
+    uint16              TablesCSErrCounter;  /**< \brief Tables miscompare counter */
+    uint16              CfeCoreCSErrCounter; /**< \brief cFE core miscompare counter */
+    uint16              OSCSErrCounter;      /**< \brief OS code segment miscopmare counter */
+    uint16              CurrentCSTable;      /**< \brief Current table being checksummed */
+    uint16              CurrentEntryInTable; /**< \brief Current entry ID in table being checksummed */
+    uint32              EepromBaseline;      /**< \brief Baseline checksum for all of EEPROM */
+    uint32              OSBaseline;          /**< \brief Baseline checksum for the OS code segment */
+    uint32              CfeCoreBaseline;     /**< \brief Basline checksum for the cFE core */
+    CFE_ES_MemAddress_t LastOneShotAddress;  /**< \brief Address used in last one shot checksum command */
+    uint32              LastOneShotSize;     /**< \brief Size used in the last one shot checksum command */
+    uint32 LastOneShotMaxBytesPerCycle;      /**< \brief Max bytes per cycle for last one shot checksum command */
+    uint32 LastOneShotChecksum;              /**< \brief Checksum of the last one shot checksum command */
+    uint32 PassCounter;                      /**< \brief Number of times CS has passed through all of its tables */
 } CS_HkPacket_Payload_t;
 
 /**
@@ -88,7 +88,7 @@ typedef struct
  */
 typedef struct
 {
-    cpuaddr Address; /**< \brief Address to get the ID for */
+    CFE_ES_MemAddress_t Address; /**< \brief Address to get the ID for */
 } CS_GetEntryIDCmd_Payload_t;
 
 /**
@@ -120,10 +120,10 @@ typedef struct
  */
 typedef struct
 {
-    cpuaddr Address;          /**< \brief Address to start checksum */
-    uint32  Size;             /**< \brief Number of bytes to checksum */
-    uint32  MaxBytesPerCycle; /**< \brief Max Number of bytes to compute per cycle. Value of Zero to use platform config
-                                value */
+    CFE_ES_MemAddress_t Address; /**< \brief Address to start checksum */
+    uint32              Size;    /**< \brief Number of bytes to checksum */
+    uint32 MaxBytesPerCycle; /**< \brief Max Number of bytes to compute per cycle. Value of Zero to use platform config
+                               value */
 } CS_OneShotCmd_Payload_t;
 
 /**

--- a/fsw/inc/cs_tbldefs.h
+++ b/fsw/inc/cs_tbldefs.h
@@ -68,10 +68,10 @@
  */
 typedef struct
 {
-    cpuaddr StartAddress;       /**< \brief The Start address to Checksum */
-    uint16  State;              /**< \brief Uses the CS_STATE_... defines from above */
-    uint16  Filler16;           /** <\brief Padding */
-    uint32  NumBytesToChecksum; /**< \brief The number of Bytes to Checksum */
+    CFE_ES_MemAddress_t StartAddress;       /**< \brief The Start address to Checksum */
+    uint16              State;              /**< \brief Uses the CS_STATE_... defines from above */
+    uint16              Filler16;           /** <\brief Padding */
+    uint32              NumBytesToChecksum; /**< \brief The number of Bytes to Checksum */
 } CS_Def_EepromMemory_Table_Entry_t;
 
 /**
@@ -79,14 +79,13 @@ typedef struct
  */
 typedef struct
 {
-    cpuaddr StartAddress;       /**< \brief The Start address to Checksum */
-    uint16  State;              /**< \brief Uses the CS_STATE_... defines from above */
-    uint16  ComputedYet;        /**< \brief Have we computed an Integrity value yet */
-    uint32  NumBytesToChecksum; /**< \brief The number of Bytes to Checksum */
-    uint32  ComparisonValue;    /**< \brief The Memory Integrity Value */
-    uint32  ByteOffset;         /**< \brief Where a previous unfinished calc left off */
-    uint32  TempChecksumValue;  /**< \brief The unfinished caluculation */
-    uint32  Filler32;           /**< \brief Padding */
+    CFE_ES_MemAddress_t StartAddress;       /**< \brief The Start address to Checksum */
+    uint16              State;              /**< \brief Uses the CS_STATE_... defines from above */
+    uint16              ComputedYet;        /**< \brief Have we computed an Integrity value yet */
+    uint32              NumBytesToChecksum; /**< \brief The number of Bytes to Checksum */
+    uint32              ComparisonValue;    /**< \brief The Memory Integrity Value */
+    uint32              ByteOffset;         /**< \brief Where a previous unfinished calc left off */
+    uint32              TempChecksumValue;  /**< \brief The unfinished caluculation */
 } CS_Res_EepromMemory_Table_Entry_t;
 
 /**
@@ -112,17 +111,17 @@ typedef struct
  */
 typedef struct
 {
-    cpuaddr          StartAddress;                    /**< \brief The Start address to Checksum */
-    uint16           State;                           /**< \brief Uses the CS_STATE_... defines from above */
-    uint16           ComputedYet;                     /**< \brief Have we computed an Integrity value yet */
-    uint32           NumBytesToChecksum;              /**< \brief The number of Bytes to Checksum */
-    uint32           ComparisonValue;                 /**< \brief The Memory Integrity Value */
-    uint32           ByteOffset;                      /**< \brief Where a previous unfinished calc left off */
-    uint32           TempChecksumValue;               /**< \brief The unfinished caluculation */
-    CFE_TBL_Handle_t TblHandle;                       /**< \brief handle recieved from CFE_TBL */
-    bool             IsCSOwner;                       /**< \brief Is CS the original owner of this table */
-    bool             Filler8;                         /**< \brief Padding */
-    char             Name[CFE_TBL_MAX_FULL_NAME_LEN]; /**< \brief name of the table */
+    CFE_ES_MemAddress_t StartAddress;                    /**< \brief The Start address to Checksum */
+    uint16              State;                           /**< \brief Uses the CS_STATE_... defines from above */
+    uint16              ComputedYet;                     /**< \brief Have we computed an Integrity value yet */
+    uint32              NumBytesToChecksum;              /**< \brief The number of Bytes to Checksum */
+    uint32              ComparisonValue;                 /**< \brief The Memory Integrity Value */
+    uint32              ByteOffset;                      /**< \brief Where a previous unfinished calc left off */
+    uint32              TempChecksumValue;               /**< \brief The unfinished caluculation */
+    CFE_TBL_Handle_t    TblHandle;                       /**< \brief handle recieved from CFE_TBL */
+    bool                IsCSOwner;                       /**< \brief Is CS the original owner of this table */
+    bool                Filler8;                         /**< \brief Padding */
+    char                Name[CFE_TBL_MAX_FULL_NAME_LEN]; /**< \brief name of the table */
 } CS_Res_Tables_Table_Entry_t;
 
 /**
@@ -130,14 +129,14 @@ typedef struct
  */
 typedef struct
 {
-    cpuaddr StartAddress;          /**< \brief The Start address to Checksum */
-    uint16  State;                 /**< \brief Uses the CS_STATE_... defines from above */
-    uint16  ComputedYet;           /**< \brief Have we computed an Integrity value yet */
-    uint32  NumBytesToChecksum;    /**< \brief The number of Bytes to Checksum */
-    uint32  ComparisonValue;       /**< \brief The Memory Integrity Value */
-    uint32  ByteOffset;            /**< \brief Where a previous unfinished calc left off */
-    uint32  TempChecksumValue;     /**< \brief The unfinished caluculation */
-    char    Name[OS_MAX_API_NAME]; /**< \brief name of the app */
+    CFE_ES_MemAddress_t StartAddress;          /**< \brief The Start address to Checksum */
+    uint16              State;                 /**< \brief Uses the CS_STATE_... defines from above */
+    uint16              ComputedYet;           /**< \brief Have we computed an Integrity value yet */
+    uint32              NumBytesToChecksum;    /**< \brief The number of Bytes to Checksum */
+    uint32              ComparisonValue;       /**< \brief The Memory Integrity Value */
+    uint32              ByteOffset;            /**< \brief Where a previous unfinished calc left off */
+    uint32              TempChecksumValue;     /**< \brief The unfinished caluculation */
+    char                Name[OS_MAX_API_NAME]; /**< \brief name of the app */
 } CS_Res_App_Table_Entry_t;
 
 /**************************************************************************


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #26
  - Convert `cpuaddr` types in tables/cmd/tlm structs to fixed-size `CFE_ES_MemAddress_t`
    - removed the `Filler32` in `CS_Res_EepromMemory_Table_Entry_t` (I assume it was there to align to the 64-bit `cpuaddr` which is is longer necessary (unless/until `CFE_ES_MemAddress_t` and `CFE_ES_MemOffset_t` are redefined as 64-bits in https://github.com/nasa/cFE/issues/2093. Another option is to just leave it in now for future compatibility with 64-bit alignment.

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Coverage Tests etc.).

**Expected behavior changes**
Exposed structs will no longer change size based on the definition of `cpuaddr`.

**Contributor Info**
Avi Weiss @thnkslprpt