### PR TITLE
Fix #74, cmd and tlm messages use payload sub-structure

### DIFF
--- a/fsw/inc/cs_msg.h
+++ b/fsw/inc/cs_msg.h
@@ -33,12 +33,10 @@
  */
 
 /**
- *  \brief Housekeeping Packet Structure
+ *  \brief Housekeeping Payload Structure
  */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief cFE SB Tlm Msg Hdr */
-
     uint8   CmdCounter;                  /**< \brief CS Application Command Counter */
     uint8   CmdErrCounter;               /**< \brief CS Application Command Error Counter */
     uint8   ChecksumState;               /**< \brief CS Application global checksum state */
@@ -67,6 +65,15 @@ typedef struct
     uint32  LastOneShotMaxBytesPerCycle; /**< \brief Max bytes per cycle for last one shot checksum command */
     uint32  LastOneShotChecksum;         /**< \brief Checksum of the last one shot checksum command */
     uint32  PassCounter;                 /**< \brief Number of times CS has passed through all of its tables */
+} CS_HkPacket_Payload_t;
+
+/**
+ *  \brief Housekeeping Packet Structure
+ */
+typedef struct
+{
+    CFE_MSG_TelemetryHeader_t TlmHeader; /**< \brief cFE SB Tlm Msg Hdr */
+    CS_HkPacket_Payload_t Payload; /**< \brief CS HK Payload */
 } CS_HkPacket_t;
 
 /**\}*/
@@ -75,6 +82,49 @@ typedef struct
  * \defgroup cfscscmdstructs CFS Checksum Command Structures
  * \{
  */
+
+/**
+ * \brief Get entry ID command payload
+ */
+typedef struct
+{
+    cpuaddr Address; /**< \brief Address to get the ID for */
+} CS_GetEntryIDCmd_Payload_t;
+
+/**
+ * \brief Payload for commands using Memory or EEPROM tables
+ */
+typedef struct
+{
+    uint32 EntryID; /**< \brief EntryID to perform a command on */
+} CS_EntryCmd_Payload_t;
+
+/**
+ * \brief Payload for commanding by table name
+ */
+typedef struct
+{
+    char Name[CFE_TBL_MAX_FULL_NAME_LEN]; /**< \brief Table name to perform a command on */
+} CS_TableNameCmd_Payload_t;
+
+/**
+ * \brief Payload for commanding by app name
+ */
+typedef struct
+{
+    char Name[OS_MAX_API_NAME]; /**< \brief App name to perform a command on */
+} CS_AppNameCmd_Payload_t;
+
+/**
+ * \brief Payload for sending one shot calculation
+ */
+typedef struct
+{
+    cpuaddr Address; /**< \brief Address to start checksum */
+    uint32  Size;    /**< \brief Number of bytes to checksum */
+    uint32  MaxBytesPerCycle; /**< \brief Max Number of bytes to compute per cycle. Value of Zero to use platform config
+                                value */
+} CS_OneShotCmd_Payload_t;
 
 /**
  * \brief No arguments command data type
@@ -98,7 +148,7 @@ typedef struct
 typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader;
-    cpuaddr                 Address; /**< \brief Address to get the ID for */
+    CS_GetEntryIDCmd_Payload_t Payload;
 } CS_GetEntryIDCmd_t;
 
 /**
@@ -110,7 +160,7 @@ typedef struct
 typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader;
-    uint32                  EntryID; /**< \brief EntryID to perform a command on */
+    CS_EntryCmd_Payload_t Payload;
 } CS_EntryCmd_t;
 
 /**
@@ -122,7 +172,7 @@ typedef struct
 typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader;
-    char                    Name[CFE_TBL_MAX_FULL_NAME_LEN]; /**< \brief Table name to perform a command on */
+    CS_TableNameCmd_Payload_t Payload;
 } CS_TableNameCmd_t;
 
 /**
@@ -134,7 +184,7 @@ typedef struct
 typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader;
-    char                    Name[OS_MAX_API_NAME]; /**< \brief App name to perform a command on */
+    CS_AppNameCmd_Payload_t Payload;
 } CS_AppNameCmd_t;
 
 /**
@@ -145,10 +195,7 @@ typedef struct
 typedef struct
 {
     CFE_MSG_CommandHeader_t CmdHeader;
-    cpuaddr                 Address; /**< \brief Address to start checksum */
-    uint32                  Size;    /**< \brief Number of bytes to checksum */
-    uint32 MaxBytesPerCycle; /**< \brief Max Number of bytes to compute per cycle. Value of Zero to use platform config
-                                value */
+    CS_OneShotCmd_Payload_t Payload;
 } CS_OneShotCmd_t;
 
 /**\}*/

--- a/fsw/inc/cs_msgdefs.h
+++ b/fsw/inc/cs_msgdefs.h
@@ -44,7 +44,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_NOOP_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -53,7 +53,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -75,8 +75,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will be cleared
- *       - #CS_HkPacket_t.CmdErrCounter will be cleared
+ *       - #CS_HkPacket_Payload_t.CmdCounter will be cleared
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will be cleared
  *       - The #CS_RESET_DBG_EID informational event message will be
  *         generated when the command is executed
  *
@@ -85,7 +85,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -110,12 +110,12 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_ONESHOT_STARTED_DBG_EID debug event message will be
  *         generated when the command is received
  *       - The CS_ONESHOT_FINISHED_INF_EID informational message will
  *         be generated when the compuation finishes.
- *       - #CS_HkPacket_t.LastOneShotChecksum will be updated to the new value
+ *       - #CS_HkPacket_Payload_t.LastOneShotChecksum will be updated to the new value
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
@@ -127,7 +127,7 @@
  *       - The child task failed to be created
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_ONESHOT_MEMVALIDATE_ERR_EID
  *       - Error specific event message #CS_ONESHOT_CHDTASK_ERR_EID
@@ -158,7 +158,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_ONESHOT_CANCELLED_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -169,7 +169,7 @@
  *       - The child task could not be deleted
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_ONESHOT_CANCEL_NO_CHDTASK_ERR_EID
  *       - Error specific event message #CS_ONESHOT_CANCEL_DELETE_CHDTASK_ERR_EID
@@ -193,17 +193,17 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_ENABLE_ALL_INF_EID informational event message will be
  *         generated when the command is received
- *       - #CS_HkPacket_t.ChecksumState set to #CS_STATE_ENABLED
+ *       - #CS_HkPacket_Payload_t.ChecksumState set to #CS_STATE_ENABLED
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -225,17 +225,17 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_DISABLE_ALL_INF_EID informational event message will be
  *         generated when the command is received
- *       - #CS_HkPacket_t.ChecksumState set to #CS_STATE_DISABLED
+ *       - #CS_HkPacket_Payload_t.ChecksumState set to #CS_STATE_DISABLED
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -257,17 +257,17 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_ENABLE_CFECORE_INF_EID informational event message will be
  *         generated when the command is received
- *       - #CS_HkPacket_t.CfeCoreCSState set to #CS_STATE_ENABLED
+ *       - #CS_HkPacket_Payload_t.CfeCoreCSState set to #CS_STATE_ENABLED
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -289,17 +289,17 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_DISABLE_CFECORE_INF_EID informational event message will be
  *         generated when the command is received
- *       - #CS_HkPacket_t.CfeCoreCSState set to #CS_STATE_DISABLED
+ *       - #CS_HkPacket_Payload_t.CfeCoreCSState set to #CS_STATE_DISABLED
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -322,7 +322,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_BASELINE_CFECORE_INF_EID informational event message will be
  *         generated when the command is received, or
  *       - The #CS_NO_BASELINE_CFECORE_INF_EID informational event message will be
@@ -333,7 +333,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -355,7 +355,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_RECOMPUTE_CFECORE_STARTED_DBG_EID debug event message will be
  *         generated when the command is received
  *
@@ -368,7 +368,7 @@
  *       - The child task failed to be created by Executive Services (ES)
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_CFECORE_CREATE_CHDTASK_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_CFECORE_CHDTASK_ERR_EID
@@ -397,7 +397,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_ENABLE_OS_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -406,9 +406,9 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
- *       - #CS_HkPacket_t.OSCSState set to #CS_STATE_ENABLED
+ *       - #CS_HkPacket_Payload_t.OSCSState set to #CS_STATE_ENABLED
  *
  *  \par Criticality
  *       None
@@ -429,17 +429,17 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_DISABLE_OS_INF_EID informational event message will be
  *         generated when the command is received
- *       - #CS_HkPacket_t.OSCSState set to #CS_STATE_DISABLED
+ *       - #CS_HkPacket_Payload_t.OSCSState set to #CS_STATE_DISABLED
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -462,7 +462,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_BASELINE_OS_INF_EID informational event message will be
  *         generated when the command is received, or
  *       - The #CS_NO_BASELINE_OS_INF_EID informational event message will be
@@ -473,7 +473,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -494,7 +494,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_RECOMPUTE_OS_STARTED_DBG_EID debug event message will be
  *         generated when the command is received
  *
@@ -507,7 +507,7 @@
  *       - The child task failed to be created by Executive Services (ES)
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_OS_CREATE_CHDTASK_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_OS_CHDTASK_ERR_EID
@@ -535,17 +535,17 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_ENABLE_EEPROM_INF_EID informational event message will be
  *         generated when the command is received
- *       - #CS_HkPacket_t.EepromCSState set to #CS_STATE_ENABLED
+ *       - #CS_HkPacket_Payload_t.EepromCSState set to #CS_STATE_ENABLED
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -567,17 +567,17 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_DISABLE_EEPROM_INF_EID informational event message will be
  *         generated when the command is received
- *       - #CS_HkPacket_t.EepromCSState set to #CS_STATE_DISABLED
+ *       - #CS_HkPacket_Payload_t.EepromCSState set to #CS_STATE_DISABLED
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -600,7 +600,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_BASELINE_EEPROM_INF_EID informational event message will be
  *         generated when the command is received, or
  *       - The #CS_NO_BASELINE_EEPROM_INF_EID informational event message will be
@@ -612,7 +612,7 @@
  *       - The command specified Entry ID is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_BASELINE_INVALID_ENTRY_EEPROM_ERR_EID
  *
@@ -636,7 +636,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_RECOMPUTE_EEPROM_STARTED_DBG_EID debug event
  *         message will be generated when the command is received
  *       - The #CS_RECOMPUTE_FINISH_EEPROM_MEMORY_INF_EID informational event
@@ -652,7 +652,7 @@
  *       - The child task failed to be created by Executive Services (ES)
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_INVALID_ENTRY_EEPROM_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_EEPROM_CREATE_CHDTASK_ERR_EID
@@ -682,7 +682,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_ENABLE_EEPROM_ENTRY_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -692,7 +692,7 @@
  *       - Command specified entry was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_ENABLE_EEPROM_INVALID_ENTRY_ERR_EID
  *
@@ -715,7 +715,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_DISABLE_EEPROM_ENTRY_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -725,7 +725,7 @@
  *       - Command specified entry was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_DISABLE_EEPROM_INVALID_ENTRY_ERR_EID
  *
@@ -749,7 +749,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_GET_ENTRY_ID_EEPROM_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -759,7 +759,7 @@
  *       - Command specified address was not found in the table
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_GET_ENTRY_ID_EEPROM_NOT_FOUND_INF_EID
  *
@@ -780,17 +780,17 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_ENABLE_MEMORY_INF_EID informational event message will be
  *         generated when the command is received
- *       - #CS_HkPacket_t.MemoryCSState set to #CS_STATE_ENABLED
+ *       - #CS_HkPacket_Payload_t.MemoryCSState set to #CS_STATE_ENABLED
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -812,17 +812,17 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_DISABLE_MEMORY_INF_EID informational event message will be
  *         generated when the command is received
- *       - #CS_HkPacket_t.MemoryCSState set to #CS_STATE_DISABLED
+ *       - #CS_HkPacket_Payload_t.MemoryCSState set to #CS_STATE_DISABLED
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -845,7 +845,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_BASELINE_MEMORY_INF_EID informational event message will be
  *         generated when the command is received, or
  *       - The #CS_NO_BASELINE_MEMORY_INF_EID informational event message will be
@@ -857,7 +857,7 @@
  *       - The command specified Entry ID is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_BASELINE_INVALID_ENTRY_MEMORY_ERR_EID
  *
@@ -880,7 +880,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_RECOMPUTE_MEMORY_STARTED_DBG_EID debug event
  *         message will be generated when the command is received
  *       - The #CS_RECOMPUTE_FINISH_EEPROM_MEMORY_INF_EID informational event
@@ -896,7 +896,7 @@
  *       - The child task failed to be created by Executive Services (ES)
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_INVALID_ENTRY_MEMORY_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_MEMORY_CREATE_CHDTASK_ERR_EID
@@ -926,7 +926,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_ENABLE_MEMORY_ENTRY_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -936,7 +936,7 @@
  *       - Command specified entry was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_ENABLE_MEMORY_INVALID_ENTRY_ERR_EID
  *
@@ -959,7 +959,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_DISABLE_MEMORY_ENTRY_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -969,7 +969,7 @@
  *       - Command specified entry was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_DISABLE_MEMORY_INVALID_ENTRY_ERR_EID
  *
@@ -993,7 +993,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_GET_ENTRY_ID_MEMORY_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -1003,7 +1003,7 @@
  *       - Command specified address was not found in the table
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_GET_ENTRY_ID_MEMORY_NOT_FOUND_INF_EID
  *
@@ -1025,17 +1025,17 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_ENABLE_TABLES_INF_EID informational event message will be
  *         generated when the command is received
- *       - #CS_HkPacket_t.TablesCSState set to #CS_STATE_ENABLED
+ *       - #CS_HkPacket_Payload_t.TablesCSState set to #CS_STATE_ENABLED
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -1057,17 +1057,17 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_DISABLE_TABLES_INF_EID informational event message will be
  *         generated when the command is received
- *       - #CS_HkPacket_t.TablesCSState set to #CS_STATE_DISABLED
+ *       - #CS_HkPacket_Payload_t.TablesCSState set to #CS_STATE_DISABLED
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -1090,7 +1090,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_BASELINE_TABLES_INF_EID informational event message will be
  *         generated when the command is received, or
  *       - The #CS_NO_BASELINE_TABLES_INF_EID informational event message will be
@@ -1102,7 +1102,7 @@
  *       - The command specified able name is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_BASELINE_INVALID_NAME_TABLES_ERR_EID
  *
@@ -1125,7 +1125,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_RECOMPUTE_TABLES_STARTED_DBG_EID debug event
  *         message will be generated when the command is received
  *       - The #CS_RECOMPUTE_FINISH_TABLES_INF_EID informational event
@@ -1147,7 +1147,7 @@
  *       - The child task failed to be created by Executive Services (ES)
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_UNKNOWN_NAME_TABLES_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_TABLES_CREATE_CHDTASK_ERR_EID
@@ -1177,7 +1177,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_ENABLE_TABLES_NAME_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -1187,7 +1187,7 @@
  *       - Command specified table name was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_ENABLE_TABLES_UNKNOWN_NAME_ERR_EID
  *
@@ -1210,7 +1210,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_DISABLE_TABLES_NAME_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -1220,7 +1220,7 @@
  *       - Command specified table name was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_DISABLE_TABLES_NAME_INF_EID
  *       - Error specific event message #CS_DISABLE_TABLES_UNKNOWN_NAME_ERR_EID
  *
@@ -1243,17 +1243,17 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_ENABLE_APP_INF_EID informational event message will be
  *         generated when the command is received
- *       - #CS_HkPacket_t.AppCSState set to #CS_STATE_ENABLED
+ *       - #CS_HkPacket_Payload_t.AppCSState set to #CS_STATE_ENABLED
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -1275,17 +1275,17 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_DISABLE_APP_INF_EID informational event message will be
  *         generated when the command is received
- *       - #CS_HkPacket_t.AppCSState set to #CS_STATE_DISABLED
+ *       - #CS_HkPacket_Payload_t.AppCSState set to #CS_STATE_DISABLED
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *
  *  \par Criticality
@@ -1308,7 +1308,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_BASELINE_APP_INF_EID informational event message will be
  *         generated when the command is received, or
  *       - The #CS_NO_BASELINE_APP_INF_EID informational event message will be
@@ -1320,7 +1320,7 @@
  *       - The command specified able name is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_BASELINE_INVALID_NAME_APP_ERR_EID
  *
@@ -1343,7 +1343,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_RECOMPUTE_APP_STARTED_DBG_EID debug event
  *         message will be generated when the command is received
  *       - The #CS_RECOMPUTE_FINISH_APP_INF_EID informational event
@@ -1359,7 +1359,7 @@
  *       - The child task failed to be created by Executive Services (ES)
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_UNKNOWN_NAME_APP_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_APP_CREATE_CHDTASK_ERR_EID
@@ -1389,7 +1389,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_ENABLE_APP_NAME_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -1399,7 +1399,7 @@
  *       - Command specified app name was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_LEN_ERR_EID
  *       - Error specific event message #CS_ENABLE_APP_UNKNOWN_NAME_ERR_EID
  *
@@ -1422,7 +1422,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdCounter will increment
  *       - The #CS_DISABLE_APP_NAME_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -1432,7 +1432,7 @@
  *       - Command specified app name was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
  *       - Error specific event message #CS_DISABLE_APP_NAME_INF_EID
  *       - Error specific event message #CS_DISABLE_APP_UNKNOWN_NAME_ERR_EID
  *

--- a/fsw/src/cs_app.c
+++ b/fsw/src/cs_app.c
@@ -171,13 +171,13 @@ CFE_Status_t CS_AppInit(void)
         /* Set up default tables in memory */
         CS_InitializeDefaultTables();
 
-        CS_AppData.HkPacket.EepromCSState = CS_EEPROM_TBL_POWERON_STATE;
-        CS_AppData.HkPacket.MemoryCSState = CS_MEMORY_TBL_POWERON_STATE;
-        CS_AppData.HkPacket.AppCSState    = CS_APPS_TBL_POWERON_STATE;
-        CS_AppData.HkPacket.TablesCSState = CS_TABLES_TBL_POWERON_STATE;
+        CS_AppData.HkPacket.Payload.EepromCSState = CS_EEPROM_TBL_POWERON_STATE;
+        CS_AppData.HkPacket.Payload.MemoryCSState = CS_MEMORY_TBL_POWERON_STATE;
+        CS_AppData.HkPacket.Payload.AppCSState    = CS_APPS_TBL_POWERON_STATE;
+        CS_AppData.HkPacket.Payload.TablesCSState = CS_TABLES_TBL_POWERON_STATE;
 
-        CS_AppData.HkPacket.OSCSState      = CS_OSCS_CHECKSUM_STATE;
-        CS_AppData.HkPacket.CfeCoreCSState = CS_CFECORE_CHECKSUM_STATE;
+        CS_AppData.HkPacket.Payload.OSCSState      = CS_OSCS_CHECKSUM_STATE;
+        CS_AppData.HkPacket.Payload.CfeCoreCSState = CS_CFECORE_CHECKSUM_STATE;
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
         Result = CS_CreateRestoreStatesFromCDS();
@@ -194,15 +194,15 @@ CFE_Status_t CS_AppInit(void)
         CS_InitSegments();
 
         /* initialize the place to ostart background checksumming */
-        CS_AppData.HkPacket.CurrentCSTable      = 0;
-        CS_AppData.HkPacket.CurrentEntryInTable = 0;
+        CS_AppData.HkPacket.Payload.CurrentCSTable      = 0;
+        CS_AppData.HkPacket.Payload.CurrentEntryInTable = 0;
 
         /* Initial settings for the CS Application */
         /* the rest of the tables are initialized in CS_TableInit */
-        CS_AppData.HkPacket.ChecksumState = CS_STATE_ENABLED;
+        CS_AppData.HkPacket.Payload.ChecksumState = CS_STATE_ENABLED;
 
-        CS_AppData.HkPacket.RecomputeInProgress = false;
-        CS_AppData.HkPacket.OneShotInProgress   = false;
+        CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+        CS_AppData.HkPacket.Payload.OneShotInProgress   = false;
 
         CS_AppData.MaxBytesPerCycle = CS_DEFAULT_BYTES_PER_CYCLE;
 
@@ -249,7 +249,7 @@ CFE_Status_t CS_AppPipe(const CFE_SB_Buffer_t *BufPtr)
             CFE_EVS_SendEvent(CS_MID_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid command pipe message ID: 0x%08lX",
                               (unsigned long)CFE_SB_MsgIdToValue(MessageID));
 
-            CS_AppData.HkPacket.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
             break;
     }
 
@@ -565,7 +565,7 @@ void CS_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
                               "Invalid ground command code: ID = 0x%08lX, CC = %d",
                               (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode);
 
-            CS_AppData.HkPacket.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
             break;
     } /* end switch */
 }
@@ -631,13 +631,13 @@ CFE_Status_t CS_CreateRestoreStatesFromCDS(void)
         /*
         ** New CDS area - write to Critical Data Store...
         */
-        DataStoreBuffer[0] = CS_AppData.HkPacket.EepromCSState;
-        DataStoreBuffer[1] = CS_AppData.HkPacket.MemoryCSState;
-        DataStoreBuffer[2] = CS_AppData.HkPacket.AppCSState;
-        DataStoreBuffer[3] = CS_AppData.HkPacket.TablesCSState;
+        DataStoreBuffer[0] = CS_AppData.HkPacket.Payload.EepromCSState;
+        DataStoreBuffer[1] = CS_AppData.HkPacket.Payload.MemoryCSState;
+        DataStoreBuffer[2] = CS_AppData.HkPacket.Payload.AppCSState;
+        DataStoreBuffer[3] = CS_AppData.HkPacket.Payload.TablesCSState;
 
-        DataStoreBuffer[4] = CS_AppData.HkPacket.OSCSState;
-        DataStoreBuffer[5] = CS_AppData.HkPacket.CfeCoreCSState;
+        DataStoreBuffer[4] = CS_AppData.HkPacket.Payload.OSCSState;
+        DataStoreBuffer[5] = CS_AppData.HkPacket.Payload.CfeCoreCSState;
 
         Result = CFE_ES_CopyToCDS(CS_AppData.DataStoreHandle, DataStoreBuffer);
 
@@ -655,13 +655,13 @@ CFE_Status_t CS_CreateRestoreStatesFromCDS(void)
 
         if (Result == CFE_SUCCESS)
         {
-            CS_AppData.HkPacket.EepromCSState = DataStoreBuffer[0];
-            CS_AppData.HkPacket.MemoryCSState = DataStoreBuffer[1];
-            CS_AppData.HkPacket.AppCSState    = DataStoreBuffer[2];
-            CS_AppData.HkPacket.TablesCSState = DataStoreBuffer[3];
+            CS_AppData.HkPacket.Payload.EepromCSState = DataStoreBuffer[0];
+            CS_AppData.HkPacket.Payload.MemoryCSState = DataStoreBuffer[1];
+            CS_AppData.HkPacket.Payload.AppCSState    = DataStoreBuffer[2];
+            CS_AppData.HkPacket.Payload.TablesCSState = DataStoreBuffer[3];
 
-            CS_AppData.HkPacket.OSCSState      = DataStoreBuffer[4];
-            CS_AppData.HkPacket.CfeCoreCSState = DataStoreBuffer[5];
+            CS_AppData.HkPacket.Payload.OSCSState      = DataStoreBuffer[4];
+            CS_AppData.HkPacket.Payload.CfeCoreCSState = DataStoreBuffer[5];
         }
         else
         {
@@ -681,13 +681,13 @@ CFE_Status_t CS_CreateRestoreStatesFromCDS(void)
         CS_AppData.DataStoreHandle = CFE_ES_CDS_BAD_HANDLE;
 
         /* Use states from platform configuration */
-        CS_AppData.HkPacket.EepromCSState = CS_EEPROM_TBL_POWERON_STATE;
-        CS_AppData.HkPacket.MemoryCSState = CS_MEMORY_TBL_POWERON_STATE;
-        CS_AppData.HkPacket.AppCSState    = CS_APPS_TBL_POWERON_STATE;
-        CS_AppData.HkPacket.TablesCSState = CS_TABLES_TBL_POWERON_STATE;
+        CS_AppData.HkPacket.Payload.EepromCSState = CS_EEPROM_TBL_POWERON_STATE;
+        CS_AppData.HkPacket.Payload.MemoryCSState = CS_MEMORY_TBL_POWERON_STATE;
+        CS_AppData.HkPacket.Payload.AppCSState    = CS_APPS_TBL_POWERON_STATE;
+        CS_AppData.HkPacket.Payload.TablesCSState = CS_TABLES_TBL_POWERON_STATE;
 
-        CS_AppData.HkPacket.OSCSState      = CS_OSCS_CHECKSUM_STATE;
-        CS_AppData.HkPacket.CfeCoreCSState = CS_CFECORE_CHECKSUM_STATE;
+        CS_AppData.HkPacket.Payload.OSCSState      = CS_OSCS_CHECKSUM_STATE;
+        CS_AppData.HkPacket.Payload.CfeCoreCSState = CS_CFECORE_CHECKSUM_STATE;
 
         CFE_EVS_SendEvent(EventId, CFE_EVS_EventType_ERROR, "Critical Data Store access error = 0x%08X",
                           (unsigned int)Result);
@@ -720,13 +720,13 @@ void CS_UpdateCDS(void)
         /*
         ** Copy ena/dis states of tables to the data array...
         */
-        DataStoreBuffer[0] = CS_AppData.HkPacket.EepromCSState;
-        DataStoreBuffer[1] = CS_AppData.HkPacket.MemoryCSState;
-        DataStoreBuffer[2] = CS_AppData.HkPacket.AppCSState;
-        DataStoreBuffer[3] = CS_AppData.HkPacket.TablesCSState;
+        DataStoreBuffer[0] = CS_AppData.HkPacket.Payload.EepromCSState;
+        DataStoreBuffer[1] = CS_AppData.HkPacket.Payload.MemoryCSState;
+        DataStoreBuffer[2] = CS_AppData.HkPacket.Payload.AppCSState;
+        DataStoreBuffer[3] = CS_AppData.HkPacket.Payload.TablesCSState;
 
-        DataStoreBuffer[4] = CS_AppData.HkPacket.OSCSState;
-        DataStoreBuffer[5] = CS_AppData.HkPacket.CfeCoreCSState;
+        DataStoreBuffer[4] = CS_AppData.HkPacket.Payload.OSCSState;
+        DataStoreBuffer[5] = CS_AppData.HkPacket.Payload.CfeCoreCSState;
 
         /*
         ** Update CS portion of Critical Data Store...

--- a/fsw/src/cs_cmds.c
+++ b/fsw/src/cs_cmds.c
@@ -48,7 +48,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_NoopCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        CS_AppData.HkPacket.CmdCounter++;
+        CS_AppData.HkPacket.Payload.CmdCounter++;
 
         CFE_EVS_SendEvent(CS_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op command. Version %d.%d.%d.%d",
                           CS_MAJOR_VERSION, CS_MINOR_VERSION, CS_REVISION, CS_MISSION_REV);
@@ -61,16 +61,16 @@ void CS_NoopCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_ResetCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        CS_AppData.HkPacket.CmdCounter    = 0;
-        CS_AppData.HkPacket.CmdErrCounter = 0;
+        CS_AppData.HkPacket.Payload.CmdCounter    = 0;
+        CS_AppData.HkPacket.Payload.CmdErrCounter = 0;
 
-        CS_AppData.HkPacket.EepromCSErrCounter  = 0;
-        CS_AppData.HkPacket.MemoryCSErrCounter  = 0;
-        CS_AppData.HkPacket.TablesCSErrCounter  = 0;
-        CS_AppData.HkPacket.AppCSErrCounter     = 0;
-        CS_AppData.HkPacket.CfeCoreCSErrCounter = 0;
-        CS_AppData.HkPacket.OSCSErrCounter      = 0;
-        CS_AppData.HkPacket.PassCounter         = 0;
+        CS_AppData.HkPacket.Payload.EepromCSErrCounter  = 0;
+        CS_AppData.HkPacket.Payload.MemoryCSErrCounter  = 0;
+        CS_AppData.HkPacket.Payload.TablesCSErrCounter  = 0;
+        CS_AppData.HkPacket.Payload.AppCSErrCounter     = 0;
+        CS_AppData.HkPacket.Payload.CfeCoreCSErrCounter = 0;
+        CS_AppData.HkPacket.Payload.OSCSErrCounter      = 0;
+        CS_AppData.HkPacket.Payload.PassCounter         = 0;
 
         CFE_EVS_SendEvent(CS_RESET_DBG_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command recieved");
 }
@@ -105,14 +105,14 @@ void CS_BackgroundCheckCycle(const CS_NoArgsCmd_t *CmdPtr)
     }
     else
     {
-        if (CS_AppData.HkPacket.ChecksumState == CS_STATE_ENABLED)
+        if (CS_AppData.HkPacket.Payload.ChecksumState == CS_STATE_ENABLED)
         {
             DoneWithCycle = false;
             EndOfList     = false;
 
             /* Skip this background cycle if there's a recompute or one shot in
              * progress */
-            if (CS_AppData.HkPacket.RecomputeInProgress == true || CS_AppData.HkPacket.OneShotInProgress == true)
+            if (CS_AppData.HkPacket.Payload.RecomputeInProgress == true || CS_AppData.HkPacket.Payload.OneShotInProgress == true)
             {
                 CFE_EVS_SendEvent(CS_BKGND_COMPUTE_PROG_INF_EID, CFE_EVS_EventType_INFORMATION,
                                   "Skipping background cycle. Recompute or oneshot in progress.");
@@ -128,14 +128,14 @@ void CS_BackgroundCheckCycle(const CS_NoArgsCmd_t *CmdPtr)
                 /* We need to check the current table value here because
                    it is updated (and possibly reset to zero) inside each
                    function called */
-                if (CS_AppData.HkPacket.CurrentCSTable >= (CS_NUM_TABLES - 1))
+                if (CS_AppData.HkPacket.Payload.CurrentCSTable >= (CS_NUM_TABLES - 1))
                 {
                     EndOfList = true;
                 }
 
                 /* Call the appropriate background function based on the current table
                    value.  The value is updated inside each function */
-                switch (CS_AppData.HkPacket.CurrentCSTable)
+                switch (CS_AppData.HkPacket.Payload.CurrentCSTable)
                 {
                     case (CS_CFECORE):
                         DoneWithCycle = CS_BackgroundCfeCore();
@@ -163,13 +163,13 @@ void CS_BackgroundCheckCycle(const CS_NoArgsCmd_t *CmdPtr)
                         DoneWithCycle = CS_BackgroundApp();
                         break;
 
-                        /* default case in case CS_AppData.HkPacket.CurrentCSTable is some random bad value */
+                        /* default case in case CS_AppData.HkPacket.Payload.CurrentCSTable is some random bad value */
                     default:
 
                         /* We are at the end of the line */
-                        CS_AppData.HkPacket.CurrentCSTable      = 0;
-                        CS_AppData.HkPacket.CurrentEntryInTable = 0;
-                        CS_AppData.HkPacket.PassCounter++;
+                        CS_AppData.HkPacket.Payload.CurrentCSTable      = 0;
+                        CS_AppData.HkPacket.Payload.CurrentEntryInTable = 0;
+                        CS_AppData.HkPacket.Payload.PassCounter++;
                         DoneWithCycle = true;
                         break;
 
@@ -190,7 +190,7 @@ void CS_BackgroundCheckCycle(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableAllCSCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        CS_AppData.HkPacket.ChecksumState = CS_STATE_DISABLED;
+        CS_AppData.HkPacket.Payload.ChecksumState = CS_STATE_DISABLED;
 
         /* zero out the temp values in all the tables
          so that when the checksums are re-enabled,
@@ -202,7 +202,7 @@ void CS_DisableAllCSCmd(const CS_NoArgsCmd_t *CmdPtr)
         CS_ZeroCfeCoreTempValues();
         CS_ZeroOSTempValues();
 
-        CS_AppData.HkPacket.CmdCounter++;
+        CS_AppData.HkPacket.Payload.CmdCounter++;
 
         CFE_EVS_SendEvent(CS_DISABLE_ALL_INF_EID, CFE_EVS_EventType_INFORMATION, "Background Checksumming Disabled");
 }
@@ -214,9 +214,9 @@ void CS_DisableAllCSCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableAllCSCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        CS_AppData.HkPacket.ChecksumState = CS_STATE_ENABLED;
+        CS_AppData.HkPacket.Payload.ChecksumState = CS_STATE_ENABLED;
 
-        CS_AppData.HkPacket.CmdCounter++;
+        CS_AppData.HkPacket.Payload.CmdCounter++;
 
         CFE_EVS_SendEvent(CS_ENABLE_ALL_INF_EID, CFE_EVS_EventType_INFORMATION, "Background Checksumming Enabled");
 }
@@ -228,7 +228,7 @@ void CS_EnableAllCSCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        CS_AppData.HkPacket.CfeCoreCSState = CS_STATE_DISABLED;
+        CS_AppData.HkPacket.Payload.CfeCoreCSState = CS_STATE_DISABLED;
         CS_ZeroCfeCoreTempValues();
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
@@ -238,7 +238,7 @@ void CS_DisableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
         CFE_EVS_SendEvent(CS_DISABLE_CFECORE_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Checksumming of cFE Core is Disabled");
 
-        CS_AppData.HkPacket.CmdCounter++;
+        CS_AppData.HkPacket.Payload.CmdCounter++;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -248,7 +248,7 @@ void CS_DisableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        CS_AppData.HkPacket.CfeCoreCSState = CS_STATE_ENABLED;
+        CS_AppData.HkPacket.Payload.CfeCoreCSState = CS_STATE_ENABLED;
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
         CS_UpdateCDS();
@@ -257,7 +257,7 @@ void CS_EnableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
         CFE_EVS_SendEvent(CS_ENABLE_CFECORE_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Checksumming of cFE Core is Enabled");
 
-        CS_AppData.HkPacket.CmdCounter++;
+        CS_AppData.HkPacket.Payload.CmdCounter++;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -267,7 +267,7 @@ void CS_EnableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableOSCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        CS_AppData.HkPacket.OSCSState = CS_STATE_DISABLED;
+        CS_AppData.HkPacket.Payload.OSCSState = CS_STATE_DISABLED;
         CS_ZeroOSTempValues();
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
@@ -277,7 +277,7 @@ void CS_DisableOSCmd(const CS_NoArgsCmd_t *CmdPtr)
         CFE_EVS_SendEvent(CS_DISABLE_OS_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Checksumming of OS code segment is Disabled");
 
-        CS_AppData.HkPacket.CmdCounter++;
+        CS_AppData.HkPacket.Payload.CmdCounter++;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -287,7 +287,7 @@ void CS_DisableOSCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableOSCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        CS_AppData.HkPacket.OSCSState = CS_STATE_ENABLED;
+        CS_AppData.HkPacket.Payload.OSCSState = CS_STATE_ENABLED;
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
         CS_UpdateCDS();
@@ -296,7 +296,7 @@ void CS_EnableOSCmd(const CS_NoArgsCmd_t *CmdPtr)
         CFE_EVS_SendEvent(CS_ENABLE_OS_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Checksumming of OS code segment is Enabled");
 
-        CS_AppData.HkPacket.CmdCounter++;
+        CS_AppData.HkPacket.Payload.CmdCounter++;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -317,7 +317,7 @@ void CS_ReportBaselineCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_NO_BASELINE_CFECORE_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Baseline of cFE Core has not been computed yet");
         }
-        CS_AppData.HkPacket.CmdCounter++;
+        CS_AppData.HkPacket.Payload.CmdCounter++;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -338,7 +338,7 @@ void CS_ReportBaselineOSCmd(const CS_NoArgsCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_NO_BASELINE_OS_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Baseline of OS code segment has not been computed yet");
         }
-        CS_AppData.HkPacket.CmdCounter++;
+        CS_AppData.HkPacket.Payload.CmdCounter++;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -352,10 +352,10 @@ void CS_RecomputeBaselineCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
     CFE_ES_TaskId_t ChildTaskID;
     CFE_Status_t    Status;
 
-        if (CS_AppData.HkPacket.RecomputeInProgress == false && CS_AppData.HkPacket.OneShotInProgress == false)
+        if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false && CS_AppData.HkPacket.Payload.OneShotInProgress == false)
         {
             /* There is no child task running right now, we can use it*/
-            CS_AppData.HkPacket.RecomputeInProgress = true;
+            CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
             /* fill in child task variables */
             CS_AppData.ChildTaskTable                = CS_CFECORE;
@@ -370,15 +370,15 @@ void CS_RecomputeBaselineCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
             {
                 CFE_EVS_SendEvent(CS_RECOMPUTE_CFECORE_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
                                   "Recompute of cFE core started");
-                CS_AppData.HkPacket.CmdCounter++;
+                CS_AppData.HkPacket.Payload.CmdCounter++;
             }
             else /* child task creation failed */
             {
                 CFE_EVS_SendEvent(CS_RECOMPUTE_CFECORE_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Recompute cFE core failed, CFE_ES_CreateChildTask returned: 0x%08X",
                                   (unsigned int)Status);
-                CS_AppData.HkPacket.CmdErrCounter++;
-                CS_AppData.HkPacket.RecomputeInProgress = false;
+                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
             }
         }
         else
@@ -386,7 +386,7 @@ void CS_RecomputeBaselineCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
             /*send event that we can't start another task right now */
             CFE_EVS_SendEvent(CS_RECOMPUTE_CFECORE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Recompute cFE core failed: child task in use");
-            CS_AppData.HkPacket.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
         }
 }
 
@@ -401,10 +401,10 @@ void CS_RecomputeBaselineOSCmd(const CS_NoArgsCmd_t *CmdPtr)
     CFE_ES_TaskId_t ChildTaskID;
     CFE_Status_t    Status;
 
-        if (CS_AppData.HkPacket.RecomputeInProgress == false && CS_AppData.HkPacket.OneShotInProgress == false)
+        if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false && CS_AppData.HkPacket.Payload.OneShotInProgress == false)
         {
             /* There is no child task running right now, we can use it*/
-            CS_AppData.HkPacket.RecomputeInProgress = true;
+            CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
             /* fill in child task variables */
             CS_AppData.ChildTaskTable                = CS_OSCORE;
@@ -417,15 +417,15 @@ void CS_RecomputeBaselineOSCmd(const CS_NoArgsCmd_t *CmdPtr)
             {
                 CFE_EVS_SendEvent(CS_RECOMPUTE_OS_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
                                   "Recompute of OS code segment started");
-                CS_AppData.HkPacket.CmdCounter++;
+                CS_AppData.HkPacket.Payload.CmdCounter++;
             }
             else /* child task creation failed */
             {
                 CFE_EVS_SendEvent(CS_RECOMPUTE_OS_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Recompute OS code segment failed, CFE_ES_CreateChildTask returned: 0x%08X",
                                   (unsigned int)Status);
-                CS_AppData.HkPacket.CmdErrCounter++;
-                CS_AppData.HkPacket.RecomputeInProgress = false;
+                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
             }
         }
         else
@@ -433,7 +433,7 @@ void CS_RecomputeBaselineOSCmd(const CS_NoArgsCmd_t *CmdPtr)
             /*send event that we can't start another task right now */
             CFE_EVS_SendEvent(CS_RECOMPUTE_OS_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Recompute OS code segment failed: child task in use");
-            CS_AppData.HkPacket.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
         }
 }
 
@@ -449,28 +449,28 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
     CFE_Status_t    Status;
 
         /* validate size and address */
-        Status = CFE_PSP_MemValidateRange(CmdPtr->Address, CmdPtr->Size, CFE_PSP_MEM_ANY);
+        Status = CFE_PSP_MemValidateRange(CmdPtr->Payload.Address, CmdPtr->Payload.Size, CFE_PSP_MEM_ANY);
 
         if (Status == CFE_SUCCESS)
         {
-            if (CS_AppData.HkPacket.RecomputeInProgress == false && CS_AppData.HkPacket.OneShotInProgress == false)
+            if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false && CS_AppData.HkPacket.Payload.OneShotInProgress == false)
             {
                 /* There is no child task running right now, we can use it*/
-                CS_AppData.HkPacket.RecomputeInProgress = false;
-                CS_AppData.HkPacket.OneShotInProgress   = true;
+                CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+                CS_AppData.HkPacket.Payload.OneShotInProgress   = true;
 
-                CS_AppData.HkPacket.LastOneShotAddress = CmdPtr->Address;
-                CS_AppData.HkPacket.LastOneShotSize    = CmdPtr->Size;
-                if (CmdPtr->MaxBytesPerCycle == 0)
+                CS_AppData.HkPacket.Payload.LastOneShotAddress = CmdPtr->Payload.Address;
+                CS_AppData.HkPacket.Payload.LastOneShotSize    = CmdPtr->Payload.Size;
+                if (CmdPtr->Payload.MaxBytesPerCycle == 0)
                 {
-                    CS_AppData.HkPacket.LastOneShotMaxBytesPerCycle = CS_AppData.MaxBytesPerCycle;
+                    CS_AppData.HkPacket.Payload.LastOneShotMaxBytesPerCycle = CS_AppData.MaxBytesPerCycle;
                 }
                 else
                 {
-                    CS_AppData.HkPacket.LastOneShotMaxBytesPerCycle = CmdPtr->MaxBytesPerCycle;
+                    CS_AppData.HkPacket.Payload.LastOneShotMaxBytesPerCycle = CmdPtr->Payload.MaxBytesPerCycle;
                 }
 
-                CS_AppData.HkPacket.LastOneShotChecksum = 0;
+                CS_AppData.HkPacket.Payload.LastOneShotChecksum = 0;
 
                 Status = CFE_ES_CreateChildTask(&ChildTaskID, CS_ONESHOT_TASK_NAME, CS_OneShotChildTask, NULL,
                                                 CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
@@ -478,10 +478,10 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
                 {
                     CFE_EVS_SendEvent(CS_ONESHOT_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
                                       "OneShot checksum started on address: 0x%08X, size: %d",
-                                      (unsigned int)(CmdPtr->Address), (int)(CmdPtr->Size));
+                                      (unsigned int)(CmdPtr->Payload.Address), (int)(CmdPtr->Payload.Size));
 
                     CS_AppData.ChildTaskID = ChildTaskID;
-                    CS_AppData.HkPacket.CmdCounter++;
+                    CS_AppData.HkPacket.Payload.CmdCounter++;
                 }
                 else /* child task creation failed */
                 {
@@ -489,9 +489,9 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
                                       "OneShot checkum failed, CFE_ES_CreateChildTask returned: 0x%08X",
                                       (unsigned int)Status);
 
-                    CS_AppData.HkPacket.CmdErrCounter++;
-                    CS_AppData.HkPacket.RecomputeInProgress = false;
-                    CS_AppData.HkPacket.OneShotInProgress   = false;
+                    CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+                    CS_AppData.HkPacket.Payload.OneShotInProgress   = false;
                 }
             }
             else
@@ -500,7 +500,7 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
                 CFE_EVS_SendEvent(CS_ONESHOT_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "OneShot checksum failed: child task in use");
 
-                CS_AppData.HkPacket.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CmdErrCounter++;
             }
         } /* end if CFE_PSP_MemValidateRange */
         else
@@ -509,7 +509,7 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
                               "OneShot checksum failed, CFE_PSP_MemValidateRange returned: 0x%08X",
                               (unsigned int)Status);
 
-            CS_AppData.HkPacket.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
         }
 }
 
@@ -524,16 +524,16 @@ void CS_CancelOneShotCmd(const CS_NoArgsCmd_t *CmdPtr)
     CFE_Status_t Status;
 
         /* Make sure there is a OneShot command in use */
-        if (CS_AppData.HkPacket.RecomputeInProgress == false && CS_AppData.HkPacket.OneShotInProgress == true)
+        if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false && CS_AppData.HkPacket.Payload.OneShotInProgress == true)
         {
             Status = CFE_ES_DeleteChildTask(CS_AppData.ChildTaskID);
 
             if (Status == CFE_SUCCESS)
             {
                 CS_AppData.ChildTaskID                  = CFE_ES_TASKID_UNDEFINED;
-                CS_AppData.HkPacket.RecomputeInProgress = false;
-                CS_AppData.HkPacket.OneShotInProgress   = false;
-                CS_AppData.HkPacket.CmdCounter++;
+                CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+                CS_AppData.HkPacket.Payload.OneShotInProgress   = false;
+                CS_AppData.HkPacket.Payload.CmdCounter++;
                 CFE_EVS_SendEvent(CS_ONESHOT_CANCELLED_INF_EID, CFE_EVS_EventType_INFORMATION,
                                   "OneShot checksum calculation has been cancelled");
             }
@@ -542,13 +542,13 @@ void CS_CancelOneShotCmd(const CS_NoArgsCmd_t *CmdPtr)
                 CFE_EVS_SendEvent(CS_ONESHOT_CANCEL_DELETE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Cancel OneShot checksum failed, CFE_ES_DeleteChildTask returned:  0x%08X",
                                   (unsigned int)Status);
-                CS_AppData.HkPacket.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CmdErrCounter++;
             }
         }
         else
         {
             CFE_EVS_SendEvent(CS_ONESHOT_CANCEL_NO_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Cancel OneShot checksum failed. No OneShot active");
-            CS_AppData.HkPacket.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
         }
 }

--- a/fsw/src/cs_compute.c
+++ b/fsw/src/cs_compute.c
@@ -546,19 +546,19 @@ void CS_RecomputeEepromMemoryChildTask(void)
     if (Table == CS_CFECORE)
     {
         strncpy(TableType, "cFE Core", CS_TABLETYPE_NAME_SIZE);
-        CS_AppData.HkPacket.CfeCoreBaseline = NewChecksumValue;
+        CS_AppData.HkPacket.Payload.CfeCoreBaseline = NewChecksumValue;
     }
     if (Table == CS_OSCORE)
     {
         strncpy(TableType, "OS", CS_TABLETYPE_NAME_SIZE);
-        CS_AppData.HkPacket.OSBaseline = NewChecksumValue;
+        CS_AppData.HkPacket.Payload.OSBaseline = NewChecksumValue;
     }
 
     CFE_EVS_SendEvent(CS_RECOMPUTE_FINISH_EEPROM_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "%s entry %d recompute finished. New baseline is 0X%08X", TableType, EntryID,
                       (unsigned int)NewChecksumValue);
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
     CFE_ES_ExitChildTask();
 }
 
@@ -664,7 +664,7 @@ void CS_RecomputeAppChildTask(void)
                           (unsigned int)NewChecksumValue);
     }
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
     CFE_ES_ExitChildTask();
 }
 
@@ -770,7 +770,7 @@ void CS_RecomputeTablesChildTask(void)
         CFE_TBL_Modified(DefTblHandle);
     }
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
     CFE_ES_ExitChildTask();
 }
 
@@ -788,9 +788,9 @@ void CS_OneShotChildTask(void)
     uint32  MaxBytesPerCycle        = 0;
 
     NewChecksumValue        = 0;
-    NumBytesRemainingCycles = CS_AppData.HkPacket.LastOneShotSize;
-    FirstAddrThisCycle      = CS_AppData.HkPacket.LastOneShotAddress;
-    MaxBytesPerCycle        = CS_AppData.HkPacket.LastOneShotMaxBytesPerCycle;
+    NumBytesRemainingCycles = CS_AppData.HkPacket.Payload.LastOneShotSize;
+    FirstAddrThisCycle      = CS_AppData.HkPacket.Payload.LastOneShotAddress;
+    MaxBytesPerCycle        = CS_AppData.HkPacket.Payload.LastOneShotMaxBytesPerCycle;
 
     while (NumBytesRemainingCycles > 0)
     {
@@ -809,16 +809,16 @@ void CS_OneShotChildTask(void)
     /*Checksum Calculation is done! */
 
     /* put the new checksum value in the baseline */
-    CS_AppData.HkPacket.LastOneShotChecksum = NewChecksumValue;
+    CS_AppData.HkPacket.Payload.LastOneShotChecksum = NewChecksumValue;
 
     /* send event message */
     CFE_EVS_SendEvent(CS_ONESHOT_FINISHED_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "OneShot checksum on Address: 0x%08X, size %d completed. Checksum =  0x%08X",
-                      (unsigned int)(CS_AppData.HkPacket.LastOneShotAddress),
-                      (unsigned int)(CS_AppData.HkPacket.LastOneShotSize),
-                      (unsigned int)(CS_AppData.HkPacket.LastOneShotChecksum));
+                      (unsigned int)(CS_AppData.HkPacket.Payload.LastOneShotAddress),
+                      (unsigned int)(CS_AppData.HkPacket.Payload.LastOneShotSize),
+                      (unsigned int)(CS_AppData.HkPacket.Payload.LastOneShotChecksum));
 
-    CS_AppData.HkPacket.OneShotInProgress = false;
+    CS_AppData.HkPacket.Payload.OneShotInProgress = false;
     CS_AppData.ChildTaskID                = CFE_ES_TASKID_UNDEFINED;
 
     CFE_ES_ExitChildTask();

--- a/fsw/src/cs_eeprom_cmds.c
+++ b/fsw/src/cs_eeprom_cmds.c
@@ -50,7 +50,7 @@ void CS_DisableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
         if (CS_CheckRecomputeOneshot() == false)
         {
-            CS_AppData.HkPacket.EepromCSState = CS_STATE_DISABLED;
+            CS_AppData.HkPacket.Payload.EepromCSState = CS_STATE_DISABLED;
             CS_ZeroEepromTempValues();
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
@@ -60,7 +60,7 @@ void CS_DisableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_DISABLE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Checksumming of EEPROM is Disabled");
 
-            CS_AppData.HkPacket.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CmdCounter++;
         }
 }
 
@@ -73,7 +73,7 @@ void CS_EnableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
         if (CS_CheckRecomputeOneshot() == false)
         {
-            CS_AppData.HkPacket.EepromCSState = CS_STATE_ENABLED;
+            CS_AppData.HkPacket.Payload.EepromCSState = CS_STATE_ENABLED;
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
             CS_UpdateCDS();
@@ -82,7 +82,7 @@ void CS_EnableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_ENABLE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Checksumming of EEPROM is Enabled");
 
-            CS_AppData.HkPacket.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CmdCounter++;
         }
 }
 
@@ -99,7 +99,7 @@ void CS_ReportBaselineEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
     uint16                            State    = CS_STATE_EMPTY;
     CS_Res_EepromMemory_Table_Entry_t ResultsEntry;
 
-        EntryID = CmdPtr->EntryID;
+        EntryID = CmdPtr->Payload.EntryID;
 
         if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
             (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
@@ -118,7 +118,7 @@ void CS_ReportBaselineEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 CFE_EVS_SendEvent(CS_NO_BASELINE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
                                   "Report baseline of EEPROM Entry %d has not been computed yet", EntryID);
             }
-            CS_AppData.HkPacket.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CmdCounter++;
         }
         else
         {
@@ -134,7 +134,7 @@ void CS_ReportBaselineEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_BASELINE_INVALID_ENTRY_EEPROM_ERR_EID, CFE_EVS_EventType_ERROR,
                               "EEPROM report baseline failed, Entry ID invalid: %d, State: %d Max ID: %d", EntryID,
                               State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
-            CS_AppData.HkPacket.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
         }
 }
 
@@ -151,16 +151,16 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
     uint16          EntryID     = 0;
     uint16          State       = CS_STATE_EMPTY;
 
-        EntryID = CmdPtr->EntryID;
+        EntryID = CmdPtr->Payload.EntryID;
 
-        if (CS_AppData.HkPacket.RecomputeInProgress == false && CS_AppData.HkPacket.OneShotInProgress == false)
+        if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false && CS_AppData.HkPacket.Payload.OneShotInProgress == false)
         {
             /* make sure the entry is a valid number and is defined in the table */
             if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
                 (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
             {
                 /* There is no child task running right now, we can use it*/
-                CS_AppData.HkPacket.RecomputeInProgress = true;
+                CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
                 /* fill in child task variables */
                 CS_AppData.ChildTaskTable   = CS_EEPROM_TABLE;
@@ -175,7 +175,7 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 {
                     CFE_EVS_SendEvent(CS_RECOMPUTE_EEPROM_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
                                       "Recompute baseline of EEPROM Entry ID %d started", EntryID);
-                    CS_AppData.HkPacket.CmdCounter++;
+                    CS_AppData.HkPacket.Payload.CmdCounter++;
                 }
                 else /* child task creation failed */
                 {
@@ -183,8 +183,8 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
                         CS_RECOMPUTE_EEPROM_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                         "Recompute baseline of EEPROM Entry ID %d failed, CFE_ES_CreateChildTask returned:  0x%08X",
                         EntryID, (unsigned int)Status);
-                    CS_AppData.HkPacket.CmdErrCounter++;
-                    CS_AppData.HkPacket.RecomputeInProgress = false;
+                    CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
                 }
             }
             else
@@ -203,7 +203,7 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
                     "EEPROM recompute baseline of entry failed, Entry ID invalid: %d, State: %d, Max ID: %d", EntryID,
                     State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
 
-                CS_AppData.HkPacket.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CmdErrCounter++;
             }
         }
         else
@@ -211,7 +211,7 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
             /*send event that we can't start another task right now */
             CFE_EVS_SendEvent(CS_RECOMPUTE_EEPROM_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Recompute baseline of EEPROM Entry ID %d failed: child task in use", EntryID);
-            CS_AppData.HkPacket.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
         }
 }
 
@@ -229,7 +229,7 @@ void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
 
         if (CS_CheckRecomputeOneshot() == false)
         {
-            EntryID = CmdPtr->EntryID;
+            EntryID = CmdPtr->Payload.EntryID;
 
             if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
                 (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
@@ -254,7 +254,7 @@ void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                                       State);
                 }
 
-                CS_AppData.HkPacket.CmdCounter++;
+                CS_AppData.HkPacket.Payload.CmdCounter++;
             }
             else
             {
@@ -270,7 +270,7 @@ void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 CFE_EVS_SendEvent(CS_ENABLE_EEPROM_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Enable EEPROM entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
                                   State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
-                CS_AppData.HkPacket.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CmdErrCounter++;
             }
         } /* end InProgress if */
 }
@@ -289,7 +289,7 @@ void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
 
         if (CS_CheckRecomputeOneshot() == false)
         {
-            EntryID = CmdPtr->EntryID;
+            EntryID = CmdPtr->Payload.EntryID;
 
             if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
                 (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
@@ -316,7 +316,7 @@ void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                                       State);
                 }
 
-                CS_AppData.HkPacket.CmdCounter++;
+                CS_AppData.HkPacket.Payload.CmdCounter++;
             }
             else
             {
@@ -333,7 +333,7 @@ void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                                   "Disable EEPROM entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
                                   State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
 
-                CS_AppData.HkPacket.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CmdErrCounter++;
             }
         } /* end InProgress if */
 }
@@ -357,12 +357,12 @@ void CS_GetEntryIDEepromCmd(const CS_GetEntryIDCmd_t *CmdPtr)
         {
             ResultsEntry = StartOfResultsTable[Loop];
 
-            if ((ResultsEntry.StartAddress <= CmdPtr->Address) &&
-                CmdPtr->Address <= (ResultsEntry.StartAddress + ResultsEntry.NumBytesToChecksum) &&
+            if ((ResultsEntry.StartAddress <= CmdPtr->Payload.Address) &&
+                CmdPtr->Payload.Address <= (ResultsEntry.StartAddress + ResultsEntry.NumBytesToChecksum) &&
                 ResultsEntry.State != CS_STATE_EMPTY)
             {
                 CFE_EVS_SendEvent(CS_GET_ENTRY_ID_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "EEPROM Found Address 0x%08X in Entry ID %d", (unsigned int)(CmdPtr->Address), Loop);
+                                  "EEPROM Found Address 0x%08X in Entry ID %d", (unsigned int)(CmdPtr->Payload.Address), Loop);
                 EntryFound = true;
             }
         }
@@ -370,7 +370,7 @@ void CS_GetEntryIDEepromCmd(const CS_GetEntryIDCmd_t *CmdPtr)
         if (EntryFound == false)
         {
             CFE_EVS_SendEvent(CS_GET_ENTRY_ID_EEPROM_NOT_FOUND_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Address 0x%08X was not found in EEPROM table", (unsigned int)(CmdPtr->Address));
+                              "Address 0x%08X was not found in EEPROM table", (unsigned int)(CmdPtr->Payload.Address));
         }
-        CS_AppData.HkPacket.CmdCounter++;
+        CS_AppData.HkPacket.Payload.CmdCounter++;
 }

--- a/fsw/src/cs_init.c
+++ b/fsw/src/cs_init.c
@@ -110,7 +110,7 @@ CFE_Status_t CS_InitAllTables(void)
 
     if (ResultInit != CFE_SUCCESS)
     {
-        CS_AppData.HkPacket.EepromCSState = CS_STATE_DISABLED;
+        CS_AppData.HkPacket.Payload.EepromCSState = CS_STATE_DISABLED;
         CFE_EVS_SendEvent(CS_INIT_EEPROM_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Table initialization failed for EEPROM: 0x%08X", (unsigned int)ResultInit);
     }
@@ -125,7 +125,7 @@ CFE_Status_t CS_InitAllTables(void)
 
         if (ResultInit != CFE_SUCCESS)
         {
-            CS_AppData.HkPacket.MemoryCSState = CS_STATE_DISABLED;
+            CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_DISABLED;
             CFE_EVS_SendEvent(CS_INIT_MEMORY_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Table initialization failed for Memory: 0x%08X", (unsigned int)ResultInit);
         }
@@ -141,7 +141,7 @@ CFE_Status_t CS_InitAllTables(void)
 
         if (ResultInit != CFE_SUCCESS)
         {
-            CS_AppData.HkPacket.AppCSState = CS_STATE_DISABLED;
+            CS_AppData.HkPacket.Payload.AppCSState = CS_STATE_DISABLED;
             CFE_EVS_SendEvent(CS_INIT_APP_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Table initialization failed for Apps: 0x%08X", (unsigned int)ResultInit);
         }
@@ -158,7 +158,7 @@ CFE_Status_t CS_InitAllTables(void)
 
         if (ResultInit != CFE_SUCCESS)
         {
-            CS_AppData.HkPacket.TablesCSState = CS_STATE_DISABLED;
+            CS_AppData.HkPacket.Payload.TablesCSState = CS_STATE_DISABLED;
             CFE_EVS_SendEvent(CS_INIT_TABLES_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Table initialization failed for Tables: 0x%08X", (unsigned int)ResultInit);
         }

--- a/fsw/src/cs_memory_cmds.c
+++ b/fsw/src/cs_memory_cmds.c
@@ -50,7 +50,7 @@ void CS_DisableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
         if (CS_CheckRecomputeOneshot() == false)
         {
-            CS_AppData.HkPacket.MemoryCSState = CS_STATE_DISABLED;
+            CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_DISABLED;
             CS_ZeroMemoryTempValues();
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
@@ -60,7 +60,7 @@ void CS_DisableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_DISABLE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Checksumming of Memory is Disabled");
 
-            CS_AppData.HkPacket.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CmdCounter++;
         }
 }
 
@@ -73,7 +73,7 @@ void CS_EnableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
         if (CS_CheckRecomputeOneshot() == false)
         {
-            CS_AppData.HkPacket.MemoryCSState = CS_STATE_ENABLED;
+            CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_ENABLED;
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
             CS_UpdateCDS();
@@ -82,7 +82,7 @@ void CS_EnableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_ENABLE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Checksumming of Memory is Enabled");
 
-            CS_AppData.HkPacket.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CmdCounter++;
         }
 }
 
@@ -99,7 +99,7 @@ void CS_ReportBaselineEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
     uint16                             EntryID        = 0;
     uint16                             State          = CS_STATE_EMPTY;
 
-        EntryID = CmdPtr->EntryID;
+        EntryID = CmdPtr->Payload.EntryID;
 
         if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
             (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
@@ -118,7 +118,7 @@ void CS_ReportBaselineEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                 CFE_EVS_SendEvent(CS_NO_BASELINE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
                                   "Report baseline of Memory Entry %d has not been computed yet", EntryID);
             }
-            CS_AppData.HkPacket.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CmdCounter++;
         }
         else
         {
@@ -134,7 +134,7 @@ void CS_ReportBaselineEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_BASELINE_INVALID_ENTRY_MEMORY_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Memory report baseline failed, Entry ID invalid: %d, State: %d Max ID: %d", EntryID,
                               State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
-            CS_AppData.HkPacket.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
         }
 }
 
@@ -151,16 +151,16 @@ void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
     uint16          EntryID        = 0;
     uint16          State          = CS_STATE_EMPTY;
 
-        EntryID = CmdPtr->EntryID;
+        EntryID = CmdPtr->Payload.EntryID;
 
-        if (CS_AppData.HkPacket.RecomputeInProgress == false && CS_AppData.HkPacket.OneShotInProgress == false)
+        if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false && CS_AppData.HkPacket.Payload.OneShotInProgress == false)
         {
             /* make sure the entry is a valid number and is defined in the table */
             if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
                 (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
             {
                 /* There is no child task running right now, we can use it*/
-                CS_AppData.HkPacket.RecomputeInProgress = true;
+                CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
                 /* fill in child task variables */
                 CS_AppData.ChildTaskTable   = CS_MEMORY_TABLE;
@@ -175,7 +175,7 @@ void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                 {
                     CFE_EVS_SendEvent(CS_RECOMPUTE_MEMORY_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
                                       "Recompute baseline of Memory Entry ID %d started", EntryID);
-                    CS_AppData.HkPacket.CmdCounter++;
+                    CS_AppData.HkPacket.Payload.CmdCounter++;
                 }
                 else /* child task creation failed */
                 {
@@ -183,8 +183,8 @@ void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                         CS_RECOMPUTE_MEMORY_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                         "Recompute baseline of Memory Entry ID %d failed, ES_CreateChildTask returned:  0x%08X",
                         EntryID, (unsigned int)Status);
-                    CS_AppData.HkPacket.CmdErrCounter++;
-                    CS_AppData.HkPacket.RecomputeInProgress = false;
+                    CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
                 }
             }
             else
@@ -203,7 +203,7 @@ void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                     "Memory recompute baseline of entry failed, Entry ID invalid: %d, State: %d, Max ID: %d", EntryID,
                     State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
 
-                CS_AppData.HkPacket.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CmdErrCounter++;
             }
         }
         else
@@ -211,7 +211,7 @@ void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
             /*send event that we can't start another task right now */
             CFE_EVS_SendEvent(CS_RECOMPUTE_MEMORY_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Recompute baseline of Memory Entry ID %d failed: child task in use", EntryID);
-            CS_AppData.HkPacket.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
         }
 }
 
@@ -229,7 +229,7 @@ void CS_EnableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 
         if (CS_CheckRecomputeOneshot() == false)
         {
-            EntryID = CmdPtr->EntryID;
+            EntryID = CmdPtr->Payload.EntryID;
 
             if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
                 (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
@@ -254,7 +254,7 @@ void CS_EnableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                                       State);
                 }
 
-                CS_AppData.HkPacket.CmdCounter++;
+                CS_AppData.HkPacket.Payload.CmdCounter++;
             }
             else
             {
@@ -270,7 +270,7 @@ void CS_EnableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                 CFE_EVS_SendEvent(CS_ENABLE_MEMORY_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Enable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
                                   State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
-                CS_AppData.HkPacket.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CmdErrCounter++;
             }
         } /* end InProgress if */
 }
@@ -289,7 +289,7 @@ void CS_DisableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 
         if (CS_CheckRecomputeOneshot() == false)
         {
-            EntryID = CmdPtr->EntryID;
+            EntryID = CmdPtr->Payload.EntryID;
 
             if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
                 (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
@@ -316,7 +316,7 @@ void CS_DisableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                                       State);
                 }
 
-                CS_AppData.HkPacket.CmdCounter++;
+                CS_AppData.HkPacket.Payload.CmdCounter++;
             }
             else
             {
@@ -333,7 +333,7 @@ void CS_DisableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                                   "Disable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
                                   State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
 
-                CS_AppData.HkPacket.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CmdErrCounter++;
             }
         } /* end InProgress if */
 }
@@ -357,12 +357,12 @@ void CS_GetEntryIDMemoryCmd(const CS_GetEntryIDCmd_t *CmdPtr)
         {
             ResultsEntry = &StartOfResultsTable[Loop];
 
-            if ((ResultsEntry->StartAddress <= CmdPtr->Address) &&
-                CmdPtr->Address <= (ResultsEntry->StartAddress + ResultsEntry->NumBytesToChecksum) &&
+            if ((ResultsEntry->StartAddress <= CmdPtr->Payload.Address) &&
+                CmdPtr->Payload.Address <= (ResultsEntry->StartAddress + ResultsEntry->NumBytesToChecksum) &&
                 ResultsEntry->State != CS_STATE_EMPTY)
             {
                 CFE_EVS_SendEvent(CS_GET_ENTRY_ID_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Memory Found Address 0x%08X in Entry ID %d", (unsigned int)(CmdPtr->Address), Loop);
+                                  "Memory Found Address 0x%08X in Entry ID %d", (unsigned int)(CmdPtr->Payload.Address), Loop);
                 EntryFound = true;
             }
         }
@@ -370,7 +370,7 @@ void CS_GetEntryIDMemoryCmd(const CS_GetEntryIDCmd_t *CmdPtr)
         if (EntryFound == false)
         {
             CFE_EVS_SendEvent(CS_GET_ENTRY_ID_MEMORY_NOT_FOUND_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Address 0x%08X was not found in Memory table", (unsigned int)(CmdPtr->Address));
+                              "Address 0x%08X was not found in Memory table", (unsigned int)(CmdPtr->Payload.Address));
         }
-        CS_AppData.HkPacket.CmdCounter++;
+        CS_AppData.HkPacket.Payload.CmdCounter++;
 }

--- a/fsw/src/cs_table_processing.c
+++ b/fsw/src/cs_table_processing.c
@@ -471,13 +471,13 @@ void CS_ProcessNewEepromMemoryDefinitionTable(const CS_Def_EepromMemory_Table_En
     /* We don't want to be doing chekcksums while changing the table out */
     if (Table == CS_EEPROM_TABLE)
     {
-        PreviousState                     = CS_AppData.HkPacket.EepromCSState;
-        CS_AppData.HkPacket.EepromCSState = CS_STATE_DISABLED;
+        PreviousState                     = CS_AppData.HkPacket.Payload.EepromCSState;
+        CS_AppData.HkPacket.Payload.EepromCSState = CS_STATE_DISABLED;
     }
     if (Table == CS_MEMORY_TABLE)
     {
-        PreviousState                     = CS_AppData.HkPacket.MemoryCSState;
-        CS_AppData.HkPacket.MemoryCSState = CS_STATE_DISABLED;
+        PreviousState                     = CS_AppData.HkPacket.Payload.MemoryCSState;
+        CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_DISABLED;
     }
 
     for (Loop = 0; Loop < NumEntries; Loop++)
@@ -514,13 +514,13 @@ void CS_ProcessNewEepromMemoryDefinitionTable(const CS_Def_EepromMemory_Table_En
     /* Reset the table back to the original checksumming state */
     if (Table == CS_EEPROM_TABLE)
     {
-        CS_AppData.HkPacket.EepromCSState = PreviousState;
+        CS_AppData.HkPacket.Payload.EepromCSState = PreviousState;
         CS_ResetTablesTblResultEntry(CS_AppData.EepResTablesTblPtr);
     }
 
     if (Table == CS_MEMORY_TABLE)
     {
-        CS_AppData.HkPacket.MemoryCSState = PreviousState;
+        CS_AppData.HkPacket.Payload.MemoryCSState = PreviousState;
         CS_ResetTablesTblResultEntry(CS_AppData.MemResTablesTblPtr);
     }
 
@@ -572,8 +572,8 @@ void CS_ProcessNewTablesDefinitionTable(const CS_Def_Tables_Table_Entry_t *Defin
     CFE_ES_GetAppName(AppName, AppID, OS_MAX_API_NAME);
 
     /* We don't want to be doing chekcksums while changing the table out */
-    PreviousState                     = CS_AppData.HkPacket.TablesCSState;
-    CS_AppData.HkPacket.TablesCSState = CS_STATE_DISABLED;
+    PreviousState                     = CS_AppData.HkPacket.Payload.TablesCSState;
+    CS_AppData.HkPacket.Payload.TablesCSState = CS_STATE_DISABLED;
 
     /* Assume none of the CS tables are listed in the new Tables table */
     CS_AppData.EepResTablesTblPtr = NULL;
@@ -724,7 +724,7 @@ void CS_ProcessNewTablesDefinitionTable(const CS_Def_Tables_Table_Entry_t *Defin
 
     /* Reset the table back to the original checksumming state */
 
-    CS_AppData.HkPacket.TablesCSState = PreviousState;
+    CS_AppData.HkPacket.Payload.TablesCSState = PreviousState;
 
     if (NumRegionsInTable == 0)
     {
@@ -754,8 +754,8 @@ void CS_ProcessNewAppDefinitionTable(const CS_Def_App_Table_Entry_t *DefinitionT
 
     /* We don't want to be doing chekcksums while changing the table out */
 
-    PreviousState                  = CS_AppData.HkPacket.AppCSState;
-    CS_AppData.HkPacket.AppCSState = CS_STATE_DISABLED;
+    PreviousState                  = CS_AppData.HkPacket.Payload.AppCSState;
+    CS_AppData.HkPacket.Payload.AppCSState = CS_STATE_DISABLED;
 
     for (Loop = 0; Loop < CS_MAX_NUM_APP_TABLE_ENTRIES; Loop++)
     {
@@ -795,7 +795,7 @@ void CS_ProcessNewAppDefinitionTable(const CS_Def_App_Table_Entry_t *DefinitionT
 
     /* Reset the table back to the original checksumming state */
 
-    CS_AppData.HkPacket.AppCSState = PreviousState;
+    CS_AppData.HkPacket.Payload.AppCSState = PreviousState;
     CS_ResetTablesTblResultEntry(CS_AppData.AppResTablesTblPtr);
 
     if (NumRegionsInTable == 0)
@@ -931,16 +931,16 @@ CFE_Status_t CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handl
         switch (Table)
         {
             case CS_EEPROM_TABLE:
-                CS_AppData.HkPacket.EepromCSState = CS_STATE_DISABLED;
+                CS_AppData.HkPacket.Payload.EepromCSState = CS_STATE_DISABLED;
                 break;
             case CS_MEMORY_TABLE:
-                CS_AppData.HkPacket.MemoryCSState = CS_STATE_DISABLED;
+                CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_DISABLED;
                 break;
             case CS_APP_TABLE:
-                CS_AppData.HkPacket.AppCSState = CS_STATE_DISABLED;
+                CS_AppData.HkPacket.Payload.AppCSState = CS_STATE_DISABLED;
                 break;
             case CS_TABLES_TABLE:
-                CS_AppData.HkPacket.TablesCSState = CS_STATE_DISABLED;
+                CS_AppData.HkPacket.Payload.TablesCSState = CS_STATE_DISABLED;
                 break;
             default:
                 break;

--- a/fsw/src/cs_utils.c
+++ b/fsw/src/cs_utils.c
@@ -168,19 +168,19 @@ void CS_InitializeDefaultTables(void)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_GoToNextTable(void)
 {
-    if (CS_AppData.HkPacket.CurrentCSTable < (CS_NUM_TABLES - 1))
+    if (CS_AppData.HkPacket.Payload.CurrentCSTable < (CS_NUM_TABLES - 1))
     {
-        CS_AppData.HkPacket.CurrentCSTable++;
+        CS_AppData.HkPacket.Payload.CurrentCSTable++;
     }
     else
     {
-        CS_AppData.HkPacket.CurrentCSTable = 0;
+        CS_AppData.HkPacket.Payload.CurrentCSTable = 0;
         /* we are back to the beginning of the tables to checksum
          we need to update the pass counter */
-        CS_AppData.HkPacket.PassCounter++;
+        CS_AppData.HkPacket.Payload.PassCounter++;
     }
 
-    CS_AppData.HkPacket.CurrentEntryInTable = 0;
+    CS_AppData.HkPacket.Payload.CurrentEntryInTable = 0;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -317,23 +317,23 @@ bool CS_FindEnabledEepromEntry(uint16 *EnabledEntry)
 
     StartOfResultsTable = CS_AppData.ResEepromTblPtr;
 
-    ResultsEntry = &StartOfResultsTable[CS_AppData.HkPacket.CurrentEntryInTable];
+    ResultsEntry = &StartOfResultsTable[CS_AppData.HkPacket.Payload.CurrentEntryInTable];
 
     while (ResultsEntry->State != CS_STATE_ENABLED)
     {
-        CS_AppData.HkPacket.CurrentEntryInTable++;
+        CS_AppData.HkPacket.Payload.CurrentEntryInTable++;
 
-        if (CS_AppData.HkPacket.CurrentEntryInTable >= CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
+        if (CS_AppData.HkPacket.Payload.CurrentEntryInTable >= CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
         {
             /* we reached the end no more enabled entries */
             EnabledEntries = false;
             break;
         }
 
-        ResultsEntry = &StartOfResultsTable[CS_AppData.HkPacket.CurrentEntryInTable];
+        ResultsEntry = &StartOfResultsTable[CS_AppData.HkPacket.Payload.CurrentEntryInTable];
     } /* end while */
 
-    *EnabledEntry = CS_AppData.HkPacket.CurrentEntryInTable;
+    *EnabledEntry = CS_AppData.HkPacket.Payload.CurrentEntryInTable;
 
     return EnabledEntries;
 }
@@ -350,23 +350,23 @@ bool CS_FindEnabledMemoryEntry(uint16 *EnabledEntry)
     bool                               EnabledEntries      = true;
 
     StartOfResultsTable = CS_AppData.ResMemoryTblPtr;
-    ResultsEntry        = &StartOfResultsTable[CS_AppData.HkPacket.CurrentEntryInTable];
+    ResultsEntry        = &StartOfResultsTable[CS_AppData.HkPacket.Payload.CurrentEntryInTable];
 
     while (ResultsEntry->State != CS_STATE_ENABLED)
     {
-        CS_AppData.HkPacket.CurrentEntryInTable++;
+        CS_AppData.HkPacket.Payload.CurrentEntryInTable++;
 
-        if (CS_AppData.HkPacket.CurrentEntryInTable >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
+        if (CS_AppData.HkPacket.Payload.CurrentEntryInTable >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
         {
             /* we reached the end no more enabled entries */
             EnabledEntries = false;
             break;
         }
 
-        ResultsEntry = &StartOfResultsTable[CS_AppData.HkPacket.CurrentEntryInTable];
+        ResultsEntry = &StartOfResultsTable[CS_AppData.HkPacket.Payload.CurrentEntryInTable];
     } /* end while */
 
-    *EnabledEntry = CS_AppData.HkPacket.CurrentEntryInTable;
+    *EnabledEntry = CS_AppData.HkPacket.Payload.CurrentEntryInTable;
 
     return EnabledEntries;
 }
@@ -383,13 +383,13 @@ bool CS_FindEnabledTablesEntry(uint16 *EnabledEntry)
     bool                         EnabledEntries      = true;
 
     StartOfResultsTable = CS_AppData.ResTablesTblPtr;
-    ResultsEntry        = &StartOfResultsTable[CS_AppData.HkPacket.CurrentEntryInTable];
+    ResultsEntry        = &StartOfResultsTable[CS_AppData.HkPacket.Payload.CurrentEntryInTable];
 
     while (ResultsEntry->State != CS_STATE_ENABLED)
     {
-        CS_AppData.HkPacket.CurrentEntryInTable++;
+        CS_AppData.HkPacket.Payload.CurrentEntryInTable++;
 
-        if (CS_AppData.HkPacket.CurrentEntryInTable >= CS_MAX_NUM_TABLES_TABLE_ENTRIES)
+        if (CS_AppData.HkPacket.Payload.CurrentEntryInTable >= CS_MAX_NUM_TABLES_TABLE_ENTRIES)
         {
             /* we reached the end no more enabled entries */
             EnabledEntries = false;
@@ -397,11 +397,11 @@ bool CS_FindEnabledTablesEntry(uint16 *EnabledEntry)
             break;
         }
 
-        ResultsEntry = &StartOfResultsTable[CS_AppData.HkPacket.CurrentEntryInTable];
+        ResultsEntry = &StartOfResultsTable[CS_AppData.HkPacket.Payload.CurrentEntryInTable];
 
     } /* end while */
 
-    *EnabledEntry = CS_AppData.HkPacket.CurrentEntryInTable;
+    *EnabledEntry = CS_AppData.HkPacket.Payload.CurrentEntryInTable;
 
     return EnabledEntries;
 }
@@ -417,24 +417,24 @@ bool CS_FindEnabledAppEntry(uint16 *EnabledEntry)
     bool                      EnabledEntries      = true;
 
     StartOfResultsTable = CS_AppData.ResAppTblPtr;
-    ResultsEntry        = &StartOfResultsTable[CS_AppData.HkPacket.CurrentEntryInTable];
+    ResultsEntry        = &StartOfResultsTable[CS_AppData.HkPacket.Payload.CurrentEntryInTable];
 
     while (ResultsEntry->State != CS_STATE_ENABLED)
     {
-        CS_AppData.HkPacket.CurrentEntryInTable++;
+        CS_AppData.HkPacket.Payload.CurrentEntryInTable++;
 
-        if (CS_AppData.HkPacket.CurrentEntryInTable >= CS_MAX_NUM_APP_TABLE_ENTRIES)
+        if (CS_AppData.HkPacket.Payload.CurrentEntryInTable >= CS_MAX_NUM_APP_TABLE_ENTRIES)
         {
             /* we reached the end no more enabled entries */
             EnabledEntries = false;
             break;
         }
 
-        ResultsEntry = &StartOfResultsTable[CS_AppData.HkPacket.CurrentEntryInTable];
+        ResultsEntry = &StartOfResultsTable[CS_AppData.HkPacket.Payload.CurrentEntryInTable];
 
     } /* end while */
 
-    *EnabledEntry = CS_AppData.HkPacket.CurrentEntryInTable;
+    *EnabledEntry = CS_AppData.HkPacket.Payload.CurrentEntryInTable;
 
     return EnabledEntries;
 }
@@ -464,7 +464,7 @@ bool CS_VerifyCmdLength(const CFE_MSG_Message_t *msg, size_t ExpectedLength)
                           (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode, (unsigned long)ActualLength,
                           (unsigned long)ExpectedLength);
         Result = false;
-        CS_AppData.HkPacket.CmdErrCounter++;
+        CS_AppData.HkPacket.Payload.CmdErrCounter++;
     }
     return Result;
 }
@@ -482,7 +482,7 @@ bool CS_BackgroundCfeCore(void)
     uint32                             ComputedCSValue = 0;
     CFE_Status_t                       Status;
 
-    if (CS_AppData.HkPacket.CfeCoreCSState == CS_STATE_ENABLED)
+    if (CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_STATE_ENABLED)
     {
         ResultsEntry = &CS_AppData.CfeCoreCodeSeg;
 
@@ -502,7 +502,7 @@ bool CS_BackgroundCfeCore(void)
             {
                 /* we had a miscompare */
 
-                CS_AppData.HkPacket.CfeCoreCSErrCounter++;
+                CS_AppData.HkPacket.Payload.CfeCoreCSErrCounter++;
 
                 CFE_EVS_SendEvent(CS_CFECORE_MISCOMPARE_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Checksum Failure: cFE Core, Expected: 0x%08X, Calculated: 0x%08X",
@@ -511,14 +511,14 @@ bool CS_BackgroundCfeCore(void)
 
             if (DoneWithEntry == true)
             {
-                CS_AppData.HkPacket.CurrentEntryInTable++;
+                CS_AppData.HkPacket.Payload.CurrentEntryInTable++;
             }
 
             /* only one entry to do */
-            if (CS_AppData.HkPacket.CurrentEntryInTable > 0)
+            if (CS_AppData.HkPacket.Payload.CurrentEntryInTable > 0)
             {
                 /* We are done with this table */
-                CS_AppData.HkPacket.CfeCoreBaseline = ResultsEntry->ComparisonValue;
+                CS_AppData.HkPacket.Payload.CfeCoreBaseline = ResultsEntry->ComparisonValue;
                 CS_GoToNextTable();
             }
         }
@@ -549,7 +549,7 @@ bool CS_BackgroundOS(void)
     uint32                             ComputedCSValue = 0;
     CFE_Status_t                       Status;
 
-    if (CS_AppData.HkPacket.OSCSState == CS_STATE_ENABLED)
+    if (CS_AppData.HkPacket.Payload.OSCSState == CS_STATE_ENABLED)
     {
         ResultsEntry = &CS_AppData.OSCodeSeg;
 
@@ -568,7 +568,7 @@ bool CS_BackgroundOS(void)
             if (Status == CS_ERROR)
             {
                 /* we had a miscompare */
-                CS_AppData.HkPacket.OSCSErrCounter++;
+                CS_AppData.HkPacket.Payload.OSCSErrCounter++;
 
                 CFE_EVS_SendEvent(CS_OS_MISCOMPARE_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Checksum Failure: OS code segment, Expected: 0x%08X, Calculated: 0x%08X",
@@ -577,14 +577,14 @@ bool CS_BackgroundOS(void)
 
             if (DoneWithEntry == true)
             {
-                CS_AppData.HkPacket.CurrentEntryInTable++;
+                CS_AppData.HkPacket.Payload.CurrentEntryInTable++;
             }
 
             /* only one entry to do */
-            if (CS_AppData.HkPacket.CurrentEntryInTable > 0)
+            if (CS_AppData.HkPacket.Payload.CurrentEntryInTable > 0)
             {
                 /* We are done with this table */
-                CS_AppData.HkPacket.OSBaseline = ResultsEntry->ComparisonValue;
+                CS_AppData.HkPacket.Payload.OSBaseline = ResultsEntry->ComparisonValue;
                 CS_GoToNextTable();
             }
         }
@@ -618,7 +618,7 @@ bool CS_BackgroundEeprom(void)
     uint16                             CurrEntry;
     CFE_Status_t                       Status;
 
-    if (CS_AppData.HkPacket.EepromCSState == CS_STATE_ENABLED)
+    if (CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_ENABLED)
     {
         if (CS_FindEnabledEepromEntry(&CurrEntry) == true)
         {
@@ -638,7 +638,7 @@ bool CS_BackgroundEeprom(void)
             {
                 /* we had a miscompare */
 
-                CS_AppData.HkPacket.EepromCSErrCounter++;
+                CS_AppData.HkPacket.Payload.EepromCSErrCounter++;
 
                 CFE_EVS_SendEvent(CS_EEPROM_MISCOMPARE_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Checksum Failure: Entry %d in EEPROM Table, Expected: 0x%08X, Calculated: 0x%08X",
@@ -648,11 +648,11 @@ bool CS_BackgroundEeprom(void)
 
             if (DoneWithEntry == true)
             {
-                CS_AppData.HkPacket.CurrentEntryInTable++;
+                CS_AppData.HkPacket.Payload.CurrentEntryInTable++;
             }
         }
 
-        if (CS_AppData.HkPacket.CurrentEntryInTable >= CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
+        if (CS_AppData.HkPacket.Payload.CurrentEntryInTable >= CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
         {
             /* Since we are done CS'ing the entire EEPROM table, update the baseline
              number for telemetry */
@@ -662,7 +662,7 @@ bool CS_BackgroundEeprom(void)
                 EntireEepromCS += CS_AppData.ResEepromTblPtr[Loop].ComparisonValue;
             }
 
-            CS_AppData.HkPacket.EepromBaseline = EntireEepromCS;
+            CS_AppData.HkPacket.Payload.EepromBaseline = EntireEepromCS;
 
             /* We are done with this table */
             CS_GoToNextTable();
@@ -691,7 +691,7 @@ bool CS_BackgroundMemory(void)
     uint16                             CurrEntry;
     CFE_Status_t                       Status;
 
-    if (CS_AppData.HkPacket.MemoryCSState == CS_STATE_ENABLED)
+    if (CS_AppData.HkPacket.Payload.MemoryCSState == CS_STATE_ENABLED)
     {
         /* If we complete an entry's checksum, this function will update it for us */
 
@@ -713,7 +713,7 @@ bool CS_BackgroundMemory(void)
             {
                 /* we had a miscompare */
 
-                CS_AppData.HkPacket.MemoryCSErrCounter++;
+                CS_AppData.HkPacket.Payload.MemoryCSErrCounter++;
 
                 CFE_EVS_SendEvent(CS_MEMORY_MISCOMPARE_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Checksum Failure: Entry %d in Memory Table, Expected: 0x%08X, Calculated: 0x%08X",
@@ -723,10 +723,10 @@ bool CS_BackgroundMemory(void)
 
             if (DoneWithEntry == true)
             {
-                CS_AppData.HkPacket.CurrentEntryInTable++;
+                CS_AppData.HkPacket.Payload.CurrentEntryInTable++;
             }
 
-            if (CS_AppData.HkPacket.CurrentEntryInTable >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
+            if (CS_AppData.HkPacket.Payload.CurrentEntryInTable >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
             {
                 /* We are done with this table */
                 CS_GoToNextTable();
@@ -760,7 +760,7 @@ bool CS_BackgroundTables(void)
     uint16                       CurrEntry;
     CFE_Status_t                 Status;
 
-    if (CS_AppData.HkPacket.TablesCSState == CS_STATE_ENABLED)
+    if (CS_AppData.HkPacket.Payload.TablesCSState == CS_STATE_ENABLED)
     {
         /* If we complete an entry's checksum, this function will update it for us */
 
@@ -781,7 +781,7 @@ bool CS_BackgroundTables(void)
             if (Status == CS_ERROR)
             {
                 /* we had a miscompare */
-                CS_AppData.HkPacket.TablesCSErrCounter++;
+                CS_AppData.HkPacket.Payload.TablesCSErrCounter++;
 
                 CFE_EVS_SendEvent(CS_TABLES_MISCOMPARE_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Checksum Failure: Table %s, Expected: 0x%08X, Calculated: 0x%08X",
@@ -795,15 +795,15 @@ bool CS_BackgroundTables(void)
                                   "Tables table computing: Table %s could not be found, skipping",
                                   TablesResultsEntry->Name);
 
-                CS_AppData.HkPacket.CurrentEntryInTable++;
+                CS_AppData.HkPacket.Payload.CurrentEntryInTable++;
             }
 
             if (DoneWithEntry == true)
             {
-                CS_AppData.HkPacket.CurrentEntryInTable++;
+                CS_AppData.HkPacket.Payload.CurrentEntryInTable++;
             }
 
-            if (CS_AppData.HkPacket.CurrentEntryInTable >= CS_MAX_NUM_TABLES_TABLE_ENTRIES)
+            if (CS_AppData.HkPacket.Payload.CurrentEntryInTable >= CS_MAX_NUM_TABLES_TABLE_ENTRIES)
             {
                 /* We are done with this table */
                 CS_GoToNextTable();
@@ -837,7 +837,7 @@ bool CS_BackgroundApp(void)
     uint16                    CurrEntry;
     CFE_Status_t              Status;
 
-    if (CS_AppData.HkPacket.AppCSState == CS_STATE_ENABLED)
+    if (CS_AppData.HkPacket.Payload.AppCSState == CS_STATE_ENABLED)
     {
         if (CS_FindEnabledAppEntry(&CurrEntry) == true)
         {
@@ -857,7 +857,7 @@ bool CS_BackgroundApp(void)
             if (Status == CS_ERROR)
             {
                 /* we had a miscompare */
-                CS_AppData.HkPacket.AppCSErrCounter++;
+                CS_AppData.HkPacket.Payload.AppCSErrCounter++;
 
                 CFE_EVS_SendEvent(CS_APP_MISCOMPARE_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Checksum Failure: Application %s, Expected: 0x%08X, Calculated: 0x%08X",
@@ -870,15 +870,15 @@ bool CS_BackgroundApp(void)
                 CFE_EVS_SendEvent(CS_COMPUTE_APP_NOT_FOUND_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "App table computing: App %s could not be found, skipping", AppResultsEntry->Name);
 
-                CS_AppData.HkPacket.CurrentEntryInTable++;
+                CS_AppData.HkPacket.Payload.CurrentEntryInTable++;
             }
 
             if (DoneWithEntry == true)
             {
-                CS_AppData.HkPacket.CurrentEntryInTable++;
+                CS_AppData.HkPacket.Payload.CurrentEntryInTable++;
             }
 
-            if (CS_AppData.HkPacket.CurrentEntryInTable >= CS_MAX_NUM_APP_TABLE_ENTRIES)
+            if (CS_AppData.HkPacket.Payload.CurrentEntryInTable >= CS_MAX_NUM_APP_TABLE_ENTRIES)
             {
                 /* We are done with this table */
                 CS_GoToNextTable();
@@ -922,7 +922,7 @@ CFE_Status_t CS_HandleRoutineTableUpdates(void)
     CFE_Status_t Result    = CFE_SUCCESS;
     CFE_Status_t ErrorCode = CFE_SUCCESS;
 
-    if (!((CS_AppData.HkPacket.RecomputeInProgress == true) && (CS_AppData.HkPacket.OneShotInProgress == false) &&
+    if (!((CS_AppData.HkPacket.Payload.RecomputeInProgress == true) && (CS_AppData.HkPacket.Payload.OneShotInProgress == false) &&
           (CS_AppData.ChildTaskTable == CS_EEPROM_TABLE)))
     {
         Result = CS_HandleTableUpdate((void *)&CS_AppData.DefEepromTblPtr, (void *)&CS_AppData.ResEepromTblPtr,
@@ -931,7 +931,7 @@ CFE_Status_t CS_HandleRoutineTableUpdates(void)
 
         if (Result != CFE_SUCCESS)
         {
-            CS_AppData.HkPacket.EepromCSState = CS_STATE_DISABLED;
+            CS_AppData.HkPacket.Payload.EepromCSState = CS_STATE_DISABLED;
             Result                            = CFE_EVS_SendEvent(CS_UPDATE_EEPROM_ERR_EID, CFE_EVS_EventType_ERROR,
                                        "Table update failed for EEPROM: 0x%08X, checksumming EEPROM is disabled",
                                        (unsigned int)Result);
@@ -939,7 +939,7 @@ CFE_Status_t CS_HandleRoutineTableUpdates(void)
         }
     }
 
-    if (!((CS_AppData.HkPacket.RecomputeInProgress == true) && (CS_AppData.HkPacket.OneShotInProgress == false) &&
+    if (!((CS_AppData.HkPacket.Payload.RecomputeInProgress == true) && (CS_AppData.HkPacket.Payload.OneShotInProgress == false) &&
           (CS_AppData.ChildTaskTable == CS_MEMORY_TABLE)))
     {
         Result = CS_HandleTableUpdate((void *)&CS_AppData.DefMemoryTblPtr, (void *)&CS_AppData.ResMemoryTblPtr,
@@ -947,7 +947,7 @@ CFE_Status_t CS_HandleRoutineTableUpdates(void)
                                       CS_MAX_NUM_MEMORY_TABLE_ENTRIES);
         if (Result != CFE_SUCCESS)
         {
-            CS_AppData.HkPacket.MemoryCSState = CS_STATE_DISABLED;
+            CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_DISABLED;
             Result                            = CFE_EVS_SendEvent(CS_UPDATE_MEMORY_ERR_EID, CFE_EVS_EventType_ERROR,
                                        "Table update failed for Memory: 0x%08X, checksumming Memory is disabled",
                                        (unsigned int)Result);
@@ -959,7 +959,7 @@ CFE_Status_t CS_HandleRoutineTableUpdates(void)
         }
     }
 
-    if (!((CS_AppData.HkPacket.RecomputeInProgress == true) && (CS_AppData.HkPacket.OneShotInProgress == false) &&
+    if (!((CS_AppData.HkPacket.Payload.RecomputeInProgress == true) && (CS_AppData.HkPacket.Payload.OneShotInProgress == false) &&
           (CS_AppData.ChildTaskTable == CS_APP_TABLE)))
     {
         Result = CS_HandleTableUpdate((void *)&CS_AppData.DefAppTblPtr, (void *)&CS_AppData.ResAppTblPtr,
@@ -967,7 +967,7 @@ CFE_Status_t CS_HandleRoutineTableUpdates(void)
                                       CS_MAX_NUM_APP_TABLE_ENTRIES);
         if (Result != CFE_SUCCESS)
         {
-            CS_AppData.HkPacket.AppCSState = CS_STATE_DISABLED;
+            CS_AppData.HkPacket.Payload.AppCSState = CS_STATE_DISABLED;
             Result                         = CFE_EVS_SendEvent(CS_UPDATE_APP_ERR_EID, CFE_EVS_EventType_ERROR,
                                        "Table update failed for Apps: 0x%08X, checksumming Apps is disabled",
                                        (unsigned int)Result);
@@ -978,7 +978,7 @@ CFE_Status_t CS_HandleRoutineTableUpdates(void)
         }
     }
 
-    if (!((CS_AppData.HkPacket.RecomputeInProgress == true) && (CS_AppData.HkPacket.OneShotInProgress == false) &&
+    if (!((CS_AppData.HkPacket.Payload.RecomputeInProgress == true) && (CS_AppData.HkPacket.Payload.OneShotInProgress == false) &&
           (CS_AppData.ChildTaskTable == CS_TABLES_TABLE)))
     {
         Result = CS_HandleTableUpdate((void *)&CS_AppData.DefTablesTblPtr, (void *)&CS_AppData.ResTablesTblPtr,
@@ -987,7 +987,7 @@ CFE_Status_t CS_HandleRoutineTableUpdates(void)
 
         if (Result != CFE_SUCCESS)
         {
-            CS_AppData.HkPacket.TablesCSState = CS_STATE_DISABLED;
+            CS_AppData.HkPacket.Payload.TablesCSState = CS_STATE_DISABLED;
             Result                            = CFE_EVS_SendEvent(CS_UPDATE_TABLES_ERR_EID, CFE_EVS_EventType_ERROR,
                                        "Table update failed for Tables: 0x%08X, checksumming Tables is disabled",
                                        (unsigned int)Result);
@@ -1033,12 +1033,12 @@ bool CS_CheckRecomputeOneshot(void)
 {
     bool Result = false;
 
-    if (CS_AppData.HkPacket.RecomputeInProgress == true || CS_AppData.HkPacket.OneShotInProgress == true)
+    if (CS_AppData.HkPacket.Payload.RecomputeInProgress == true || CS_AppData.HkPacket.Payload.OneShotInProgress == true)
     {
         CFE_EVS_SendEvent(CS_CMD_COMPUTE_PROG_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Cannot perform command. Recompute or oneshot in progress.");
 
-        CS_AppData.HkPacket.CmdErrCounter++;
+        CS_AppData.HkPacket.Payload.CmdErrCounter++;
 
         Result = true;
     }

--- a/unit-test/cs_app_cmds_tests.c
+++ b/unit-test/cs_app_cmds_tests.c
@@ -88,8 +88,8 @@ void CS_DisableAppCmd_Test(void)
     CS_DisableAppCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.AppCSState == CS_STATE_DISABLED,
-                  "CS_AppData.HkPacket.AppCSState == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.AppCSState == CS_STATE_DISABLED,
+                  "CS_AppData.HkPacket.Payload.AppCSState == CS_STATE_DISABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_DISABLE_APP_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -98,7 +98,7 @@ void CS_DisableAppCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -118,7 +118,7 @@ void CS_DisableAppCmd_Test_OneShot(void)
     CS_DisableAppCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -140,8 +140,8 @@ void CS_EnableAppCmd_Test(void)
     CS_EnableAppCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.AppCSState == CS_STATE_ENABLED,
-                  "CS_AppData.HkPacket.AppCSState == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.AppCSState == CS_STATE_ENABLED,
+                  "CS_AppData.HkPacket.Payload.AppCSState == CS_STATE_ENABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ENABLE_APP_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -150,9 +150,9 @@ void CS_EnableAppCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -172,7 +172,7 @@ void CS_EnableAppCmd_Test_OneShot(void)
     CS_EnableAppCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -188,7 +188,7 @@ void CS_ReportBaselineAppCmd_Test_Baseline(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Report baseline of app %%s is 0x%%08X");
 
-    strncpy(CmdPacket.Name, "App1", OS_MAX_API_NAME);
+    strncpy(CmdPacket.Payload.Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.ResAppTblPtr->Name, "App1", OS_MAX_API_NAME);
 
     /* Needed to make subfunction CS_GetAppResTblEntryByName behave properly */
@@ -212,7 +212,7 @@ void CS_ReportBaselineAppCmd_Test_Baseline(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -229,7 +229,7 @@ void CS_ReportBaselineAppCmd_Test_NoBaseline(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Report baseline of app %%s has not been computed yet");
 
-    strncpy(CmdPacket.Name, "App1", OS_MAX_API_NAME);
+    strncpy(CmdPacket.Payload.Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.ResAppTblPtr->Name, "App1", OS_MAX_API_NAME);
 
     /* Needed to make subfunction CS_GetAppResTblEntryByName behave properly */
@@ -252,9 +252,9 @@ void CS_ReportBaselineAppCmd_Test_NoBaseline(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -270,7 +270,7 @@ void CS_ReportBaselineAppCmd_Test_BaselineInvalidName(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "App report baseline failed, app %%s not found");
 
-    strncpy(CmdPacket.Name, "App1", OS_MAX_API_NAME);
+    strncpy(CmdPacket.Payload.Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.ResAppTblPtr->Name, "App2", OS_MAX_API_NAME);
 
     /* Needed to make subfunction CS_GetAppResTblEntryByName behave properly */
@@ -290,7 +290,7 @@ void CS_ReportBaselineAppCmd_Test_BaselineInvalidName(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -307,11 +307,11 @@ void CS_ReportBaselineAppCmd_Test_OneShot(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "App recompute baseline for app %%s failed: child task in use");
 
-    strncpy(CmdPacket.Name, "App1", OS_MAX_API_NAME);
+    strncpy(CmdPacket.Payload.Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.ResAppTblPtr->Name, "App2", OS_MAX_API_NAME);
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
-    CS_AppData.HkPacket.OneShotInProgress   = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.OneShotInProgress   = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -329,7 +329,7 @@ void CS_ReportBaselineAppCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -345,10 +345,10 @@ void CS_RecomputeBaselineAppCmd_Test_Nominal(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Recompute baseline of app %%s started");
 
-    strncpy(CmdPacket.Name, "App1", OS_MAX_API_NAME);
+    strncpy(CmdPacket.Payload.Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.ResAppTblPtr->Name, "App1", OS_MAX_API_NAME);
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
 
     /* Needed to make subfunction CS_GetAppResTblEntryByName behave properly */
     CS_AppData.ResAppTblPtr->State = 1;
@@ -375,9 +375,9 @@ void CS_RecomputeBaselineAppCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -394,10 +394,10 @@ void CS_RecomputeBaselineAppCmd_Test_CreateChildTaskError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Recompute baseline of app %%s failed, CFE_ES_CreateChildTask returned: 0x%%08X");
 
-    strncpy(CmdPacket.Name, "App1", OS_MAX_API_NAME);
+    strncpy(CmdPacket.Payload.Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.ResAppTblPtr->Name, "App1", OS_MAX_API_NAME);
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
 
     /* Needed to make subfunction CS_GetAppResTblEntryByName behave properly */
     CS_AppData.ResAppTblPtr->State = 1;
@@ -424,7 +424,7 @@ void CS_RecomputeBaselineAppCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -441,10 +441,10 @@ void CS_RecomputeBaselineAppCmd_Test_UnknownNameError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "App recompute baseline failed, app %%s not found");
 
-    strncpy(CmdPacket.Name, "App1", OS_MAX_API_NAME);
+    strncpy(CmdPacket.Payload.Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.ResAppTblPtr->Name, "App2", OS_MAX_API_NAME);
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
 
     /* Needed to make subfunction CS_GetAppResTblEntryByName behave properly */
     CS_AppData.ResAppTblPtr->State = 1;
@@ -463,7 +463,7 @@ void CS_RecomputeBaselineAppCmd_Test_UnknownNameError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -480,10 +480,10 @@ void CS_RecomputeBaselineAppCmd_Test_RecomputeInProgress(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "App recompute baseline for app %%s failed: child task in use");
 
-    strncpy(CmdPacket.Name, "App1", OS_MAX_API_NAME);
+    strncpy(CmdPacket.Payload.Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.ResAppTblPtr->Name, "App2", OS_MAX_API_NAME);
 
-    CS_AppData.HkPacket.RecomputeInProgress = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -501,7 +501,7 @@ void CS_RecomputeBaselineAppCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -517,7 +517,7 @@ void CS_DisableNameAppCmd_Test_Nominal(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Checksumming of app %%s is Disabled");
 
-    strncpy(CmdPacket.Name, "App1", OS_MAX_API_NAME);
+    strncpy(CmdPacket.Payload.Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.ResAppTblPtr->Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.DefAppTblPtr->Name, "App1", OS_MAX_API_NAME);
 
@@ -547,9 +547,9 @@ void CS_DisableNameAppCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -568,7 +568,7 @@ void CS_DisableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS unable to update apps definition table for entry %%s");
 
-    strncpy(CmdPacket.Name, "App1", OS_MAX_API_NAME);
+    strncpy(CmdPacket.Payload.Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.ResAppTblPtr->Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.DefAppTblPtr->Name, "App1", OS_MAX_API_NAME);
 
@@ -603,9 +603,9 @@ void CS_DisableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -622,7 +622,7 @@ void CS_DisableNameAppCmd_Test_UnknownNameError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "App disable app command failed, app %%s not found");
 
-    strncpy(CmdPacket.Name, "App1", OS_MAX_API_NAME);
+    strncpy(CmdPacket.Payload.Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.ResAppTblPtr->Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.DefAppTblPtr->Name, "App1", OS_MAX_API_NAME);
 
@@ -643,7 +643,7 @@ void CS_DisableNameAppCmd_Test_UnknownNameError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -663,7 +663,7 @@ void CS_DisableNameAppCmd_Test_OneShot(void)
     CS_DisableNameAppCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -679,7 +679,7 @@ void CS_EnableNameAppCmd_Test_Nominal(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Checksumming of app %%s is Enabled");
 
-    strncpy(CmdPacket.Name, "App1", OS_MAX_API_NAME);
+    strncpy(CmdPacket.Payload.Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.ResAppTblPtr->Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.DefAppTblPtr->Name, "App1", OS_MAX_API_NAME);
 
@@ -709,9 +709,9 @@ void CS_EnableNameAppCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -730,7 +730,7 @@ void CS_EnableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS unable to update apps definition table for entry %%s");
 
-    strncpy(CmdPacket.Name, "App1", OS_MAX_API_NAME);
+    strncpy(CmdPacket.Payload.Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.ResAppTblPtr->Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.DefAppTblPtr->Name, "App1", OS_MAX_API_NAME);
 
@@ -765,9 +765,9 @@ void CS_EnableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -784,7 +784,7 @@ void CS_EnableNameAppCmd_Test_UnknownNameError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "App enable app command failed, app %%s not found");
 
-    strncpy(CmdPacket.Name, "App1", OS_MAX_API_NAME);
+    strncpy(CmdPacket.Payload.Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.ResAppTblPtr->Name, "App1", OS_MAX_API_NAME);
     strncpy(CS_AppData.DefAppTblPtr->Name, "App1", OS_MAX_API_NAME);
 
@@ -799,7 +799,7 @@ void CS_EnableNameAppCmd_Test_UnknownNameError(void)
     CS_EnableNameAppCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ENABLE_APP_UNKNOWN_NAME_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -826,7 +826,7 @@ void CS_EnableNameAppCmd_Test_OneShot(void)
     CS_EnableNameAppCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 

--- a/unit-test/cs_app_tests.c
+++ b/unit-test/cs_app_tests.c
@@ -529,10 +529,10 @@ void CS_AppInit_Test_NominalPowerOnReset(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "CS Initialized. Version %%d.%%d.%%d.%%d");
 
-    CS_AppData.HkPacket.EepromCSState = 99;
-    CS_AppData.HkPacket.MemoryCSState = 99;
-    CS_AppData.HkPacket.AppCSState    = 99;
-    CS_AppData.HkPacket.TablesCSState = 99;
+    CS_AppData.HkPacket.Payload.EepromCSState = 99;
+    CS_AppData.HkPacket.Payload.MemoryCSState = 99;
+    CS_AppData.HkPacket.Payload.AppCSState    = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState = 99;
 
     /* Set to prevent segmentation fault */
     UT_SetDeferredRetcode(UT_KEY(CFE_MSG_GetMsgId), 1, 99);
@@ -554,19 +554,19 @@ void CS_AppInit_Test_NominalPowerOnReset(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.EepromCSState == CS_EEPROM_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.EepromCSState == CS_EEPROM_TBL_POWERON_STATE");
-    UtAssert_True(CS_AppData.HkPacket.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE");
-    UtAssert_True(CS_AppData.HkPacket.AppCSState == CS_APPS_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.AppCSState    == CS_APPS_TBL_POWERON_STATE");
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == CS_TABLES_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.TablesCSState == CS_TABLES_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSState == CS_EEPROM_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.EepromCSState == CS_EEPROM_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.AppCSState == CS_APPS_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.AppCSState    == CS_APPS_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == CS_TABLES_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.TablesCSState == CS_TABLES_TBL_POWERON_STATE");
 
-    UtAssert_True(CS_AppData.HkPacket.OSCSState == CS_OSCS_CHECKSUM_STATE,
-                  "CS_AppData.HkPacket.OSCSState == CS_OSCS_CHECKSUM_STATE");
-    UtAssert_True(CS_AppData.HkPacket.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE,
-                  "CS_AppData.HkPacket.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OSCSState == CS_OSCS_CHECKSUM_STATE,
+                  "CS_AppData.HkPacket.Payload.OSCSState == CS_OSCS_CHECKSUM_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE,
+                  "CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -578,21 +578,21 @@ void CS_AppInit_Test_NominalPowerOnReset(void)
 
 void CS_AppInit_Test_NominalProcReset(void)
 {
-    CS_AppData.HkPacket.EepromCSState = 99;
-    CS_AppData.HkPacket.MemoryCSState = 99;
-    CS_AppData.HkPacket.AppCSState    = 99;
-    CS_AppData.HkPacket.TablesCSState = 99;
+    CS_AppData.HkPacket.Payload.EepromCSState = 99;
+    CS_AppData.HkPacket.Payload.MemoryCSState = 99;
+    CS_AppData.HkPacket.Payload.AppCSState    = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState = 99;
 
     /* Execute the function being tested */
     UtAssert_INT32_EQ(CS_AppInit(), CFE_SUCCESS);
 
     /* Verify results */
-    UtAssert_UINT32_EQ(CS_AppData.HkPacket.EepromCSState, CS_STATE_ENABLED);
-    UtAssert_UINT32_EQ(CS_AppData.HkPacket.MemoryCSState, CS_STATE_ENABLED);
-    UtAssert_UINT32_EQ(CS_AppData.HkPacket.AppCSState, CS_STATE_ENABLED);
-    UtAssert_UINT32_EQ(CS_AppData.HkPacket.TablesCSState, CS_STATE_ENABLED);
-    UtAssert_UINT32_EQ(CS_AppData.HkPacket.OSCSState, CS_STATE_ENABLED);
-    UtAssert_UINT32_EQ(CS_AppData.HkPacket.CfeCoreCSState, CS_STATE_ENABLED);
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.Payload.EepromCSState, CS_STATE_ENABLED);
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.Payload.MemoryCSState, CS_STATE_ENABLED);
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.Payload.AppCSState, CS_STATE_ENABLED);
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.Payload.TablesCSState, CS_STATE_ENABLED);
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.Payload.OSCSState, CS_STATE_ENABLED);
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.Payload.CfeCoreCSState, CS_STATE_ENABLED);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_INIT_INF_EID);
@@ -603,12 +603,12 @@ void CS_CreateRestoreStatesFromCDS_Test_NoExistingCDS(void)
 {
     CFE_Status_t Result;
 
-    CS_AppData.HkPacket.EepromCSState  = 99;
-    CS_AppData.HkPacket.MemoryCSState  = 99;
-    CS_AppData.HkPacket.AppCSState     = 99;
-    CS_AppData.HkPacket.TablesCSState  = 99;
-    CS_AppData.HkPacket.OSCSState      = 99;
-    CS_AppData.HkPacket.CfeCoreCSState = 99;
+    CS_AppData.HkPacket.Payload.EepromCSState  = 99;
+    CS_AppData.HkPacket.Payload.MemoryCSState  = 99;
+    CS_AppData.HkPacket.Payload.AppCSState     = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState  = 99;
+    CS_AppData.HkPacket.Payload.OSCSState      = 99;
+    CS_AppData.HkPacket.Payload.CfeCoreCSState = 99;
 
     /* Execute the function being tested */
     Result = CS_CreateRestoreStatesFromCDS();
@@ -616,14 +616,14 @@ void CS_CreateRestoreStatesFromCDS_Test_NoExistingCDS(void)
     /* Verify results */
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
-    UtAssert_True(CS_AppData.HkPacket.EepromCSState == 99, "CS_AppData.HkPacket.EepromCSState == CS_STATE_ENABLED");
-    UtAssert_True(CS_AppData.HkPacket.MemoryCSState == 99, "CS_AppData.HkPacket.MemoryCSState == CS_STATE_ENABLED");
-    UtAssert_True(CS_AppData.HkPacket.AppCSState == 99, "CS_AppData.HkPacket.AppCSState  == CS_STATE_ENABLED");
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == 99, "CS_AppData.HkPacket.TablesCSState == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSState == 99, "CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSState == 99, "CS_AppData.HkPacket.Payload.MemoryCSState == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.AppCSState == 99, "CS_AppData.HkPacket.Payload.AppCSState  == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == 99, "CS_AppData.HkPacket.Payload.TablesCSState == CS_STATE_ENABLED");
 
-    UtAssert_True(CS_AppData.HkPacket.OSCSState == 99, "CS_AppData.HkPacket.OSCSState == CS_OSCS_CHECKSUM_STATE");
-    UtAssert_True(CS_AppData.HkPacket.CfeCoreCSState == 99,
-                  "CS_AppData.HkPacket.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OSCSState == 99, "CS_AppData.HkPacket.Payload.OSCSState == CS_OSCS_CHECKSUM_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CfeCoreCSState == 99,
+                  "CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -635,12 +635,12 @@ void CS_CreateRestoreStatesFromCDS_Test_CDSSuccess(void)
 {
     CFE_Status_t Result;
 
-    CS_AppData.HkPacket.EepromCSState  = 99;
-    CS_AppData.HkPacket.MemoryCSState  = 99;
-    CS_AppData.HkPacket.AppCSState     = 99;
-    CS_AppData.HkPacket.TablesCSState  = 99;
-    CS_AppData.HkPacket.OSCSState      = 99;
-    CS_AppData.HkPacket.CfeCoreCSState = 99;
+    CS_AppData.HkPacket.Payload.EepromCSState  = 99;
+    CS_AppData.HkPacket.Payload.MemoryCSState  = 99;
+    CS_AppData.HkPacket.Payload.AppCSState     = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState  = 99;
+    CS_AppData.HkPacket.Payload.OSCSState      = 99;
+    CS_AppData.HkPacket.Payload.CfeCoreCSState = 99;
 
     /* Set CDS return calls */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RegisterCDS), 1, CFE_ES_CDS_ALREADY_EXISTS);
@@ -653,19 +653,19 @@ void CS_CreateRestoreStatesFromCDS_Test_CDSSuccess(void)
     /* Verify results */
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
-    UtAssert_True(CS_AppData.HkPacket.EepromCSState == CS_STATE_ENABLED,
-                  "CS_AppData.HkPacket.EepromCSState == CS_STATE_ENABLED");
-    UtAssert_True(CS_AppData.HkPacket.MemoryCSState == CS_STATE_ENABLED,
-                  "CS_AppData.HkPacket.MemoryCSState == CS_STATE_ENABLED");
-    UtAssert_True(CS_AppData.HkPacket.AppCSState == CS_STATE_ENABLED,
-                  "CS_AppData.HkPacket.AppCSState    == CS_STATE_ENABLED");
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == CS_STATE_ENABLED,
-                  "CS_AppData.HkPacket.TablesCSState == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_ENABLED,
+                  "CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSState == CS_STATE_ENABLED,
+                  "CS_AppData.HkPacket.Payload.MemoryCSState == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.AppCSState == CS_STATE_ENABLED,
+                  "CS_AppData.HkPacket.Payload.AppCSState    == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == CS_STATE_ENABLED,
+                  "CS_AppData.HkPacket.Payload.TablesCSState == CS_STATE_ENABLED");
 
-    UtAssert_True(CS_AppData.HkPacket.OSCSState == CS_STATE_ENABLED,
-                  "CS_AppData.HkPacket.OSCSState == CS_STATE_ENABLED");
-    UtAssert_True(CS_AppData.HkPacket.CfeCoreCSState == CS_STATE_ENABLED,
-                  "CS_AppData.HkPacket.CfeCoreCSState == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OSCSState == CS_STATE_ENABLED,
+                  "CS_AppData.HkPacket.Payload.OSCSState == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_STATE_ENABLED,
+                  "CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_STATE_ENABLED");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -682,12 +682,12 @@ void CS_CreateRestoreStatesFromCDS_Test_CDSFail(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Critical Data Store access error = 0x%%08X");
 
-    CS_AppData.HkPacket.EepromCSState  = 99;
-    CS_AppData.HkPacket.MemoryCSState  = 99;
-    CS_AppData.HkPacket.AppCSState     = 99;
-    CS_AppData.HkPacket.TablesCSState  = 99;
-    CS_AppData.HkPacket.OSCSState      = 99;
-    CS_AppData.HkPacket.CfeCoreCSState = 99;
+    CS_AppData.HkPacket.Payload.EepromCSState  = 99;
+    CS_AppData.HkPacket.Payload.MemoryCSState  = 99;
+    CS_AppData.HkPacket.Payload.AppCSState     = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState  = 99;
+    CS_AppData.HkPacket.Payload.OSCSState      = 99;
+    CS_AppData.HkPacket.Payload.CfeCoreCSState = 99;
 
     /* Set CDS return calls */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RegisterCDS), 1, CFE_ES_CDS_ALREADY_EXISTS);
@@ -701,19 +701,19 @@ void CS_CreateRestoreStatesFromCDS_Test_CDSFail(void)
     /* Verify results */
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
-    UtAssert_True(CS_AppData.HkPacket.EepromCSState == CS_EEPROM_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.EepromCSState == CS_EEPROM_TBL_POWERON_STATE");
-    UtAssert_True(CS_AppData.HkPacket.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE");
-    UtAssert_True(CS_AppData.HkPacket.AppCSState == CS_APPS_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.AppCSState    == CS_APPS_TBL_POWERON_STATE");
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == CS_TABLES_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.TablesCSState == CS_TABLES_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSState == CS_EEPROM_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.EepromCSState == CS_EEPROM_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.AppCSState == CS_APPS_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.AppCSState    == CS_APPS_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == CS_TABLES_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.TablesCSState == CS_TABLES_TBL_POWERON_STATE");
 
-    UtAssert_True(CS_AppData.HkPacket.OSCSState == CS_OSCS_CHECKSUM_STATE,
-                  "CS_AppData.HkPacket.OSCSState == CS_OSCS_CHECKSUM_STATE");
-    UtAssert_True(CS_AppData.HkPacket.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE,
-                  "CS_AppData.HkPacket.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OSCSState == CS_OSCS_CHECKSUM_STATE,
+                  "CS_AppData.HkPacket.Payload.OSCSState == CS_OSCS_CHECKSUM_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE,
+                  "CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_CR_CDS_RES_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -737,12 +737,12 @@ void CS_CreateRestoreStatesFromCDS_Test_CopyToCDSFail(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Critical Data Store access error = 0x%%08X");
 
-    CS_AppData.HkPacket.EepromCSState  = 99;
-    CS_AppData.HkPacket.MemoryCSState  = 99;
-    CS_AppData.HkPacket.AppCSState     = 99;
-    CS_AppData.HkPacket.TablesCSState  = 99;
-    CS_AppData.HkPacket.OSCSState      = 99;
-    CS_AppData.HkPacket.CfeCoreCSState = 99;
+    CS_AppData.HkPacket.Payload.EepromCSState  = 99;
+    CS_AppData.HkPacket.Payload.MemoryCSState  = 99;
+    CS_AppData.HkPacket.Payload.AppCSState     = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState  = 99;
+    CS_AppData.HkPacket.Payload.OSCSState      = 99;
+    CS_AppData.HkPacket.Payload.CfeCoreCSState = 99;
 
     /* Set CDS return calls */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RegisterCDS), 1, CFE_SUCCESS);
@@ -758,19 +758,19 @@ void CS_CreateRestoreStatesFromCDS_Test_CopyToCDSFail(void)
     /* Verify results */
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
-    UtAssert_True(CS_AppData.HkPacket.EepromCSState == CS_EEPROM_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.EepromCSState == CS_EEPROM_TBL_POWERON_STATE");
-    UtAssert_True(CS_AppData.HkPacket.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE");
-    UtAssert_True(CS_AppData.HkPacket.AppCSState == CS_APPS_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.AppCSState    == CS_APPS_TBL_POWERON_STATE");
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == CS_TABLES_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.TablesCSState == CS_TABLES_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSState == CS_EEPROM_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.EepromCSState == CS_EEPROM_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.AppCSState == CS_APPS_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.AppCSState    == CS_APPS_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == CS_TABLES_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.TablesCSState == CS_TABLES_TBL_POWERON_STATE");
 
-    UtAssert_True(CS_AppData.HkPacket.OSCSState == CS_OSCS_CHECKSUM_STATE,
-                  "CS_AppData.HkPacket.OSCSState == CS_OSCS_CHECKSUM_STATE");
-    UtAssert_True(CS_AppData.HkPacket.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE,
-                  "CS_AppData.HkPacket.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OSCSState == CS_OSCS_CHECKSUM_STATE,
+                  "CS_AppData.HkPacket.Payload.OSCSState == CS_OSCS_CHECKSUM_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE,
+                  "CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_CR_CDS_CPY_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -794,12 +794,12 @@ void CS_CreateRestoreStatesFromCDS_Test_RegisterCDSFail(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Critical Data Store access error = 0x%%08X");
 
-    CS_AppData.HkPacket.EepromCSState  = 99;
-    CS_AppData.HkPacket.MemoryCSState  = 99;
-    CS_AppData.HkPacket.AppCSState     = 99;
-    CS_AppData.HkPacket.TablesCSState  = 99;
-    CS_AppData.HkPacket.OSCSState      = 99;
-    CS_AppData.HkPacket.CfeCoreCSState = 99;
+    CS_AppData.HkPacket.Payload.EepromCSState  = 99;
+    CS_AppData.HkPacket.Payload.MemoryCSState  = 99;
+    CS_AppData.HkPacket.Payload.AppCSState     = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState  = 99;
+    CS_AppData.HkPacket.Payload.OSCSState      = 99;
+    CS_AppData.HkPacket.Payload.CfeCoreCSState = 99;
 
     /* Set CDS return calls */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RegisterCDS), 1, -1);
@@ -815,19 +815,19 @@ void CS_CreateRestoreStatesFromCDS_Test_RegisterCDSFail(void)
     /* Verify results */
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
-    UtAssert_True(CS_AppData.HkPacket.EepromCSState == CS_EEPROM_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.EepromCSState == CS_EEPROM_TBL_POWERON_STATE");
-    UtAssert_True(CS_AppData.HkPacket.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE");
-    UtAssert_True(CS_AppData.HkPacket.AppCSState == CS_APPS_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.AppCSState    == CS_APPS_TBL_POWERON_STATE");
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == CS_TABLES_TBL_POWERON_STATE,
-                  "CS_AppData.HkPacket.TablesCSState == CS_TABLES_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSState == CS_EEPROM_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.EepromCSState == CS_EEPROM_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.MemoryCSState == CS_MEMORY_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.AppCSState == CS_APPS_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.AppCSState    == CS_APPS_TBL_POWERON_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == CS_TABLES_TBL_POWERON_STATE,
+                  "CS_AppData.HkPacket.Payload.TablesCSState == CS_TABLES_TBL_POWERON_STATE");
 
-    UtAssert_True(CS_AppData.HkPacket.OSCSState == CS_OSCS_CHECKSUM_STATE,
-                  "CS_AppData.HkPacket.OSCSState == CS_OSCS_CHECKSUM_STATE");
-    UtAssert_True(CS_AppData.HkPacket.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE,
-                  "CS_AppData.HkPacket.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OSCSState == CS_OSCS_CHECKSUM_STATE,
+                  "CS_AppData.HkPacket.Payload.OSCSState == CS_OSCS_CHECKSUM_STATE");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE,
+                  "CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_CFECORE_CHECKSUM_STATE");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_CR_CDS_REG_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -2184,63 +2184,63 @@ void CS_HousekeepingCmd_Test_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    CS_AppData.HkPacket.CmdCounter          = 1;
-    CS_AppData.HkPacket.CmdErrCounter       = 2;
-    CS_AppData.HkPacket.ChecksumState       = 3;
-    CS_AppData.HkPacket.EepromCSState       = 4;
-    CS_AppData.HkPacket.MemoryCSState       = 5;
-    CS_AppData.HkPacket.AppCSState          = 6;
-    CS_AppData.HkPacket.TablesCSState       = 7;
-    CS_AppData.HkPacket.OSCSState           = 8;
-    CS_AppData.HkPacket.CfeCoreCSState      = 9;
-    CS_AppData.HkPacket.RecomputeInProgress = 10;
-    CS_AppData.HkPacket.OneShotInProgress   = 11;
-    CS_AppData.HkPacket.EepromCSErrCounter  = 12;
-    CS_AppData.HkPacket.MemoryCSErrCounter  = 13;
-    CS_AppData.HkPacket.AppCSErrCounter     = 14;
-    CS_AppData.HkPacket.TablesCSErrCounter  = 15;
-    CS_AppData.HkPacket.CfeCoreCSErrCounter = 16;
-    CS_AppData.HkPacket.OSCSErrCounter      = 17;
-    CS_AppData.HkPacket.CurrentCSTable      = 18;
-    CS_AppData.HkPacket.CurrentEntryInTable = 19;
-    CS_AppData.HkPacket.EepromBaseline      = 20;
-    CS_AppData.HkPacket.OSBaseline          = 21;
-    CS_AppData.HkPacket.CfeCoreBaseline     = 22;
-    CS_AppData.HkPacket.LastOneShotAddress  = 23;
-    CS_AppData.HkPacket.LastOneShotSize     = 24;
-    CS_AppData.HkPacket.LastOneShotChecksum = 25;
-    CS_AppData.HkPacket.PassCounter         = 26;
+    CS_AppData.HkPacket.Payload.CmdCounter          = 1;
+    CS_AppData.HkPacket.Payload.CmdErrCounter       = 2;
+    CS_AppData.HkPacket.Payload.ChecksumState       = 3;
+    CS_AppData.HkPacket.Payload.EepromCSState       = 4;
+    CS_AppData.HkPacket.Payload.MemoryCSState       = 5;
+    CS_AppData.HkPacket.Payload.AppCSState          = 6;
+    CS_AppData.HkPacket.Payload.TablesCSState       = 7;
+    CS_AppData.HkPacket.Payload.OSCSState           = 8;
+    CS_AppData.HkPacket.Payload.CfeCoreCSState      = 9;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = 10;
+    CS_AppData.HkPacket.Payload.OneShotInProgress   = 11;
+    CS_AppData.HkPacket.Payload.EepromCSErrCounter  = 12;
+    CS_AppData.HkPacket.Payload.MemoryCSErrCounter  = 13;
+    CS_AppData.HkPacket.Payload.AppCSErrCounter     = 14;
+    CS_AppData.HkPacket.Payload.TablesCSErrCounter  = 15;
+    CS_AppData.HkPacket.Payload.CfeCoreCSErrCounter = 16;
+    CS_AppData.HkPacket.Payload.OSCSErrCounter      = 17;
+    CS_AppData.HkPacket.Payload.CurrentCSTable      = 18;
+    CS_AppData.HkPacket.Payload.CurrentEntryInTable = 19;
+    CS_AppData.HkPacket.Payload.EepromBaseline      = 20;
+    CS_AppData.HkPacket.Payload.OSBaseline          = 21;
+    CS_AppData.HkPacket.Payload.CfeCoreBaseline     = 22;
+    CS_AppData.HkPacket.Payload.LastOneShotAddress  = 23;
+    CS_AppData.HkPacket.Payload.LastOneShotSize     = 24;
+    CS_AppData.HkPacket.Payload.LastOneShotChecksum = 25;
+    CS_AppData.HkPacket.Payload.PassCounter         = 26;
 
     /* Execute the function being tested */
     CS_HousekeepingCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 2, "CS_AppData.HkPacket.CmdErrCounter == 2");
-    UtAssert_True(CS_AppData.HkPacket.ChecksumState == 3, "CS_AppData.HkPacket.ChecksumState == 3");
-    UtAssert_True(CS_AppData.HkPacket.EepromCSState == 4, "CS_AppData.HkPacket.EepromCSState == 4");
-    UtAssert_True(CS_AppData.HkPacket.MemoryCSState == 5, "CS_AppData.HkPacket.MemoryCSState == 5");
-    UtAssert_True(CS_AppData.HkPacket.AppCSState == 6, "CS_AppData.HkPacket.AppCSState == 6");
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == 7, "CS_AppData.HkPacket.TablesCSState == 7");
-    UtAssert_True(CS_AppData.HkPacket.OSCSState == 8, "CS_AppData.HkPacket.OSCSState == 8");
-    UtAssert_True(CS_AppData.HkPacket.CfeCoreCSState == 9, "CS_AppData.HkPacket.CfeCoreCSState == 9");
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == 10, "CS_AppData.HkPacket.ChildTaskInUse == 10");
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == 11, "CS_AppData.HkPacket.OneShotInProgress == 11");
-    UtAssert_True(CS_AppData.HkPacket.EepromCSErrCounter == 12, "CS_AppData.HkPacket.EepromCSErrCounter == 12");
-    UtAssert_True(CS_AppData.HkPacket.MemoryCSErrCounter == 13, "CS_AppData.HkPacket.MemoryCSErrCounter == 13");
-    UtAssert_True(CS_AppData.HkPacket.AppCSErrCounter == 14, "CS_AppData.HkPacket.AppCSErrCounter == 14");
-    UtAssert_True(CS_AppData.HkPacket.TablesCSErrCounter == 15, "CS_AppData.HkPacket.TablesCSErrCounter == 15");
-    UtAssert_True(CS_AppData.HkPacket.CfeCoreCSErrCounter == 16, "CS_AppData.HkPacket.CfeCoreCSErrCounter == 16");
-    UtAssert_True(CS_AppData.HkPacket.OSCSErrCounter == 17, "CS_AppData.HkPacket.OSCSErrCounter == 17");
-    UtAssert_True(CS_AppData.HkPacket.CurrentCSTable == 18, "CS_AppData.HkPacket.CurrentCSTable == 18");
-    UtAssert_True(CS_AppData.HkPacket.CurrentEntryInTable == 19, "CS_AppData.HkPacket.CurrentEntryInTable == 19");
-    UtAssert_True(CS_AppData.HkPacket.EepromBaseline == 20, "CS_AppData.HkPacket.EepromBaseline == 20");
-    UtAssert_True(CS_AppData.HkPacket.OSBaseline == 21, "CS_AppData.HkPacket.OSBaseline == 21");
-    UtAssert_True(CS_AppData.HkPacket.CfeCoreBaseline == 22, "CS_AppData.HkPacket.CfeCoreBaseline == 22");
-    UtAssert_True(CS_AppData.HkPacket.LastOneShotAddress == 23, "CS_AppData.HkPacket.LastOneShotAddress == 23");
-    UtAssert_True(CS_AppData.HkPacket.LastOneShotSize == 24, "CS_AppData.HkPacket.LastOneShotSize == 24");
-    UtAssert_True(CS_AppData.HkPacket.LastOneShotChecksum == 25, "CS_AppData.HkPacket.LastOneShotChecksum == 25");
-    UtAssert_True(CS_AppData.HkPacket.PassCounter == 26, "CS_AppData.HkPacket.PassCounter == 26");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 2, "CS_AppData.HkPacket.Payload.CmdErrCounter == 2");
+    UtAssert_True(CS_AppData.HkPacket.Payload.ChecksumState == 3, "CS_AppData.HkPacket.Payload.ChecksumState == 3");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSState == 4, "CS_AppData.HkPacket.Payload.EepromCSState == 4");
+    UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSState == 5, "CS_AppData.HkPacket.Payload.MemoryCSState == 5");
+    UtAssert_True(CS_AppData.HkPacket.Payload.AppCSState == 6, "CS_AppData.HkPacket.Payload.AppCSState == 6");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == 7, "CS_AppData.HkPacket.Payload.TablesCSState == 7");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OSCSState == 8, "CS_AppData.HkPacket.Payload.OSCSState == 8");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CfeCoreCSState == 9, "CS_AppData.HkPacket.Payload.CfeCoreCSState == 9");
+    UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == 10, "CS_AppData.HkPacket.Payload.ChildTaskInUse == 10");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == 11, "CS_AppData.HkPacket.Payload.OneShotInProgress == 11");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSErrCounter == 12, "CS_AppData.HkPacket.Payload.EepromCSErrCounter == 12");
+    UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSErrCounter == 13, "CS_AppData.HkPacket.Payload.MemoryCSErrCounter == 13");
+    UtAssert_True(CS_AppData.HkPacket.Payload.AppCSErrCounter == 14, "CS_AppData.HkPacket.Payload.AppCSErrCounter == 14");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSErrCounter == 15, "CS_AppData.HkPacket.Payload.TablesCSErrCounter == 15");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CfeCoreCSErrCounter == 16, "CS_AppData.HkPacket.Payload.CfeCoreCSErrCounter == 16");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OSCSErrCounter == 17, "CS_AppData.HkPacket.Payload.OSCSErrCounter == 17");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CurrentCSTable == 18, "CS_AppData.HkPacket.Payload.CurrentCSTable == 18");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CurrentEntryInTable == 19, "CS_AppData.HkPacket.Payload.CurrentEntryInTable == 19");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromBaseline == 20, "CS_AppData.HkPacket.Payload.EepromBaseline == 20");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OSBaseline == 21, "CS_AppData.HkPacket.Payload.OSBaseline == 21");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CfeCoreBaseline == 22, "CS_AppData.HkPacket.Payload.CfeCoreBaseline == 22");
+    UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotAddress == 23, "CS_AppData.HkPacket.Payload.LastOneShotAddress == 23");
+    UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotSize == 24, "CS_AppData.HkPacket.Payload.LastOneShotSize == 24");
+    UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotChecksum == 25, "CS_AppData.HkPacket.Payload.LastOneShotChecksum == 25");
+    UtAssert_True(CS_AppData.HkPacket.Payload.PassCounter == 26, "CS_AppData.HkPacket.Payload.PassCounter == 26");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 

--- a/unit-test/cs_cmds_tests.c
+++ b/unit-test/cs_cmds_tests.c
@@ -87,15 +87,15 @@ void CS_ResetCmd_Test(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Reset Counters command recieved");
 
-    CS_AppData.HkPacket.CmdCounter          = 1;
-    CS_AppData.HkPacket.CmdErrCounter       = 2;
-    CS_AppData.HkPacket.EepromCSErrCounter  = 3;
-    CS_AppData.HkPacket.MemoryCSErrCounter  = 4;
-    CS_AppData.HkPacket.TablesCSErrCounter  = 5;
-    CS_AppData.HkPacket.AppCSErrCounter     = 6;
-    CS_AppData.HkPacket.CfeCoreCSErrCounter = 7;
-    CS_AppData.HkPacket.OSCSErrCounter      = 8;
-    CS_AppData.HkPacket.PassCounter         = 9;
+    CS_AppData.HkPacket.Payload.CmdCounter          = 1;
+    CS_AppData.HkPacket.Payload.CmdErrCounter       = 2;
+    CS_AppData.HkPacket.Payload.EepromCSErrCounter  = 3;
+    CS_AppData.HkPacket.Payload.MemoryCSErrCounter  = 4;
+    CS_AppData.HkPacket.Payload.TablesCSErrCounter  = 5;
+    CS_AppData.HkPacket.Payload.AppCSErrCounter     = 6;
+    CS_AppData.HkPacket.Payload.CfeCoreCSErrCounter = 7;
+    CS_AppData.HkPacket.Payload.OSCSErrCounter      = 8;
+    CS_AppData.HkPacket.Payload.PassCounter         = 9;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -103,15 +103,15 @@ void CS_ResetCmd_Test(void)
     CS_ResetCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 0, "CS_AppData.HkPacket.CmdErrCounter == 0");
-    UtAssert_True(CS_AppData.HkPacket.EepromCSErrCounter == 0, "CS_AppData.HkPacket.EepromCSErrCounter == 0");
-    UtAssert_True(CS_AppData.HkPacket.MemoryCSErrCounter == 0, "CS_AppData.HkPacket.MemoryCSErrCounter == 0");
-    UtAssert_True(CS_AppData.HkPacket.TablesCSErrCounter == 0, "CS_AppData.HkPacket.TablesCSErrCounter == 0");
-    UtAssert_True(CS_AppData.HkPacket.AppCSErrCounter == 0, "CS_AppData.HkPacket.AppCSErrCounter == 0");
-    UtAssert_True(CS_AppData.HkPacket.CfeCoreCSErrCounter == 0, "CS_AppData.HkPacket.CfeCoreCSErrCounter == 0");
-    UtAssert_True(CS_AppData.HkPacket.OSCSErrCounter == 0, "CS_AppData.HkPacket.OSCSErrCounter == 0");
-    UtAssert_True(CS_AppData.HkPacket.PassCounter == 0, "CS_AppData.HkPacket.PassCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 0, "CS_AppData.HkPacket.Payload.CmdErrCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSErrCounter == 0, "CS_AppData.HkPacket.Payload.EepromCSErrCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSErrCounter == 0, "CS_AppData.HkPacket.Payload.MemoryCSErrCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSErrCounter == 0, "CS_AppData.HkPacket.Payload.TablesCSErrCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.AppCSErrCounter == 0, "CS_AppData.HkPacket.Payload.AppCSErrCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CfeCoreCSErrCounter == 0, "CS_AppData.HkPacket.Payload.CfeCoreCSErrCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OSCSErrCounter == 0, "CS_AppData.HkPacket.Payload.OSCSErrCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.PassCounter == 0, "CS_AppData.HkPacket.Payload.PassCounter == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RESET_DBG_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
@@ -191,12 +191,12 @@ void CS_BackgroundCheckCycle_Test_BackgroundInProgress(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    CS_AppData.HkPacket.ChecksumState  = CS_STATE_ENABLED;
-    CS_AppData.HkPacket.CurrentCSTable = CS_CFECORE;
-    CS_AppData.HkPacket.CfeCoreCSState = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.ChecksumState  = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.CurrentCSTable = CS_CFECORE;
+    CS_AppData.HkPacket.Payload.CfeCoreCSState = CS_STATE_ENABLED;
     CS_AppData.CfeCoreCodeSeg.State    = CS_STATE_ENABLED;
 
-    CS_AppData.HkPacket.RecomputeInProgress = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CS_BackgroundCfeCore), 1, true);
@@ -233,9 +233,9 @@ void CS_BackgroundCheckCycle_Test_BackgroundCfeCore(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    CS_AppData.HkPacket.ChecksumState  = CS_STATE_ENABLED;
-    CS_AppData.HkPacket.CurrentCSTable = CS_CFECORE;
-    CS_AppData.HkPacket.CfeCoreCSState = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.ChecksumState  = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.CurrentCSTable = CS_CFECORE;
+    CS_AppData.HkPacket.Payload.CfeCoreCSState = CS_STATE_ENABLED;
     CS_AppData.CfeCoreCodeSeg.State    = CS_STATE_ENABLED;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
@@ -266,9 +266,9 @@ void CS_BackgroundCheckCycle_Test_BackgroundOS(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    CS_AppData.HkPacket.ChecksumState  = CS_STATE_ENABLED;
-    CS_AppData.HkPacket.CurrentCSTable = CS_OSCORE;
-    CS_AppData.HkPacket.OSCSState      = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.ChecksumState  = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.CurrentCSTable = CS_OSCORE;
+    CS_AppData.HkPacket.Payload.OSCSState      = CS_STATE_ENABLED;
     CS_AppData.OSCodeSeg.State         = CS_STATE_ENABLED;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
@@ -299,9 +299,9 @@ void CS_BackgroundCheckCycle_Test_BackgroundEeprom(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    CS_AppData.HkPacket.ChecksumState  = CS_STATE_ENABLED;
-    CS_AppData.HkPacket.CurrentCSTable = CS_EEPROM_TABLE;
-    CS_AppData.HkPacket.EepromCSState  = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.ChecksumState  = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.CurrentCSTable = CS_EEPROM_TABLE;
+    CS_AppData.HkPacket.Payload.EepromCSState  = CS_STATE_ENABLED;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CS_BackgroundEeprom), 1, true);
@@ -331,9 +331,9 @@ void CS_BackgroundCheckCycle_Test_BackgroundMemory(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    CS_AppData.HkPacket.ChecksumState  = CS_STATE_ENABLED;
-    CS_AppData.HkPacket.CurrentCSTable = CS_MEMORY_TABLE;
-    CS_AppData.HkPacket.MemoryCSState  = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.ChecksumState  = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.CurrentCSTable = CS_MEMORY_TABLE;
+    CS_AppData.HkPacket.Payload.MemoryCSState  = CS_STATE_ENABLED;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CS_BackgroundMemory), 1, true);
@@ -363,9 +363,9 @@ void CS_BackgroundCheckCycle_Test_BackgroundTables(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    CS_AppData.HkPacket.ChecksumState  = CS_STATE_ENABLED;
-    CS_AppData.HkPacket.CurrentCSTable = CS_TABLES_TABLE;
-    CS_AppData.HkPacket.TablesCSState  = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.ChecksumState  = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.CurrentCSTable = CS_TABLES_TABLE;
+    CS_AppData.HkPacket.Payload.TablesCSState  = CS_STATE_ENABLED;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CS_BackgroundTables), 1, true);
@@ -395,9 +395,9 @@ void CS_BackgroundCheckCycle_Test_BackgroundApp(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    CS_AppData.HkPacket.ChecksumState  = CS_STATE_ENABLED;
-    CS_AppData.HkPacket.CurrentCSTable = CS_APP_TABLE;
-    CS_AppData.HkPacket.AppCSState     = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.ChecksumState  = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.CurrentCSTable = CS_APP_TABLE;
+    CS_AppData.HkPacket.Payload.AppCSState     = CS_STATE_ENABLED;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CS_BackgroundApp), 1, true);
@@ -427,8 +427,8 @@ void CS_BackgroundCheckCycle_Test_Default(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    CS_AppData.HkPacket.ChecksumState  = CS_STATE_ENABLED;
-    CS_AppData.HkPacket.CurrentCSTable = 99;
+    CS_AppData.HkPacket.Payload.ChecksumState  = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.CurrentCSTable = 99;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -436,9 +436,9 @@ void CS_BackgroundCheckCycle_Test_Default(void)
     CS_BackgroundCheckCycle(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CurrentCSTable == 0, "CS_AppData.HkPacket.CurrentCSTable == 0");
-    UtAssert_True(CS_AppData.HkPacket.CurrentEntryInTable == 0, "CS_AppData.HkPacket.CurrentEntryInTable == 0");
-    UtAssert_True(CS_AppData.HkPacket.PassCounter == 1, "CS_AppData.HkPacket.PassCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CurrentCSTable == 0, "CS_AppData.HkPacket.Payload.CurrentCSTable == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CurrentEntryInTable == 0, "CS_AppData.HkPacket.Payload.CurrentEntryInTable == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.PassCounter == 1, "CS_AppData.HkPacket.Payload.PassCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -461,7 +461,7 @@ void CS_BackgroundCheckCycle_Test_Disabled(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    CS_AppData.HkPacket.ChecksumState = CS_STATE_DISABLED;
+    CS_AppData.HkPacket.Payload.ChecksumState = CS_STATE_DISABLED;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -469,7 +469,7 @@ void CS_BackgroundCheckCycle_Test_Disabled(void)
     CS_BackgroundCheckCycle(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.PassCounter == 0, "CS_AppData.HkPacket.PassCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.PassCounter == 0, "CS_AppData.HkPacket.Payload.PassCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -497,13 +497,13 @@ void CS_BackgroundCheckCycle_Test_OneShot(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    CS_AppData.HkPacket.ChecksumState  = CS_STATE_ENABLED;
-    CS_AppData.HkPacket.CurrentCSTable = CS_CFECORE;
-    CS_AppData.HkPacket.CfeCoreCSState = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.ChecksumState  = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.CurrentCSTable = CS_CFECORE;
+    CS_AppData.HkPacket.Payload.CfeCoreCSState = CS_STATE_ENABLED;
     CS_AppData.CfeCoreCodeSeg.State    = CS_STATE_ENABLED;
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
-    CS_AppData.HkPacket.OneShotInProgress   = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.OneShotInProgress   = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CS_BackgroundCfeCore), 1, true);
@@ -540,13 +540,13 @@ void CS_BackgroundCheckCycle_Test_EndOfList(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
 
-    CS_AppData.HkPacket.ChecksumState  = CS_STATE_ENABLED;
-    CS_AppData.HkPacket.CurrentCSTable = CS_NUM_TABLES - 1;
-    CS_AppData.HkPacket.CfeCoreCSState = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.ChecksumState  = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.CurrentCSTable = CS_NUM_TABLES - 1;
+    CS_AppData.HkPacket.Payload.CfeCoreCSState = CS_STATE_ENABLED;
     CS_AppData.CfeCoreCodeSeg.State    = CS_STATE_ENABLED;
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
-    CS_AppData.HkPacket.OneShotInProgress   = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.OneShotInProgress   = false;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CS_BackgroundCfeCore), 1, true);
@@ -575,9 +575,9 @@ void CS_DisableAllCSCmd_Test(void)
     CS_DisableAllCSCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.ChecksumState == CS_STATE_DISABLED,
-                  "CS_AppData.HkPacket.ChecksumState == CS_STATE_DISABLED");
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.ChecksumState == CS_STATE_DISABLED,
+                  "CS_AppData.HkPacket.Payload.ChecksumState == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_DISABLE_ALL_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -606,9 +606,9 @@ void CS_EnableAllCSCmd_Test(void)
     CS_EnableAllCSCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.ChecksumState == CS_STATE_ENABLED,
-                  "CS_AppData.HkPacket.ChecksumState == CS_STATE_ENABLED");
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.ChecksumState == CS_STATE_ENABLED,
+                  "CS_AppData.HkPacket.Payload.ChecksumState == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ENABLE_ALL_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -637,8 +637,8 @@ void CS_DisableCfeCoreCmd_Test(void)
     CS_DisableCfeCoreCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CfeCoreCSState == CS_STATE_DISABLED,
-                  "CS_AppData.HkPacket.CfeCoreCSState == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_STATE_DISABLED,
+                  "CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_STATE_DISABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_DISABLE_CFECORE_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -647,7 +647,7 @@ void CS_DisableCfeCoreCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -669,8 +669,8 @@ void CS_EnableCfeCoreCmd_Test(void)
     CS_EnableCfeCoreCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CfeCoreCSState == CS_STATE_ENABLED,
-                  "CS_AppData.HkPacket.CfeCoreCSState == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_STATE_ENABLED,
+                  "CS_AppData.HkPacket.Payload.CfeCoreCSState == CS_STATE_ENABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ENABLE_CFECORE_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -679,7 +679,7 @@ void CS_EnableCfeCoreCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -701,8 +701,8 @@ void CS_DisableOSCmd_Test(void)
     CS_DisableOSCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.OSCSState == CS_STATE_DISABLED,
-                  "CS_AppData.HkPacket.OSCSState == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OSCSState == CS_STATE_DISABLED,
+                  "CS_AppData.HkPacket.Payload.OSCSState == CS_STATE_DISABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_DISABLE_OS_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -711,7 +711,7 @@ void CS_DisableOSCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -733,8 +733,8 @@ void CS_EnableOSCmd_Test(void)
     CS_EnableOSCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.OSCSState == CS_STATE_ENABLED,
-                  "CS_AppData.HkPacket.OSCSState == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OSCSState == CS_STATE_ENABLED,
+                  "CS_AppData.HkPacket.Payload.OSCSState == CS_STATE_ENABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ENABLE_OS_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -743,7 +743,7 @@ void CS_EnableOSCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -775,7 +775,7 @@ void CS_ReportBaselineCfeCoreCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -806,7 +806,7 @@ void CS_ReportBaselineCfeCoreCmd_Test_NotComputedYet(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -838,7 +838,7 @@ void CS_ReportBaselineOSCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -870,7 +870,7 @@ void CS_ReportBaselineOSCmd_Test_NotComputedYet(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -886,7 +886,7 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_Nominal(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Recompute of cFE core started");
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -894,8 +894,8 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_Nominal(void)
     CS_RecomputeBaselineCfeCoreCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == true, "CS_AppData.HkPacket.RecomputeInProgress == true");
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == false, "CS_AppData.HkPacket.OneShotInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == true, "CS_AppData.HkPacket.Payload.RecomputeInProgress == true");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == false, "CS_AppData.HkPacket.Payload.OneShotInProgress == false");
     UtAssert_True(CS_AppData.ChildTaskTable == CS_CFECORE, "CS_AppData.ChildTaskTable == CS_CFECORE");
     UtAssert_True(CS_AppData.ChildTaskEntryID == 0, "CS_AppData.ChildTaskEntryID == 0");
     UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.CfeCoreCodeSeg,
@@ -908,7 +908,7 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -925,7 +925,7 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_CreateChildTaskError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Recompute cFE core failed, CFE_ES_CreateChildTask returned: 0x%%08X");
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
 
     /* Set to generate error message CS_RECOMPUTE_CFECORE_CREATE_CHDTASK_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CreateChildTask), 1, -1);
@@ -936,7 +936,7 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_CreateChildTaskError(void)
     CS_RecomputeBaselineCfeCoreCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == false, "CS_AppData.HkPacket.OneShotInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == false, "CS_AppData.HkPacket.Payload.OneShotInProgress == false");
     UtAssert_True(CS_AppData.ChildTaskTable == CS_CFECORE, "CS_AppData.ChildTaskTable == CS_CFECORE");
     UtAssert_True(CS_AppData.ChildTaskEntryID == 0, "CS_AppData.ChildTaskEntryID == 0");
     UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.CfeCoreCodeSeg,
@@ -949,8 +949,8 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -966,7 +966,7 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_ChildTaskError(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Recompute cFE core failed: child task in use");
 
-    CS_AppData.HkPacket.RecomputeInProgress = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -981,7 +981,7 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_ChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -997,9 +997,9 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_OneShot(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Recompute cFE core failed: child task in use");
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
 
-    CS_AppData.HkPacket.OneShotInProgress = true;
+    CS_AppData.HkPacket.Payload.OneShotInProgress = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -1014,7 +1014,7 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1030,7 +1030,7 @@ void CS_RecomputeBaselineOSCmd_Test_Nominal(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Recompute of OS code segment started");
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -1038,8 +1038,8 @@ void CS_RecomputeBaselineOSCmd_Test_Nominal(void)
     CS_RecomputeBaselineOSCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == true, "CS_AppData.HkPacket.RecomputeInProgress == true");
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == false, "CS_AppData.HkPacket.OneShotInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == true, "CS_AppData.HkPacket.Payload.RecomputeInProgress == true");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == false, "CS_AppData.HkPacket.Payload.OneShotInProgress == false");
     UtAssert_True(CS_AppData.ChildTaskTable == CS_OSCORE, "CS_AppData.ChildTaskTable == CS_OSCORE");
     UtAssert_True(CS_AppData.ChildTaskEntryID == 0, "CS_AppData.OSCodeSeg == 0");
     UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.OSCodeSeg,
@@ -1052,7 +1052,7 @@ void CS_RecomputeBaselineOSCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1069,7 +1069,7 @@ void CS_RecomputeBaselineOSCmd_Test_CreateChildTaskError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Recompute OS code segment failed, CFE_ES_CreateChildTask returned: 0x%%08X");
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
 
     /* Set to generate error message CS_RECOMPUTE_OS_CREATE_CHDTASK_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CreateChildTask), 1, -1);
@@ -1080,7 +1080,7 @@ void CS_RecomputeBaselineOSCmd_Test_CreateChildTaskError(void)
     CS_RecomputeBaselineOSCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == false, "CS_AppData.HkPacket.OneShotInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == false, "CS_AppData.HkPacket.Payload.OneShotInProgress == false");
     UtAssert_True(CS_AppData.ChildTaskTable == CS_OSCORE, "CS_AppData.ChildTaskTable == CS_OSCORE");
     UtAssert_True(CS_AppData.ChildTaskEntryID == 0, "CS_AppData.OSCodeSeg == 0");
     UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.OSCodeSeg,
@@ -1093,8 +1093,8 @@ void CS_RecomputeBaselineOSCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1111,7 +1111,7 @@ void CS_RecomputeBaselineOSCmd_Test_ChildTaskError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Recompute OS code segment failed: child task in use");
 
-    CS_AppData.HkPacket.RecomputeInProgress = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -1126,7 +1126,7 @@ void CS_RecomputeBaselineOSCmd_Test_ChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1143,9 +1143,9 @@ void CS_RecomputeBaselineOSCmd_Test_OneShot(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Recompute OS code segment failed: child task in use");
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
 
-    CS_AppData.HkPacket.OneShotInProgress = true;
+    CS_AppData.HkPacket.Payload.OneShotInProgress = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -1160,7 +1160,7 @@ void CS_RecomputeBaselineOSCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1177,11 +1177,11 @@ void CS_OneShotCmd_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "OneShot checksum started on address: 0x%%08X, size: %%d");
 
-    CmdPacket.Address          = 0x00000001;
-    CmdPacket.Size             = 2;
-    CmdPacket.MaxBytesPerCycle = 0;
+    CmdPacket.Payload.Address          = 0x00000001;
+    CmdPacket.Payload.Size             = 2;
+    CmdPacket.Payload.MaxBytesPerCycle = 0;
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
     CS_AppData.MaxBytesPerCycle             = 8;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
@@ -1190,16 +1190,16 @@ void CS_OneShotCmd_Test_Nominal(void)
     CS_OneShotCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == true, "CS_AppData.HkPacket.OneShotInProgress == true");
+    UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == true, "CS_AppData.HkPacket.Payload.OneShotInProgress == true");
 
-    UtAssert_True(CS_AppData.HkPacket.LastOneShotAddress == CmdPacket.Address,
-                  "CS_AppData.HkPacket.LastOneShotAddress == CmdPacket.Address");
-    UtAssert_True(CS_AppData.HkPacket.LastOneShotSize == CmdPacket.Size,
-                  "CS_AppData.HkPacket.LastOneShotSize == CmdPacket.Size");
-    UtAssert_True(CS_AppData.HkPacket.LastOneShotChecksum == 0, "CS_AppData.HkPacket.LastOneShotChecksum == 0");
-    UtAssert_True(CS_AppData.HkPacket.LastOneShotMaxBytesPerCycle == CS_AppData.MaxBytesPerCycle,
-                  "CS_AppData.HkPacket.LastOneShotMaxBytesPerCycle == CS_AppData.MaxBytesPerCycle");
+    UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotAddress == CmdPacket.Payload.Address,
+                  "CS_AppData.HkPacket.Payload.LastOneShotAddress == CmdPacket.Payload.Address");
+    UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotSize == CmdPacket.Payload.Size,
+                  "CS_AppData.HkPacket.Payload.LastOneShotSize == CmdPacket.Payload.Size");
+    UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotChecksum == 0, "CS_AppData.HkPacket.Payload.LastOneShotChecksum == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotMaxBytesPerCycle == CS_AppData.MaxBytesPerCycle,
+                  "CS_AppData.HkPacket.Payload.LastOneShotMaxBytesPerCycle == CS_AppData.MaxBytesPerCycle");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ONESHOT_STARTED_DBG_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
@@ -1209,7 +1209,7 @@ void CS_OneShotCmd_Test_Nominal(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
     UtAssert_BOOL_TRUE(CFE_RESOURCEID_TEST_DEFINED(CS_AppData.ChildTaskID));
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1226,11 +1226,11 @@ void CS_OneShotCmd_Test_MaxBytesPerCycleNonZero(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "OneShot checksum started on address: 0x%%08X, size: %%d");
 
-    CmdPacket.Address          = 0x00000001;
-    CmdPacket.Size             = 2;
-    CmdPacket.MaxBytesPerCycle = 1;
+    CmdPacket.Payload.Address          = 0x00000001;
+    CmdPacket.Payload.Size             = 2;
+    CmdPacket.Payload.MaxBytesPerCycle = 1;
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
     CS_AppData.MaxBytesPerCycle             = 8;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
@@ -1239,16 +1239,16 @@ void CS_OneShotCmd_Test_MaxBytesPerCycleNonZero(void)
     CS_OneShotCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == true, "CS_AppData.HkPacket.OneShotInProgress == true");
+    UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == true, "CS_AppData.HkPacket.Payload.OneShotInProgress == true");
 
-    UtAssert_True(CS_AppData.HkPacket.LastOneShotAddress == CmdPacket.Address,
-                  "CS_AppData.HkPacket.LastOneShotAddress == CmdPacket.Address");
-    UtAssert_True(CS_AppData.HkPacket.LastOneShotSize == CmdPacket.Size,
-                  "CS_AppData.HkPacket.LastOneShotSize == CmdPacket.Size");
-    UtAssert_True(CS_AppData.HkPacket.LastOneShotChecksum == 0, "CS_AppData.HkPacket.LastOneShotChecksum == 0");
-    UtAssert_True(CS_AppData.HkPacket.LastOneShotMaxBytesPerCycle == CmdPacket.MaxBytesPerCycle,
-                  "CS_AppData.HkPacket.LastOneShotMaxBytesPerCycle == CmdPacket.MaxBytesPerCycle");
+    UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotAddress == CmdPacket.Payload.Address,
+                  "CS_AppData.HkPacket.Payload.LastOneShotAddress == CmdPacket.Payload.Address");
+    UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotSize == CmdPacket.Payload.Size,
+                  "CS_AppData.HkPacket.Payload.LastOneShotSize == CmdPacket.Payload.Size");
+    UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotChecksum == 0, "CS_AppData.HkPacket.Payload.LastOneShotChecksum == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotMaxBytesPerCycle == CmdPacket.Payload.MaxBytesPerCycle,
+                  "CS_AppData.HkPacket.Payload.LastOneShotMaxBytesPerCycle == CmdPacket.Payload.MaxBytesPerCycle");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ONESHOT_STARTED_DBG_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
@@ -1258,7 +1258,7 @@ void CS_OneShotCmd_Test_MaxBytesPerCycleNonZero(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
     UtAssert_BOOL_TRUE(CFE_RESOURCEID_TEST_DEFINED(CS_AppData.ChildTaskID));
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1277,7 +1277,7 @@ void CS_OneShotCmd_Test_CreateChildTaskError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "OneShot checkum failed, CFE_ES_CreateChildTask returned: 0x%%08X");
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
 
     /* Set to generate error message CS_RECOMPUTE_OS_CREATE_CHDTASK_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CreateChildTask), 1, -1);
@@ -1288,11 +1288,11 @@ void CS_OneShotCmd_Test_CreateChildTaskError(void)
     CS_OneShotCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.LastOneShotAddress == CmdPacket.Address,
-                  "CS_AppData.HkPacket.LastOneShotAddress == CmdPacket.Address");
-    UtAssert_True(CS_AppData.HkPacket.LastOneShotSize == CmdPacket.Size,
-                  "CS_AppData.HkPacket.LastOneShotSize == CmdPacket.Size");
-    UtAssert_True(CS_AppData.HkPacket.LastOneShotChecksum == 0, "CS_AppData.HkPacket.LastOneShotChecksum == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotAddress == CmdPacket.Payload.Address,
+                  "CS_AppData.HkPacket.Payload.LastOneShotAddress == CmdPacket.Payload.Address");
+    UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotSize == CmdPacket.Payload.Size,
+                  "CS_AppData.HkPacket.Payload.LastOneShotSize == CmdPacket.Payload.Size");
+    UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotChecksum == 0, "CS_AppData.HkPacket.Payload.LastOneShotChecksum == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ONESHOT_CREATE_CHDTASK_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -1301,9 +1301,9 @@ void CS_OneShotCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == false, "CS_AppData.HkPacket.OneShotInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == false, "CS_AppData.HkPacket.Payload.OneShotInProgress == false");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1319,7 +1319,7 @@ void CS_OneShotCmd_Test_ChildTaskError(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "OneShot checksum failed: child task in use");
 
-    CS_AppData.HkPacket.RecomputeInProgress = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -1334,7 +1334,7 @@ void CS_OneShotCmd_Test_ChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1351,7 +1351,7 @@ void CS_OneShotCmd_Test_MemValidateRangeError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "OneShot checksum failed, CFE_PSP_MemValidateRange returned: 0x%%08X");
 
-    CS_AppData.HkPacket.RecomputeInProgress = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
     /* Set to generate error message CS_ONESHOT_MEMVALIDATE_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_MemValidateRange), 1, -1);
@@ -1369,7 +1369,7 @@ void CS_OneShotCmd_Test_MemValidateRangeError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1385,9 +1385,9 @@ void CS_OneShotCmd_Test_OneShot(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "OneShot checksum failed: child task in use");
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
 
-    CS_AppData.HkPacket.OneShotInProgress = true;
+    CS_AppData.HkPacket.Payload.OneShotInProgress = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -1402,7 +1402,7 @@ void CS_OneShotCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1419,8 +1419,8 @@ void CS_CancelOneShotCmd_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "OneShot checksum calculation has been cancelled");
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
-    CS_AppData.HkPacket.OneShotInProgress   = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.OneShotInProgress   = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -1429,9 +1429,9 @@ void CS_CancelOneShotCmd_Test_Nominal(void)
 
     /* Verify results */
     UtAssert_BOOL_FALSE(CFE_RESOURCEID_TEST_DEFINED(CS_AppData.ChildTaskID));
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == false, "CS_AppData.HkPacket.OneShotInProgress == false");
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == false, "CS_AppData.HkPacket.Payload.OneShotInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ONESHOT_CANCELLED_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -1455,8 +1455,8 @@ void CS_CancelOneShotCmd_Test_DeleteChildTaskError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Cancel OneShot checksum failed, CFE_ES_DeleteChildTask returned:  0x%%08X");
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
-    CS_AppData.HkPacket.OneShotInProgress   = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.OneShotInProgress   = true;
 
     /* Set to generate error message CS_ONESHOT_CANCEL_DELETE_CHDTASK_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_DeleteChildTask), 1, -1);
@@ -1474,7 +1474,7 @@ void CS_CancelOneShotCmd_Test_DeleteChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1491,8 +1491,8 @@ void CS_CancelOneShotCmd_Test_NoChildTaskError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Cancel OneShot checksum failed. No OneShot active");
 
-    CS_AppData.HkPacket.RecomputeInProgress = true;
-    CS_AppData.HkPacket.OneShotInProgress   = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
+    CS_AppData.HkPacket.Payload.OneShotInProgress   = false;
 
     /* Set to generate error message CS_ONESHOT_CANCEL_NO_CHDTASK_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_DeleteChildTask), 1, -1);
@@ -1510,7 +1510,7 @@ void CS_CancelOneShotCmd_Test_NoChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1527,8 +1527,8 @@ void CS_CancelOneShotCmd_Test_OneShot(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Cancel OneShot checksum failed. No OneShot active");
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
-    CS_AppData.HkPacket.OneShotInProgress   = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.OneShotInProgress   = false;
 
     /* Set to generate error message CS_ONESHOT_CANCEL_NO_CHDTASK_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_DeleteChildTask), 1, -1);
@@ -1546,7 +1546,7 @@ void CS_CancelOneShotCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 

--- a/unit-test/cs_compute_tests.c
+++ b/unit-test/cs_compute_tests.c
@@ -1052,7 +1052,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTable(void)
     CS_RecomputeEepromMemoryChildTask();
 
     /* Verify results */
-    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.Payload.RecomputeInProgress);
 
     UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue, 0);
     UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset, 0);
@@ -1106,7 +1106,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_MemoryTable(void)
     CS_RecomputeEepromMemoryChildTask();
 
     /* Verify results */
-    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.Payload.RecomputeInProgress);
 
     UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue, 0);
     UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset, 0);
@@ -1160,7 +1160,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_CFECore(void)
     CS_RecomputeEepromMemoryChildTask();
 
     /* Verify results */
-    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.Payload.RecomputeInProgress);
 
     UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue, 0);
     UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset, 0);
@@ -1174,7 +1174,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_CFECore(void)
     UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_UINT32_EQ(CS_AppData.HkPacket.CfeCoreBaseline, 1);
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.Payload.CfeCoreBaseline, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
@@ -1216,7 +1216,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_OSCore(void)
     CS_RecomputeEepromMemoryChildTask();
 
     /* Verify results */
-    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.Payload.RecomputeInProgress);
 
     UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue, 0);
     UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset, 0);
@@ -1230,7 +1230,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_OSCore(void)
     UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_UINT32_EQ(CS_AppData.HkPacket.OSBaseline, 1);
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.Payload.OSBaseline, 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
@@ -1272,7 +1272,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableEntryId(void)
     CS_RecomputeEepromMemoryChildTask();
 
     /* Verify results */
-    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.Payload.RecomputeInProgress);
 
     UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue, 0);
     UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset, 0);
@@ -1325,7 +1325,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableStartAddress(void)
     CS_RecomputeEepromMemoryChildTask();
 
     /* Verify results */
-    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.Payload.RecomputeInProgress);
 
     UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue, 0);
     UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset, 0);
@@ -1379,7 +1379,7 @@ void CS_RecomputeEepromMemoryChildTask_Test_EEPROMTableState(void)
     CS_RecomputeEepromMemoryChildTask();
 
     /* Verify results */
-    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.Payload.RecomputeInProgress);
 
     UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->TempChecksumValue, 0);
     UtAssert_UINT32_EQ(CS_AppData.RecomputeEepromMemoryEntryPtr->ByteOffset, 0);
@@ -1448,7 +1448,7 @@ void CS_RecomputeAppChildTask_Test_Nominal(void)
     UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.Payload.RecomputeInProgress);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
@@ -1494,7 +1494,7 @@ void CS_RecomputeAppChildTask_Test_CouldNotGetAddress(void)
     UtAssert_UINT32_EQ(CS_AppData.RecomputeAppEntryPtr->ByteOffset, 0);
 
     UtAssert_BOOL_FALSE(CS_AppData.RecomputeAppEntryPtr->ComputedYet);
-    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.Payload.RecomputeInProgress);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_COMPUTE_APP_ERR_EID);
@@ -1554,7 +1554,7 @@ void CS_RecomputeAppChildTask_Test_DefEntryId(void)
     UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.Payload.RecomputeInProgress);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
@@ -1629,7 +1629,7 @@ void CS_RecomputeTablesChildTask_Test_Nominal(void)
     UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.Payload.RecomputeInProgress);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
@@ -1672,7 +1672,7 @@ void CS_RecomputeTablesChildTask_Test_CouldNotGetAddress(void)
     UtAssert_UINT32_EQ(CS_AppData.RecomputeTablesEntryPtr->ByteOffset, 0);
 
     UtAssert_BOOL_FALSE(CS_AppData.RecomputeTablesEntryPtr->ComputedYet);
-    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.Payload.RecomputeInProgress);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_RECOMPUTE_ERROR_TABLES_ERR_EID);
@@ -1750,7 +1750,7 @@ void CS_RecomputeTablesChildTask_Test_DefEntryId(void)
     UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.Payload.RecomputeInProgress);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
 }
@@ -1765,16 +1765,16 @@ void CS_OneShotChildTask_Test_Nominal(void)
     /* NewChecksumValue will be set to value returned by this function */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CalculateCRC), 1, 1);
 
-    CS_AppData.HkPacket.LastOneShotAddress          = 0;
-    CS_AppData.HkPacket.LastOneShotSize             = 1;
-    CS_AppData.HkPacket.LastOneShotChecksum         = 1;
-    CS_AppData.HkPacket.LastOneShotMaxBytesPerCycle = 1;
+    CS_AppData.HkPacket.Payload.LastOneShotAddress          = 0;
+    CS_AppData.HkPacket.Payload.LastOneShotSize             = 1;
+    CS_AppData.HkPacket.Payload.LastOneShotChecksum         = 1;
+    CS_AppData.HkPacket.Payload.LastOneShotMaxBytesPerCycle = 1;
 
     /* Execute the function being tested */
     CS_OneShotChildTask();
 
     /* Verify results */
-    UtAssert_UINT32_EQ(CS_AppData.HkPacket.LastOneShotChecksum, 1);
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.Payload.LastOneShotChecksum, 1);
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ONESHOT_FINISHED_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -1782,8 +1782,8 @@ void CS_OneShotChildTask_Test_Nominal(void)
     UtAssert_STRINGBUF_EQ(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, context_CFE_EVS_SendEvent[0].Spec,
                           CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
-    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.RecomputeInProgress);
-    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.OneShotInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.Payload.RecomputeInProgress);
+    UtAssert_BOOL_FALSE(CS_AppData.HkPacket.Payload.OneShotInProgress);
     UtAssert_BOOL_FALSE(CFE_RESOURCEID_TEST_DEFINED(CS_AppData.ChildTaskID));
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);

--- a/unit-test/cs_eeprom_cmds_tests.c
+++ b/unit-test/cs_eeprom_cmds_tests.c
@@ -57,8 +57,8 @@ void CS_DisableEepromCmd_Test(void)
     CS_DisableEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.EepromCSState == CS_STATE_DISABLED,
-                  "CS_AppData.HkPacket.EepromCSState == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_DISABLED,
+                  "CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_DISABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_DISABLE_EEPROM_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -67,7 +67,7 @@ void CS_DisableEepromCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -86,7 +86,7 @@ void CS_DisableEepromCmd_Test_OneShot(void)
     CS_DisableEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -108,8 +108,8 @@ void CS_EnableEepromCmd_Test(void)
     CS_EnableEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.EepromCSState == CS_STATE_ENABLED,
-                  "CS_AppData.HkPacket.EepromCSState == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_ENABLED,
+                  "CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_ENABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ENABLE_EEPROM_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -118,7 +118,7 @@ void CS_EnableEepromCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -137,7 +137,7 @@ void CS_EnableEepromCmd_Test_OneShot(void)
     CS_EnableEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -153,11 +153,11 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_Computed(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Report baseline of EEPROM Entry %%d is 0x%%08X");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State           = 99;
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].ComputedYet     = true;
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].ComparisonValue = 1;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State           = 99;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].ComputedYet     = true;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].ComparisonValue = 1;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -172,7 +172,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_Computed(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -189,11 +189,11 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_NotYetComputed(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Report baseline of EEPROM Entry %%d has not been computed yet");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State           = 99;
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].ComputedYet     = false;
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].ComparisonValue = 1;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State           = 99;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].ComputedYet     = false;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].ComparisonValue = 1;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -208,7 +208,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_NotYetComputed(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -225,7 +225,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "EEPROM report baseline failed, Entry ID invalid: %%d, State: %%d Max ID: %%d");
 
-    CmdPacket.EntryID = CS_MAX_NUM_EEPROM_TABLE_ENTRIES;
+    CmdPacket.Payload.EntryID = CS_MAX_NUM_EEPROM_TABLE_ENTRIES;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -240,7 +240,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -257,9 +257,9 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "EEPROM report baseline failed, Entry ID invalid: %%d, State: %%d Max ID: %%d");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State = CS_STATE_EMPTY;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State = CS_STATE_EMPTY;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -274,7 +274,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -291,9 +291,9 @@ void CS_RecomputeBaselineEepromCmd_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Recompute baseline of EEPROM Entry ID %%d started");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State = 99;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State = 99;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -301,13 +301,13 @@ void CS_RecomputeBaselineEepromCmd_Test_Nominal(void)
     CS_RecomputeBaselineEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == true, "CS_AppData.HkPacket.RecomputeInProgress == true");
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == false, "CS_AppData.HkPacket.OneShotInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == true, "CS_AppData.HkPacket.Payload.RecomputeInProgress == true");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == false, "CS_AppData.HkPacket.Payload.OneShotInProgress == false");
 
     UtAssert_True(CS_AppData.ChildTaskTable == CS_EEPROM_TABLE, "CS_AppData.ChildTaskTable == CS_EEPROM_TABLE");
-    UtAssert_True(CS_AppData.ChildTaskEntryID == CmdPacket.EntryID, "CS_AppData.ChildTaskEntryID == CmdPacket.EntryID");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResEepromTblPtr[CmdPacket.EntryID],
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResEepromTblPtr[CmdPacket.EntryID]");
+    UtAssert_True(CS_AppData.ChildTaskEntryID == CmdPacket.Payload.EntryID, "CS_AppData.ChildTaskEntryID == CmdPacket.Payload.EntryID");
+    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID],
+                  "CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID]");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_EEPROM_STARTED_DBG_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
@@ -316,7 +316,7 @@ void CS_RecomputeBaselineEepromCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -333,9 +333,9 @@ void CS_RecomputeBaselineEepromCmd_Test_CreateChildTaskError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Recompute baseline of EEPROM Entry ID %%d failed, CFE_ES_CreateChildTask returned:  0x%%08X");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State = 99;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State = 99;
 
     /* Set to generate error message CS_RECOMPUTE_EEPROM_CREATE_CHDTASK_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CreateChildTask), 1, -1);
@@ -346,12 +346,12 @@ void CS_RecomputeBaselineEepromCmd_Test_CreateChildTaskError(void)
     CS_RecomputeBaselineEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == false, "CS_AppData.HkPacket.OneShotInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == false, "CS_AppData.HkPacket.Payload.OneShotInProgress == false");
 
     UtAssert_True(CS_AppData.ChildTaskTable == CS_EEPROM_TABLE, "CS_AppData.ChildTaskTable == CS_EEPROM_TABLE");
-    UtAssert_True(CS_AppData.ChildTaskEntryID == CmdPacket.EntryID, "CS_AppData.ChildTaskEntryID == CmdPacket.EntryID");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResEepromTblPtr[CmdPacket.EntryID],
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResEepromTblPtr[CmdPacket.EntryID]");
+    UtAssert_True(CS_AppData.ChildTaskEntryID == CmdPacket.Payload.EntryID, "CS_AppData.ChildTaskEntryID == CmdPacket.Payload.EntryID");
+    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID],
+                  "CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID]");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_EEPROM_CREATE_CHDTASK_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -360,8 +360,8 @@ void CS_RecomputeBaselineEepromCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -378,7 +378,7 @@ void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "EEPROM recompute baseline of entry failed, Entry ID invalid: %%d, State: %%d, Max ID: %%d");
 
-    CmdPacket.EntryID = CS_MAX_NUM_EEPROM_TABLE_ENTRIES;
+    CmdPacket.Payload.EntryID = CS_MAX_NUM_EEPROM_TABLE_ENTRIES;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -393,7 +393,7 @@ void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -410,9 +410,9 @@ void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "EEPROM recompute baseline of entry failed, Entry ID invalid: %%d, State: %%d, Max ID: %%d");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State = CS_STATE_EMPTY;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State = CS_STATE_EMPTY;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -427,7 +427,7 @@ void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -444,9 +444,9 @@ void CS_RecomputeBaselineEepromCmd_Test_RecomputeInProgress(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Recompute baseline of EEPROM Entry ID %%d failed: child task in use");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.HkPacket.RecomputeInProgress = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -461,7 +461,7 @@ void CS_RecomputeBaselineEepromCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -478,10 +478,10 @@ void CS_RecomputeBaselineEepromCmd_Test_OneShot(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Recompute baseline of EEPROM Entry ID %%d failed: child task in use");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
-    CS_AppData.HkPacket.OneShotInProgress   = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.OneShotInProgress   = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -496,7 +496,7 @@ void CS_RecomputeBaselineEepromCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -512,10 +512,10 @@ void CS_EnableEntryIDEepromCmd_Test_Nominal(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Checksumming of EEPROM Entry ID %%d is Enabled");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State = 99;
-    CS_AppData.DefEepromTblPtr[CmdPacket.EntryID].State = 99;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State = 99;
+    CS_AppData.DefEepromTblPtr[CmdPacket.Payload.EntryID].State = 99;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -523,8 +523,8 @@ void CS_EnableEntryIDEepromCmd_Test_Nominal(void)
     CS_EnableEntryIDEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State == CS_STATE_ENABLED,
-                  "CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED,
+                  "CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ENABLE_EEPROM_ENTRY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -533,10 +533,10 @@ void CS_EnableEntryIDEepromCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.DefEepromTblPtr[CmdPacket.EntryID].State == CS_STATE_ENABLED,
-                  "CS_AppData.DefEepromTblPtr[CmdPacket.EntryID].State == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.DefEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED,
+                  "CS_AppData.DefEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED");
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -556,10 +556,10 @@ void CS_EnableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS unable to update EEPROM definition table for entry %%d, State: %%d");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State = 99;
-    CS_AppData.DefEepromTblPtr[CmdPacket.EntryID].State = CS_STATE_EMPTY;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State = 99;
+    CS_AppData.DefEepromTblPtr[CmdPacket.Payload.EntryID].State = CS_STATE_EMPTY;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -567,8 +567,8 @@ void CS_EnableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
     CS_EnableEntryIDEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State == CS_STATE_ENABLED,
-                  "CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED,
+                  "CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ENABLE_EEPROM_ENTRY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -586,7 +586,7 @@ void CS_EnableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -603,7 +603,7 @@ void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Enable EEPROM entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
 
-    CmdPacket.EntryID = CS_MAX_NUM_EEPROM_TABLE_ENTRIES;
+    CmdPacket.Payload.EntryID = CS_MAX_NUM_EEPROM_TABLE_ENTRIES;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -618,7 +618,7 @@ void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -635,9 +635,9 @@ void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Enable EEPROM entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State = CS_STATE_EMPTY;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State = CS_STATE_EMPTY;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -652,7 +652,7 @@ void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -671,7 +671,7 @@ void CS_EnableEntryIDEepromCmd_Test_OneShot(void)
     CS_EnableEntryIDEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -688,10 +688,10 @@ void CS_DisableEntryIDEepromCmd_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Checksumming of EEPROM Entry ID %%d is Disabled");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State = 99;
-    CS_AppData.DefEepromTblPtr[CmdPacket.EntryID].State = 99;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State = 99;
+    CS_AppData.DefEepromTblPtr[CmdPacket.Payload.EntryID].State = 99;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -699,12 +699,12 @@ void CS_DisableEntryIDEepromCmd_Test_Nominal(void)
     CS_DisableEntryIDEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State == CS_STATE_DISABLED,
-                  "CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State == CS_STATE_DISABLED");
-    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].TempChecksumValue == 0,
-                  "CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].TempChecksumValue == 0");
-    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].ByteOffset == 0,
-                  "CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].ByteOffset == 0");
+    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED,
+                  "CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].TempChecksumValue == 0,
+                  "CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].TempChecksumValue == 0");
+    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].ByteOffset == 0,
+                  "CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].ByteOffset == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_DISABLE_EEPROM_ENTRY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -713,10 +713,10 @@ void CS_DisableEntryIDEepromCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.DefEepromTblPtr[CmdPacket.EntryID].State == CS_STATE_DISABLED,
-                  "CS_AppData.DefEepromTblPtr[CmdPacket.EntryID].State == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.DefEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED,
+                  "CS_AppData.DefEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED");
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -736,10 +736,10 @@ void CS_DisableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS unable to update EEPROM definition table for entry %%d, State: %%d");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State = 99;
-    CS_AppData.DefEepromTblPtr[CmdPacket.EntryID].State = CS_STATE_EMPTY;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State = 99;
+    CS_AppData.DefEepromTblPtr[CmdPacket.Payload.EntryID].State = CS_STATE_EMPTY;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -747,12 +747,12 @@ void CS_DisableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
     CS_DisableEntryIDEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State == CS_STATE_DISABLED,
-                  "CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State == CS_STATE_DISABLED");
-    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].TempChecksumValue == 0,
-                  "CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].TempChecksumValue == 0");
-    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].ByteOffset == 0,
-                  "CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].ByteOffset == 0");
+    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED,
+                  "CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].TempChecksumValue == 0,
+                  "CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].TempChecksumValue == 0");
+    UtAssert_True(CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].ByteOffset == 0,
+                  "CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].ByteOffset == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_DISABLE_EEPROM_ENTRY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -770,7 +770,7 @@ void CS_DisableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -787,7 +787,7 @@ void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Disable EEPROM entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
 
-    CmdPacket.EntryID = CS_MAX_NUM_EEPROM_TABLE_ENTRIES;
+    CmdPacket.Payload.EntryID = CS_MAX_NUM_EEPROM_TABLE_ENTRIES;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -802,7 +802,7 @@ void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -819,9 +819,9 @@ void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Disable EEPROM entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResEepromTblPtr[CmdPacket.EntryID].State = CS_STATE_EMPTY;
+    CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID].State = CS_STATE_EMPTY;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -836,7 +836,7 @@ void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -855,7 +855,7 @@ void CS_DisableEntryIDEepromCmd_Test_OneShot(void)
     CS_DisableEntryIDEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -874,7 +874,7 @@ void CS_GetEntryIDEepromCmd_Test_Nominal(void)
     int16 EntryID = 1;
 
     CS_AppData.ResEepromTblPtr[EntryID].StartAddress       = 1;
-    CmdPacket.Address                                      = 1;
+    CmdPacket.Payload.Address                                      = 1;
     CS_AppData.ResEepromTblPtr[EntryID].NumBytesToChecksum = 0;
     CS_AppData.ResEepromTblPtr[EntryID].State              = 99;
 
@@ -891,7 +891,7 @@ void CS_GetEntryIDEepromCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -907,7 +907,7 @@ void CS_GetEntryIDEepromCmd_Test_AddressNotFound(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Address 0x%%08X was not found in EEPROM table");
 
-    CmdPacket.Address = 0xFFFFFFFF;
+    CmdPacket.Payload.Address = 0xFFFFFFFF;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -922,7 +922,7 @@ void CS_GetEntryIDEepromCmd_Test_AddressNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -941,7 +941,7 @@ void CS_GetEntryIDEepromCmd_Test_AddressPtr(void)
     int16 EntryID = 1;
 
     CS_AppData.ResEepromTblPtr[EntryID].StartAddress       = 2;
-    CmdPacket.Address                                      = 1;
+    CmdPacket.Payload.Address                                      = 1;
     CS_AppData.ResEepromTblPtr[EntryID].NumBytesToChecksum = 0;
     CS_AppData.ResEepromTblPtr[EntryID].State              = 99;
 
@@ -958,7 +958,7 @@ void CS_GetEntryIDEepromCmd_Test_AddressPtr(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -977,7 +977,7 @@ void CS_GetEntryIDEepromCmd_Test_State(void)
     int16 EntryID = 1;
 
     CS_AppData.ResEepromTblPtr[EntryID].StartAddress       = 1;
-    CmdPacket.Address                                      = 1;
+    CmdPacket.Payload.Address                                      = 1;
     CS_AppData.ResEepromTblPtr[EntryID].NumBytesToChecksum = 0;
     CS_AppData.ResEepromTblPtr[EntryID].State              = CS_STATE_EMPTY;
 
@@ -994,7 +994,7 @@ void CS_GetEntryIDEepromCmd_Test_State(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 

--- a/unit-test/cs_memory_cmds_tests.c
+++ b/unit-test/cs_memory_cmds_tests.c
@@ -57,8 +57,8 @@ void CS_DisableMemoryCmd_Test(void)
     CS_DisableMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.MemoryCSState == CS_STATE_DISABLED,
-                  "CS_AppData.HkPacket.MemoryCSState = CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSState == CS_STATE_DISABLED,
+                  "CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_DISABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_DISABLE_MEMORY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -67,7 +67,7 @@ void CS_DisableMemoryCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -86,7 +86,7 @@ void CS_DisableMemoryCmd_Test_OneShot(void)
     CS_DisableMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -108,8 +108,8 @@ void CS_EnableMemoryCmd_Test(void)
     CS_EnableMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.MemoryCSState == CS_STATE_ENABLED,
-                  "CS_AppData.HkPacket.MemoryCSState = CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSState == CS_STATE_ENABLED,
+                  "CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_ENABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ENABLE_MEMORY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -118,7 +118,7 @@ void CS_EnableMemoryCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -137,7 +137,7 @@ void CS_EnableMemoryCmd_Test_OneShot(void)
     CS_EnableMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -153,11 +153,11 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_Computed(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Report baseline of Memory Entry %%d is 0x%%08X");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State           = 99;
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].ComputedYet     = true;
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].ComparisonValue = 1;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State           = 99;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].ComputedYet     = true;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].ComparisonValue = 1;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -172,7 +172,7 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_Computed(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -189,11 +189,11 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_NotYetComputed(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Report baseline of Memory Entry %%d has not been computed yet");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State           = 99;
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].ComputedYet     = false;
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].ComparisonValue = 1;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State           = 99;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].ComputedYet     = false;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].ComparisonValue = 1;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -208,7 +208,7 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_NotYetComputed(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -225,7 +225,7 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Memory report baseline failed, Entry ID invalid: %%d, State: %%d Max ID: %%d");
 
-    CmdPacket.EntryID = CS_MAX_NUM_MEMORY_TABLE_ENTRIES;
+    CmdPacket.Payload.EntryID = CS_MAX_NUM_MEMORY_TABLE_ENTRIES;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -240,7 +240,7 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -257,9 +257,9 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Memory report baseline failed, Entry ID invalid: %%d, State: %%d Max ID: %%d");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State = CS_STATE_EMPTY;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State = CS_STATE_EMPTY;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -274,7 +274,7 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -291,9 +291,9 @@ void CS_RecomputeBaselineMemoryCmd_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Recompute baseline of Memory Entry ID %%d started");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State = 99;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State = 99;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -301,13 +301,13 @@ void CS_RecomputeBaselineMemoryCmd_Test_Nominal(void)
     CS_RecomputeBaselineMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == true, "CS_AppData.HkPacket.RecomputeInProgress == true");
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == false, "CS_AppData.HkPacket.OneShotInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == true, "CS_AppData.HkPacket.Payload.RecomputeInProgress == true");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == false, "CS_AppData.HkPacket.Payload.OneShotInProgress == false");
 
     UtAssert_True(CS_AppData.ChildTaskTable == CS_MEMORY_TABLE, "CS_AppData.ChildTaskTable == CS_MEMORY_TABLE");
-    UtAssert_True(CS_AppData.ChildTaskEntryID == CmdPacket.EntryID, "CS_AppData.ChildTaskEntryID == CmdPacket.EntryID");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID],
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID]");
+    UtAssert_True(CS_AppData.ChildTaskEntryID == CmdPacket.Payload.EntryID, "CS_AppData.ChildTaskEntryID == CmdPacket.Payload.EntryID");
+    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID],
+                  "CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID]");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_MEMORY_STARTED_DBG_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
@@ -316,7 +316,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -333,9 +333,9 @@ void CS_RecomputeBaselineMemoryCmd_Test_CreateChildTaskError(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Recompute baseline of Memory Entry ID %%d failed, ES_CreateChildTask returned:  0x%%08X");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State = 99;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State = 99;
 
     /* Set to generate error message CS_RECOMPUTE_MEMORY_CREATE_CHDTASK_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CreateChildTask), 1, -1);
@@ -346,12 +346,12 @@ void CS_RecomputeBaselineMemoryCmd_Test_CreateChildTaskError(void)
     CS_RecomputeBaselineMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == false, "CS_AppData.HkPacket.OneShotInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == false, "CS_AppData.HkPacket.Payload.OneShotInProgress == false");
 
     UtAssert_True(CS_AppData.ChildTaskTable == CS_MEMORY_TABLE, "CS_AppData.ChildTaskTable == CS_MEMORY_TABLE");
-    UtAssert_True(CS_AppData.ChildTaskEntryID == CmdPacket.EntryID, "CS_AppData.ChildTaskEntryID == CmdPacket.EntryID");
-    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID],
-                  "CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID]");
+    UtAssert_True(CS_AppData.ChildTaskEntryID == CmdPacket.Payload.EntryID, "CS_AppData.ChildTaskEntryID == CmdPacket.Payload.EntryID");
+    UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID],
+                  "CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID]");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_MEMORY_CREATE_CHDTASK_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -360,8 +360,8 @@ void CS_RecomputeBaselineMemoryCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -378,7 +378,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Memory recompute baseline of entry failed, Entry ID invalid: %%d, State: %%d, Max ID: %%d");
 
-    CmdPacket.EntryID = CS_MAX_NUM_MEMORY_TABLE_ENTRIES;
+    CmdPacket.Payload.EntryID = CS_MAX_NUM_MEMORY_TABLE_ENTRIES;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -393,7 +393,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -410,9 +410,9 @@ void CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Memory recompute baseline of entry failed, Entry ID invalid: %%d, State: %%d, Max ID: %%d");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State = CS_STATE_EMPTY;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State = CS_STATE_EMPTY;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -427,7 +427,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -444,9 +444,9 @@ void CS_RecomputeBaselineMemoryCmd_Test_RecomputeInProgress(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Recompute baseline of Memory Entry ID %%d failed: child task in use");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.HkPacket.RecomputeInProgress = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -461,7 +461,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -478,10 +478,10 @@ void CS_RecomputeBaselineMemoryCmd_Test_OneShot(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Recompute baseline of Memory Entry ID %%d failed: child task in use");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
-    CS_AppData.HkPacket.OneShotInProgress   = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.OneShotInProgress   = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -496,7 +496,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -512,10 +512,10 @@ void CS_EnableEntryIDMemoryCmd_Test_Nominal(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Checksumming of Memory Entry ID %%d is Enabled");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State = 99;
-    CS_AppData.DefMemoryTblPtr[CmdPacket.EntryID].State = 99;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State = 99;
+    CS_AppData.DefMemoryTblPtr[CmdPacket.Payload.EntryID].State = 99;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -523,8 +523,8 @@ void CS_EnableEntryIDMemoryCmd_Test_Nominal(void)
     CS_EnableEntryIDMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State == CS_STATE_ENABLED,
-                  "CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED,
+                  "CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ENABLE_MEMORY_ENTRY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -533,10 +533,10 @@ void CS_EnableEntryIDMemoryCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.DefMemoryTblPtr[CmdPacket.EntryID].State == CS_STATE_ENABLED,
-                  "CS_AppData.DefMemoryTblPtr[CmdPacket.EntryID].State == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.DefMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED,
+                  "CS_AppData.DefMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED");
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -556,10 +556,10 @@ void CS_EnableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS unable to update memory definition table for entry %%d, State: %%d");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State = 99;
-    CS_AppData.DefMemoryTblPtr[CmdPacket.EntryID].State = CS_STATE_EMPTY;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State = 99;
+    CS_AppData.DefMemoryTblPtr[CmdPacket.Payload.EntryID].State = CS_STATE_EMPTY;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -567,8 +567,8 @@ void CS_EnableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
     CS_EnableEntryIDMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State == CS_STATE_ENABLED,
-                  "CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State == CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED,
+                  "CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ENABLE_MEMORY_ENTRY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -586,7 +586,7 @@ void CS_EnableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -603,7 +603,7 @@ void CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Enable Memory entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
 
-    CmdPacket.EntryID = CS_MAX_NUM_MEMORY_TABLE_ENTRIES;
+    CmdPacket.Payload.EntryID = CS_MAX_NUM_MEMORY_TABLE_ENTRIES;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -618,7 +618,7 @@ void CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -635,9 +635,9 @@ void CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Enable Memory entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State = CS_STATE_EMPTY;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State = CS_STATE_EMPTY;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -652,7 +652,7 @@ void CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -671,7 +671,7 @@ void CS_EnableEntryIDMemoryCmd_Test_OneShot(void)
     CS_EnableEntryIDMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -688,10 +688,10 @@ void CS_DisableEntryIDMemoryCmd_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Checksumming of Memory Entry ID %%d is Disabled");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State = 99;
-    CS_AppData.DefMemoryTblPtr[CmdPacket.EntryID].State = 99;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State = 99;
+    CS_AppData.DefMemoryTblPtr[CmdPacket.Payload.EntryID].State = 99;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -699,12 +699,12 @@ void CS_DisableEntryIDMemoryCmd_Test_Nominal(void)
     CS_DisableEntryIDMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State == CS_STATE_DISABLED,
-                  "CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State == CS_STATE_DISABLED");
-    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].TempChecksumValue == 0,
-                  "CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].TempChecksumValue == 0");
-    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].ByteOffset == 0,
-                  "CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].ByteOffset == 0");
+    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED,
+                  "CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].TempChecksumValue == 0,
+                  "CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].TempChecksumValue == 0");
+    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].ByteOffset == 0,
+                  "CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].ByteOffset == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_DISABLE_MEMORY_ENTRY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -713,10 +713,10 @@ void CS_DisableEntryIDMemoryCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.DefMemoryTblPtr[CmdPacket.EntryID].State == CS_STATE_DISABLED,
-                  "CS_AppData.DefMemoryTblPtr[CmdPacket.EntryID].State == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.DefMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED,
+                  "CS_AppData.DefMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED");
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -736,10 +736,10 @@ void CS_DisableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
     snprintf(ExpectedEventString[1], CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "CS unable to update memory definition table for entry %%d, State: %%d");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State = 99;
-    CS_AppData.DefMemoryTblPtr[CmdPacket.EntryID].State = CS_STATE_EMPTY;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State = 99;
+    CS_AppData.DefMemoryTblPtr[CmdPacket.Payload.EntryID].State = CS_STATE_EMPTY;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -747,12 +747,12 @@ void CS_DisableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
     CS_DisableEntryIDMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State == CS_STATE_DISABLED,
-                  "CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State == CS_STATE_DISABLED");
-    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].TempChecksumValue == 0,
-                  "CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].TempChecksumValue == 0");
-    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].ByteOffset == 0,
-                  "CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].ByteOffset == 0");
+    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED,
+                  "CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].TempChecksumValue == 0,
+                  "CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].TempChecksumValue == 0");
+    UtAssert_True(CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].ByteOffset == 0,
+                  "CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].ByteOffset == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_DISABLE_MEMORY_ENTRY_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -770,7 +770,7 @@ void CS_DisableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -787,7 +787,7 @@ void CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Disable Memory entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
 
-    CmdPacket.EntryID = CS_MAX_NUM_MEMORY_TABLE_ENTRIES;
+    CmdPacket.Payload.EntryID = CS_MAX_NUM_MEMORY_TABLE_ENTRIES;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -802,7 +802,7 @@ void CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -819,9 +819,9 @@ void CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Disable Memory entry failed, invalid Entry ID:  %%d, State: %%d, Max ID: %%d");
 
-    CmdPacket.EntryID = 1;
+    CmdPacket.Payload.EntryID = 1;
 
-    CS_AppData.ResMemoryTblPtr[CmdPacket.EntryID].State = CS_STATE_EMPTY;
+    CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID].State = CS_STATE_EMPTY;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -836,7 +836,7 @@ void CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -855,7 +855,7 @@ void CS_DisableEntryIDMemoryCmd_Test_OneShot(void)
     CS_DisableEntryIDMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -874,7 +874,7 @@ void CS_GetEntryIDMemoryCmd_Test_Nominal(void)
     int16 EntryID = 1;
 
     CS_AppData.ResMemoryTblPtr[EntryID].StartAddress       = 1;
-    CmdPacket.Address                                      = 1;
+    CmdPacket.Payload.Address                                      = 1;
     CS_AppData.ResMemoryTblPtr[EntryID].NumBytesToChecksum = 0;
     CS_AppData.ResMemoryTblPtr[EntryID].State              = 99;
 
@@ -891,7 +891,7 @@ void CS_GetEntryIDMemoryCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -907,7 +907,7 @@ void CS_GetEntryIDMemoryCmd_Test_AddressNotFound(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Address 0x%%08X was not found in Memory table");
 
-    CmdPacket.Address = 0xFFFFFFFF;
+    CmdPacket.Payload.Address = 0xFFFFFFFF;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
@@ -922,7 +922,7 @@ void CS_GetEntryIDMemoryCmd_Test_AddressNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -941,7 +941,7 @@ void CS_GetEntryIDMemoryCmd_Test_AddressPtr(void)
     int16 EntryID = 1;
 
     CS_AppData.ResMemoryTblPtr[EntryID].StartAddress       = 2;
-    CmdPacket.Address                                      = 1;
+    CmdPacket.Payload.Address                                      = 1;
     CS_AppData.ResMemoryTblPtr[EntryID].NumBytesToChecksum = 0;
     CS_AppData.ResMemoryTblPtr[EntryID].State              = 99;
 
@@ -958,7 +958,7 @@ void CS_GetEntryIDMemoryCmd_Test_AddressPtr(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -977,7 +977,7 @@ void CS_GetEntryIDMemoryCmd_Test_State(void)
     int16 EntryID = 1;
 
     CS_AppData.ResMemoryTblPtr[EntryID].StartAddress       = 1;
-    CmdPacket.Address                                      = 1;
+    CmdPacket.Payload.Address                                      = 1;
     CS_AppData.ResMemoryTblPtr[EntryID].NumBytesToChecksum = 0;
     CS_AppData.ResMemoryTblPtr[EntryID].State              = CS_STATE_EMPTY;
 
@@ -994,7 +994,7 @@ void CS_GetEntryIDMemoryCmd_Test_State(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 

--- a/unit-test/cs_table_cmds_tests.c
+++ b/unit-test/cs_table_cmds_tests.c
@@ -91,8 +91,8 @@ void CS_DisableTablesCmd_Test(void)
     CS_DisableTablesCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == CS_STATE_DISABLED,
-                  "CS_AppData.HkPacket.TablesCSState = CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == CS_STATE_DISABLED,
+                  "CS_AppData.HkPacket.Payload.TablesCSState = CS_STATE_DISABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_DISABLE_TABLES_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -101,7 +101,7 @@ void CS_DisableTablesCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -120,7 +120,7 @@ void CS_DisableTablesCmd_Test_OneShot(void)
     CS_DisableTablesCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -143,8 +143,8 @@ void CS_EnableTablesCmd_Test(void)
     CS_EnableTablesCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == CS_STATE_ENABLED,
-                  "CS_AppData.HkPacket.TablesCSState = CS_STATE_ENABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == CS_STATE_ENABLED,
+                  "CS_AppData.HkPacket.Payload.TablesCSState = CS_STATE_ENABLED");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ENABLE_TABLES_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -153,7 +153,7 @@ void CS_EnableTablesCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -172,7 +172,7 @@ void CS_EnableTablesCmd_Test_OneShot(void)
     CS_EnableTablesCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -192,7 +192,7 @@ void CS_ReportBaselineTablesCmd_Test_Computed(void)
     CS_AppData.ResTablesTblPtr[0].ComparisonValue = 1;
 
     strncpy(CS_AppData.ResTablesTblPtr[0].Name, "name", 10);
-    strncpy(CmdPacket.Name, "name", 10);
+    strncpy(CmdPacket.Payload.Name, "name", 10);
 
     CS_AppData.ResTablesTblPtr[0].State = 99; /* Needed to make CS_GetTableResTblEntryByName return correct results */
 
@@ -213,7 +213,7 @@ void CS_ReportBaselineTablesCmd_Test_Computed(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -233,7 +233,7 @@ void CS_ReportBaselineTablesCmd_Test_NotYetComputed(void)
     CS_AppData.ResTablesTblPtr[0].ComputedYet = false;
 
     strncpy(CS_AppData.ResTablesTblPtr[0].Name, "name", 10);
-    strncpy(CmdPacket.Name, "name", 10);
+    strncpy(CmdPacket.Payload.Name, "name", 10);
 
     CS_AppData.ResTablesTblPtr[0].State = 99; /* Needed to make CS_GetTableResTblEntryByName return correct results */
 
@@ -254,7 +254,7 @@ void CS_ReportBaselineTablesCmd_Test_NotYetComputed(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -272,7 +272,7 @@ void CS_ReportBaselineTablesCmd_Test_TableNotFound(void)
              "Tables report baseline failed, table %%s not found");
 
     strncpy(CS_AppData.ResTablesTblPtr[0].Name, "name1", 10);
-    strncpy(CmdPacket.Name, "name2", 10);
+    strncpy(CmdPacket.Payload.Name, "name2", 10);
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CS_GetTableResTblEntryByName), 1, false);
@@ -289,7 +289,7 @@ void CS_ReportBaselineTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -306,7 +306,7 @@ void CS_RecomputeBaselineTablesCmd_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Recompute baseline of table %%s started");
 
     strncpy(CS_AppData.ResTablesTblPtr[0].Name, "name", 10);
-    strncpy(CmdPacket.Name, "name", 10);
+    strncpy(CmdPacket.Payload.Name, "name", 10);
 
     CS_AppData.ResTablesTblPtr[0].State = 99; /* Needed to make CS_GetTableResTblEntryByName return correct results */
 
@@ -320,8 +320,8 @@ void CS_RecomputeBaselineTablesCmd_Test_Nominal(void)
     CS_RecomputeBaselineTablesCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == true, "CS_AppData.HkPacket.RecomputeInProgress == true");
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == false, "CS_AppData.HkPacket.OneShotInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == true, "CS_AppData.HkPacket.Payload.RecomputeInProgress == true");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == false, "CS_AppData.HkPacket.Payload.OneShotInProgress == false");
 
     UtAssert_True(CS_AppData.ChildTaskTable == CS_TABLES_TABLE, "CS_AppData.ChildTaskTable == CS_TABLES_TABLE");
 
@@ -332,7 +332,7 @@ void CS_RecomputeBaselineTablesCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -350,7 +350,7 @@ void CS_RecomputeBaselineTablesCmd_Test_CreateChildTaskError(void)
              "Recompute baseline of table %%s failed, CFE_ES_CreateChildTask returned: 0x%%08X");
 
     strncpy(CS_AppData.ResTablesTblPtr[0].Name, "name", 10);
-    strncpy(CmdPacket.Name, "name", 10);
+    strncpy(CmdPacket.Payload.Name, "name", 10);
 
     CS_AppData.ResTablesTblPtr[0].State = 99; /* Needed to make CS_GetTableResTblEntryByName return correct results */
 
@@ -367,7 +367,7 @@ void CS_RecomputeBaselineTablesCmd_Test_CreateChildTaskError(void)
     CS_RecomputeBaselineTablesCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.OneShotInProgress == false, "CS_AppData.HkPacket.OneShotInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == false, "CS_AppData.HkPacket.Payload.OneShotInProgress == false");
 
     UtAssert_True(CS_AppData.ChildTaskTable == CS_TABLES_TABLE, "CS_AppData.ChildTaskTable == CS_TABLES_TABLE");
 
@@ -378,9 +378,9 @@ void CS_RecomputeBaselineTablesCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.RecomputeInProgress == false, "CS_AppData.HkPacket.RecomputeInProgress == false");
+    UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -397,7 +397,7 @@ void CS_RecomputeBaselineTablesCmd_Test_TableNotFound(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Tables recompute baseline failed, table %%s not found");
 
-    strncpy(CmdPacket.Name, "name", 10);
+    strncpy(CmdPacket.Payload.Name, "name", 10);
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CS_CheckRecomputeOneshot), 1, false);
@@ -414,7 +414,7 @@ void CS_RecomputeBaselineTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -431,9 +431,9 @@ void CS_RecomputeBaselineTablesCmd_Test_RecomputeInProgress(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Tables recompute baseline for table %%s failed: child task in use");
 
-    strncpy(CmdPacket.Name, "name", 10);
+    strncpy(CmdPacket.Payload.Name, "name", 10);
 
-    CS_AppData.HkPacket.RecomputeInProgress = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CS_CheckRecomputeOneshot), 1, false);
@@ -450,7 +450,7 @@ void CS_RecomputeBaselineTablesCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -467,10 +467,10 @@ void CS_RecomputeBaselineTablesCmd_Test_OneShot(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Tables recompute baseline for table %%s failed: child task in use");
 
-    strncpy(CmdPacket.Name, "name", 10);
+    strncpy(CmdPacket.Payload.Name, "name", 10);
 
-    CS_AppData.HkPacket.RecomputeInProgress = false;
-    CS_AppData.HkPacket.OneShotInProgress   = true;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.OneShotInProgress   = true;
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CS_CheckRecomputeOneshot), 1, false);
@@ -486,7 +486,7 @@ void CS_RecomputeBaselineTablesCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -503,7 +503,7 @@ void CS_DisableNameTablesCmd_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Checksumming of table %%s is Disabled");
 
     strncpy(CS_AppData.ResTablesTblPtr[0].Name, "name", 10);
-    strncpy(CmdPacket.Name, "name", 10);
+    strncpy(CmdPacket.Payload.Name, "name", 10);
 
     CS_AppData.ResTablesTblPtr[0].State = 99; /* Needed to make CS_GetTableResTblEntryByName return correct results */
 
@@ -535,7 +535,7 @@ void CS_DisableNameTablesCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -555,7 +555,7 @@ void CS_DisableNameTablesCmd_Test_TableDefNotFound(void)
              "CS unable to update tables definition table for entry %%s");
 
     strncpy(CS_AppData.ResTablesTblPtr[0].Name, "name", 10);
-    strncpy(CmdPacket.Name, "name", 10);
+    strncpy(CmdPacket.Payload.Name, "name", 10);
 
     CS_AppData.ResTablesTblPtr[0].State = 99; /* Needed to make CS_GetTableResTblEntryByName return correct results */
 
@@ -590,7 +590,7 @@ void CS_DisableNameTablesCmd_Test_TableDefNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -607,7 +607,7 @@ void CS_DisableNameTablesCmd_Test_TableNotFound(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Tables disable table command failed, table %%s not found");
 
-    strncpy(CmdPacket.Name, "name", 10);
+    strncpy(CmdPacket.Payload.Name, "name", 10);
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CS_CheckRecomputeOneshot), 1, false);
@@ -625,7 +625,7 @@ void CS_DisableNameTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -644,7 +644,7 @@ void CS_DisableNameTablesCmd_Test_OneShot(void)
     CS_DisableNameTablesCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -661,7 +661,7 @@ void CS_EnableNameTablesCmd_Test_Nominal(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Checksumming of table %%s is Enabled");
 
     strncpy(CS_AppData.ResTablesTblPtr[0].Name, "name", 10);
-    strncpy(CmdPacket.Name, "name", 10);
+    strncpy(CmdPacket.Payload.Name, "name", 10);
 
     CS_AppData.ResTablesTblPtr[0].State = 99; /* Needed to make CS_GetTableResTblEntryByName return correct results */
 
@@ -690,7 +690,7 @@ void CS_EnableNameTablesCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -710,7 +710,7 @@ void CS_EnableNameTablesCmd_Test_TableDefNotFound(void)
              "CS unable to update tables definition table for entry %%s");
 
     strncpy(CS_AppData.ResTablesTblPtr[0].Name, "name", 10);
-    strncpy(CmdPacket.Name, "name", 10);
+    strncpy(CmdPacket.Payload.Name, "name", 10);
 
     CS_AppData.ResTablesTblPtr[0].State = 99; /* Needed to make CS_GetTableResTblEntryByName return correct results */
 
@@ -742,7 +742,7 @@ void CS_EnableNameTablesCmd_Test_TableDefNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 1, "CS_AppData.HkPacket.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -759,7 +759,7 @@ void CS_EnableNameTablesCmd_Test_TableNotFound(void)
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
              "Tables enable table command failed, table %%s not found");
 
-    strncpy(CmdPacket.Name, "name", 10);
+    strncpy(CmdPacket.Payload.Name, "name", 10);
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
     UT_SetDeferredRetcode(UT_KEY(CS_CheckRecomputeOneshot), 1, false);
@@ -777,7 +777,7 @@ void CS_EnableNameTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.CmdErrCounter == 1, "CS_AppData.HkPacket.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -796,7 +796,7 @@ void CS_EnableNameTablesCmd_Test_OneShot(void)
     CS_EnableNameTablesCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.CmdCounter == 0, "CS_AppData.HkPacket.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 

--- a/unit-test/cs_table_processing_tests.c
+++ b/unit-test/cs_table_processing_tests.c
@@ -1408,7 +1408,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNominal(void)
     uint16 NumEntries = 1;
     uint16 Table      = CS_EEPROM_TABLE;
 
-    CS_AppData.HkPacket.EepromCSState                = 99;
+    CS_AppData.HkPacket.Payload.EepromCSState                = 99;
     CS_AppData.DefEepromTblPtr[0].State              = 1;
     CS_AppData.DefEepromTblPtr[0].NumBytesToChecksum = 2;
     CS_AppData.DefEepromTblPtr[0].StartAddress       = 3;
@@ -1422,7 +1422,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNominal(void)
                                              NumEntries, Table);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.EepromCSState == 99, "CS_AppData.HkPacket.EepromCSState == 99");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSState == 99, "CS_AppData.HkPacket.Payload.EepromCSState == 99");
 
     UtAssert_True(CS_AppData.ResEepromTblPtr[0].State == 1, "CS_AppData.ResEepromTblPtr[0].State == 1");
     UtAssert_True(CS_AppData.ResEepromTblPtr[0].ComputedYet == false,
@@ -1462,7 +1462,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNominal(void)
     uint16 NumEntries = 1;
     uint16 Table      = CS_MEMORY_TABLE;
 
-    CS_AppData.HkPacket.MemoryCSState                = 99;
+    CS_AppData.HkPacket.Payload.MemoryCSState                = 99;
     CS_AppData.DefMemoryTblPtr[0].State              = 1;
     CS_AppData.DefMemoryTblPtr[0].NumBytesToChecksum = 2;
     CS_AppData.DefMemoryTblPtr[0].StartAddress       = 3;
@@ -1476,7 +1476,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNominal(void)
                                              NumEntries, Table);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.MemoryCSState == 99, "CS_AppData.HkPacket.MemoryCSState == 99");
+    UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSState == 99, "CS_AppData.HkPacket.Payload.MemoryCSState == 99");
 
     UtAssert_True(CS_AppData.ResMemoryTblPtr[0].State == 1, "CS_AppData.ResMemoryTblPtr[0].State == 1");
     UtAssert_True(CS_AppData.ResMemoryTblPtr[0].ComputedYet == false,
@@ -1521,7 +1521,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNoValidEntries(voi
     uint16 NumEntries = 1;
     uint16 Table      = CS_EEPROM_TABLE;
 
-    CS_AppData.HkPacket.MemoryCSState = 99;
+    CS_AppData.HkPacket.Payload.MemoryCSState = 99;
 
     /* Execute the function being tested */
     /* Note: first 2 arguments are passed in as addresses of pointers in the source code, even though the variable
@@ -1532,7 +1532,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_EEPROMTableNoValidEntries(voi
                                              NumEntries, Table);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.MemoryCSState == 99, "CS_AppData.HkPacket.MemoryCSState == 99");
+    UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSState == 99, "CS_AppData.HkPacket.Payload.MemoryCSState == 99");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_PROCESS_EEPROM_MEMORY_NO_ENTRIES_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -1559,7 +1559,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNoValidEntries(voi
     uint16 NumEntries = 1;
     uint16 Table      = CS_MEMORY_TABLE;
 
-    CS_AppData.HkPacket.MemoryCSState = 99;
+    CS_AppData.HkPacket.Payload.MemoryCSState = 99;
 
     /* Execute the function being tested */
     /* Note: first 2 arguments are passed in as addresses of pointers in the source code, even though the variable
@@ -1570,7 +1570,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNoValidEntries(voi
                                              NumEntries, Table);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.MemoryCSState == 99, "CS_AppData.HkPacket.MemoryCSState == 99");
+    UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSState == 99, "CS_AppData.HkPacket.Payload.MemoryCSState == 99");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_PROCESS_EEPROM_MEMORY_NO_ENTRIES_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -1587,7 +1587,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable_Test_MemoryTableNoValidEntries(voi
 
 void CS_ProcessNewTablesDefinitionTable_Test_DefEepromTableHandle(void)
 {
-    CS_AppData.HkPacket.TablesCSState   = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState   = 99;
     CS_AppData.DefTablesTblPtr[0].State = 88;
 
     strncpy(CS_AppData.DefTablesTblPtr[0].Name, "CS.DefEepromTbl", 20);
@@ -1629,7 +1629,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefEepromTableHandle(void)
     UtAssert_True(strncmp(CS_AppData.ResTablesTblPtr[0].Name, "CS.DefEepromTbl", 20) == 0,
                   "strncmp(CS_AppData.ResTablesTblPtr[0].Name, 'CS.DefEepromTbl', 20) == 0");
 
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == 99, "CS_AppData.HkPacket.TablesCSState == 99");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == 99, "CS_AppData.HkPacket.Payload.TablesCSState == 99");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1639,7 +1639,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefEepromTableHandle(void)
 
 void CS_ProcessNewTablesDefinitionTable_Test_DefMemoryTableHandle(void)
 {
-    CS_AppData.HkPacket.TablesCSState   = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState   = 99;
     CS_AppData.DefTablesTblPtr[0].State = 88;
 
     strncpy(CS_AppData.DefTablesTblPtr[0].Name, "CS.DefMemoryTbl", 20);
@@ -1681,7 +1681,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefMemoryTableHandle(void)
     UtAssert_True(strncmp(CS_AppData.ResTablesTblPtr[0].Name, "CS.DefMemoryTbl", 20) == 0,
                   "strncmp(CS_AppData.ResTablesTblPtr[0].Name, 'CS.DefMemoryTbl', 20) == 0");
 
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == 99, "CS_AppData.HkPacket.TablesCSState == 99");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == 99, "CS_AppData.HkPacket.Payload.TablesCSState == 99");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1691,7 +1691,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefMemoryTableHandle(void)
 
 void CS_ProcessNewTablesDefinitionTable_Test_DefTablesTableHandle(void)
 {
-    CS_AppData.HkPacket.TablesCSState   = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState   = 99;
     CS_AppData.DefTablesTblPtr[0].State = 88;
 
     strncpy(CS_AppData.DefTablesTblPtr[0].Name, "CS.DefTablesTbl", 20);
@@ -1733,7 +1733,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefTablesTableHandle(void)
     UtAssert_True(strncmp(CS_AppData.ResTablesTblPtr[0].Name, "CS.DefTablesTbl", 20) == 0,
                   "strncmp(CS_AppData.ResTablesTblPtr[0].Name, 'CS.DefTablesTbl', 20) == 0");
 
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == 99, "CS_AppData.HkPacket.TablesCSState == 99");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == 99, "CS_AppData.HkPacket.Payload.TablesCSState == 99");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1743,7 +1743,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefTablesTableHandle(void)
 
 void CS_ProcessNewTablesDefinitionTable_Test_DefAppTableHandle(void)
 {
-    CS_AppData.HkPacket.TablesCSState   = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState   = 99;
     CS_AppData.DefTablesTblPtr[0].State = 88;
 
     strncpy(CS_AppData.DefTablesTblPtr[0].Name, "CS.DefAppTbl", 20);
@@ -1785,7 +1785,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefAppTableHandle(void)
     UtAssert_True(strncmp(CS_AppData.ResTablesTblPtr[0].Name, "CS.DefAppTbl", 20) == 0,
                   "strncmp(CS_AppData.ResTablesTblPtr[0].Name, 'CS.DefAppTbl', 20) == 0");
 
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == 99, "CS_AppData.HkPacket.TablesCSState == 99");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == 99, "CS_AppData.HkPacket.Payload.TablesCSState == 99");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1795,7 +1795,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_DefAppTableHandle(void)
 
 void CS_ProcessNewTablesDefinitionTable_Test_ResEepromTableHandle(void)
 {
-    CS_AppData.HkPacket.TablesCSState   = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState   = 99;
     CS_AppData.DefTablesTblPtr[0].State = 88;
 
     strncpy(CS_AppData.DefTablesTblPtr[0].Name, "CS.ResEepromTbl", 20);
@@ -1835,7 +1835,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_ResEepromTableHandle(void)
     UtAssert_True(strncmp(CS_AppData.ResTablesTblPtr[0].Name, "CS.ResEepromTbl", 20) == 0,
                   "strncmp(CS_AppData.ResTablesTblPtr[0].Name, 'CS.ResEepromTbl', 20) == 0");
 
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == 99, "CS_AppData.HkPacket.TablesCSState == 99");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == 99, "CS_AppData.HkPacket.Payload.TablesCSState == 99");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1845,7 +1845,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_ResEepromTableHandle(void)
 
 void CS_ProcessNewTablesDefinitionTable_Test_ResMemoryTableHandle(void)
 {
-    CS_AppData.HkPacket.TablesCSState   = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState   = 99;
     CS_AppData.DefTablesTblPtr[0].State = 88;
 
     strncpy(CS_AppData.DefTablesTblPtr[0].Name, "CS.ResMemoryTbl", 20);
@@ -1885,7 +1885,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_ResMemoryTableHandle(void)
     UtAssert_True(strncmp(CS_AppData.ResTablesTblPtr[0].Name, "CS.ResMemoryTbl", 20) == 0,
                   "strncmp(CS_AppData.ResTablesTblPtr[0].Name, 'CS.ResMemoryTbl', 20) == 0");
 
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == 99, "CS_AppData.HkPacket.TablesCSState == 99");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == 99, "CS_AppData.HkPacket.Payload.TablesCSState == 99");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1895,7 +1895,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_ResMemoryTableHandle(void)
 
 void CS_ProcessNewTablesDefinitionTable_Test_ResTablesTableHandle(void)
 {
-    CS_AppData.HkPacket.TablesCSState   = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState   = 99;
     CS_AppData.DefTablesTblPtr[0].State = 88;
 
     strncpy(CS_AppData.DefTablesTblPtr[0].Name, "CS.ResTablesTbl", 20);
@@ -1935,7 +1935,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_ResTablesTableHandle(void)
     UtAssert_True(strncmp(CS_AppData.ResTablesTblPtr[0].Name, "CS.ResTablesTbl", 20) == 0,
                   "strncmp(CS_AppData.ResTablesTblPtr[0].Name, 'CS.ResTablesTbl', 20) == 0");
 
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == 99, "CS_AppData.HkPacket.TablesCSState == 99");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == 99, "CS_AppData.HkPacket.Payload.TablesCSState == 99");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1945,7 +1945,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_ResTablesTableHandle(void)
 
 void CS_ProcessNewTablesDefinitionTable_Test_ResAppTableHandle(void)
 {
-    CS_AppData.HkPacket.TablesCSState   = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState   = 99;
     CS_AppData.DefTablesTblPtr[0].State = 88;
 
     strncpy(CS_AppData.DefTablesTblPtr[0].Name, "CS.ResAppTbl", 20);
@@ -1985,7 +1985,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_ResAppTableHandle(void)
     UtAssert_True(strncmp(CS_AppData.ResTablesTblPtr[0].Name, "CS.ResAppTbl", 20) == 0,
                   "strncmp(CS_AppData.ResTablesTblPtr[0].Name, 'CS.ResAppTbl', 20) == 0");
 
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == 99, "CS_AppData.HkPacket.TablesCSState == 99");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == 99, "CS_AppData.HkPacket.Payload.TablesCSState == 99");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -2000,7 +2000,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_StateEmptyNoValidEntries(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "CS Tables Table: No valid entries in the table");
 
-    CS_AppData.HkPacket.TablesCSState   = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState   = 99;
     CS_AppData.DefTablesTblPtr[0].State = CS_STATE_EMPTY;
 
     /* Sets AppName to "CS" */
@@ -2037,7 +2037,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_StateEmptyNoValidEntries(void)
     UtAssert_True(CS_AppData.ResTablesTblPtr[0].IsCSOwner == false, "CS_AppData.ResTablesTblPtr[0].IsCSOwner == false");
     UtAssert_True(CS_AppData.ResTablesTblPtr[0].Name[0] == 0, "CS_AppData.ResTablesTblPtr[0].Name[0] == 0");
 
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == 99, "CS_AppData.HkPacket.TablesCSState == 99");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == 99, "CS_AppData.HkPacket.Payload.TablesCSState == 99");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_PROCESS_TABLES_NO_ENTRIES_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -2057,7 +2057,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_LimitApplicationNameLength(void)
     uint16     i;
     const char AppNameX[] = "X";
 
-    CS_AppData.HkPacket.TablesCSState   = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState   = 99;
     CS_AppData.DefTablesTblPtr[0].State = 88;
 
     /* String name chosen to be of length OS_MAX_API_NAME in order to satisfy condition "AppNameIndex ==
@@ -2100,7 +2100,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_LimitTableNameLength(void)
 {
     uint16 i;
 
-    CS_AppData.HkPacket.TablesCSState   = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState   = 99;
     CS_AppData.DefTablesTblPtr[0].State = 88;
 
     strncat(CS_AppData.DefTablesTblPtr[0].Name, "CS.", CFE_TBL_MAX_FULL_NAME_LEN);
@@ -2143,7 +2143,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_MaxTableNameLength(void)
 {
     uint16 i;
 
-    CS_AppData.HkPacket.TablesCSState   = 99;
+    CS_AppData.HkPacket.Payload.TablesCSState   = 99;
     CS_AppData.DefTablesTblPtr[0].State = 88;
 
     strncat(CS_AppData.DefTablesTblPtr[0].Name, "CS", CFE_TBL_MAX_FULL_NAME_LEN);
@@ -2184,7 +2184,7 @@ void CS_ProcessNewTablesDefinitionTable_Test_MaxTableNameLength(void)
 
 void CS_ProcessNewAppDefinitionTable_Test_Nominal(void)
 {
-    CS_AppData.HkPacket.AppCSState   = 99;
+    CS_AppData.HkPacket.Payload.AppCSState   = 99;
     CS_AppData.DefAppTblPtr[0].State = 88;
 
     strncpy(CS_AppData.DefAppTblPtr[0].Name, "name", 20);
@@ -2209,7 +2209,7 @@ void CS_ProcessNewAppDefinitionTable_Test_Nominal(void)
     UtAssert_True(strncmp(CS_AppData.ResAppTblPtr[0].Name, "name", 20) == 0,
                   "strncmp(CS_AppData.ResAppTblPtr[0].Name, 'name', 20) == 0");
 
-    UtAssert_True(CS_AppData.HkPacket.AppCSState == 99, "CS_AppData.HkPacket.AppCSState == 99");
+    UtAssert_True(CS_AppData.HkPacket.Payload.AppCSState == 99, "CS_AppData.HkPacket.Payload.AppCSState == 99");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -2224,7 +2224,7 @@ void CS_ProcessNewAppDefinitionTable_Test_StateEmptyNoValidEntries(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "CS Apps Table: No valid entries in the table");
 
-    CS_AppData.HkPacket.AppCSState   = 99;
+    CS_AppData.HkPacket.Payload.AppCSState   = 99;
     CS_AppData.DefAppTblPtr[0].State = CS_STATE_EMPTY;
 
     /* Execute the function being tested */
@@ -2247,7 +2247,7 @@ void CS_ProcessNewAppDefinitionTable_Test_StateEmptyNoValidEntries(void)
     UtAssert_True(CS_AppData.ResAppTblPtr[0].StartAddress == 0, "CS_AppData.ResAppTblPtr[0].StartAddress == 0");
     UtAssert_True(CS_AppData.ResAppTblPtr[0].Name[0] == 0, "CS_AppData.ResAppTblPtr[0].Name[0] == 0");
 
-    UtAssert_True(CS_AppData.HkPacket.AppCSState == 99, "CS_AppData.HkPacket.AppCSState == 99");
+    UtAssert_True(CS_AppData.HkPacket.Payload.AppCSState == 99, "CS_AppData.HkPacket.Payload.AppCSState == 99");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_PROCESS_APP_NO_ENTRIES_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -2531,8 +2531,8 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableRegisterEr
                           sizeof(CS_Res_EepromMemory_Table_Entry_t), NULL);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.EepromCSState == CS_STATE_DISABLED,
-                  "CS_AppData.HkPacket.EepromCSState == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_DISABLED,
+                  "CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_DISABLED");
 
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
@@ -2565,8 +2565,8 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterResultsTableGetAddress
                           sizeof(CS_Res_EepromMemory_Table_Entry_t), NULL);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.EepromCSState == CS_STATE_DISABLED,
-                  "CS_AppData.HkPacket.EepromCSState == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_DISABLED,
+                  "CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_DISABLED");
 
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
@@ -2602,8 +2602,8 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableRegiste
                           sizeof(CS_Res_EepromMemory_Table_Entry_t), NULL);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.EepromCSState == CS_STATE_DISABLED,
-                  "CS_AppData.HkPacket.EepromCSState == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_DISABLED,
+                  "CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_DISABLED");
 
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
@@ -2637,8 +2637,8 @@ void CS_TableInit_Test_EepromTableAndLoadedFromMemoryAfterDefinitionTableFileLoa
                           sizeof(CS_Res_EepromMemory_Table_Entry_t), NULL);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.EepromCSState == CS_STATE_DISABLED,
-                  "CS_AppData.HkPacket.EepromCSState == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_DISABLED,
+                  "CS_AppData.HkPacket.Payload.EepromCSState == CS_STATE_DISABLED");
 
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
@@ -2706,8 +2706,8 @@ void CS_TableInit_Test_MemoryTableAndLoadedFromMemory(void)
                           sizeof(CS_Res_EepromMemory_Table_Entry_t), NULL);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.MemoryCSState == CS_STATE_DISABLED,
-                  "CS_AppData.HkPacket.MemoryCSState == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSState == CS_STATE_DISABLED,
+                  "CS_AppData.HkPacket.Payload.MemoryCSState == CS_STATE_DISABLED");
 
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
@@ -2773,8 +2773,8 @@ void CS_TableInit_Test_AppTableAndLoadedFromMemory(void)
                           sizeof(CS_Def_App_Table_Entry_t), sizeof(CS_Res_App_Table_Entry_t), NULL);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.AppCSState == CS_STATE_DISABLED,
-                  "CS_AppData.HkPacket.AppCSState == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.AppCSState == CS_STATE_DISABLED,
+                  "CS_AppData.HkPacket.Payload.AppCSState == CS_STATE_DISABLED");
 
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
@@ -2842,8 +2842,8 @@ void CS_TableInit_Test_TablesTableAndLoadedFromMemory(void)
                           sizeof(CS_Res_Tables_Table_Entry_t), NULL);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == CS_STATE_DISABLED,
-                  "CS_AppData.HkPacket.TablesCSState == CS_STATE_DISABLED");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == CS_STATE_DISABLED,
+                  "CS_AppData.HkPacket.Payload.TablesCSState == CS_STATE_DISABLED");
 
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
@@ -2879,8 +2879,8 @@ void CS_TableInit_Test_DefaultAndLoadedFromMemory(void)
                      sizeof(CS_Def_Tables_Table_Entry_t), sizeof(CS_Res_Tables_Table_Entry_t), NULL);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == CS_STATE_EMPTY,
-                  "CS_AppData.HkPacket.TablesCSState == CS_STATE_EMPTY");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == CS_STATE_EMPTY,
+                  "CS_AppData.HkPacket.Payload.TablesCSState == CS_STATE_EMPTY");
 
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 
@@ -2918,8 +2918,8 @@ void CS_TableInit_Test_OpenCreateError(void)
                      sizeof(CS_Def_Tables_Table_Entry_t), sizeof(CS_Res_Tables_Table_Entry_t), NULL);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.TablesCSState == CS_STATE_EMPTY,
-                  "CS_AppData.HkPacket.TablesCSState == CS_STATE_EMPTY");
+    UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSState == CS_STATE_EMPTY,
+                  "CS_AppData.HkPacket.Payload.TablesCSState == CS_STATE_EMPTY");
 
     UtAssert_True(Result == CFE_SUCCESS, "Result == CFE_SUCCESS");
 

--- a/unit-test/cs_utils_tests.c
+++ b/unit-test/cs_utils_tests.c
@@ -84,23 +84,23 @@ void CS_InitializeDefaultTables_Test(void)
 
 void CS_GoToNextTable_Test(void)
 {
-    CS_AppData.HkPacket.CurrentCSTable = CS_NUM_TABLES - 2;
+    CS_AppData.HkPacket.Payload.CurrentCSTable = CS_NUM_TABLES - 2;
 
     /* increment once */
     CS_GoToNextTable();
 
     /* Verify results */
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, CS_NUM_TABLES - 1);
-    UtAssert_UINT32_EQ(CS_AppData.HkPacket.PassCounter, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, CS_NUM_TABLES - 1);
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.Payload.PassCounter, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
 
     /* Cause loop */
     CS_GoToNextTable();
 
     /* Verify results */
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 0);
-    UtAssert_UINT32_EQ(CS_AppData.HkPacket.PassCounter, 1);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 0);
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.Payload.PassCounter, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
 }
@@ -227,16 +227,16 @@ void CS_FindEnabledEepromEntry_Test(void)
 
     /* Call with zeros */
     UtAssert_BOOL_FALSE(CS_FindEnabledEepromEntry(&EnabledEntry));
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, CS_MAX_NUM_EEPROM_TABLE_ENTRIES);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, CS_MAX_NUM_EEPROM_TABLE_ENTRIES);
     UtAssert_UINT16_EQ(EnabledEntry, CS_MAX_NUM_EEPROM_TABLE_ENTRIES);
 
     /* Set up to find last entry (skip first) */
     CS_AppData.ResEepromTblPtr[0].State                                   = CS_STATE_ENABLED;
     CS_AppData.ResEepromTblPtr[CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1].State = CS_STATE_ENABLED;
-    CS_AppData.HkPacket.CurrentEntryInTable                               = 1;
+    CS_AppData.HkPacket.Payload.CurrentEntryInTable                               = 1;
 
     UtAssert_BOOL_TRUE(CS_FindEnabledEepromEntry(&EnabledEntry));
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1);
     UtAssert_UINT16_EQ(EnabledEntry, CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -248,16 +248,16 @@ void CS_FindEnabledMemoryEntry_Test(void)
 
     /* Call with zeros */
     UtAssert_BOOL_FALSE(CS_FindEnabledMemoryEntry(&EnabledEntry));
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, CS_MAX_NUM_MEMORY_TABLE_ENTRIES);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, CS_MAX_NUM_MEMORY_TABLE_ENTRIES);
     UtAssert_UINT16_EQ(EnabledEntry, CS_MAX_NUM_MEMORY_TABLE_ENTRIES);
 
     /* Set up to find last entry (skip first) */
     CS_AppData.ResMemoryTblPtr[0].State                                   = CS_STATE_ENABLED;
     CS_AppData.ResMemoryTblPtr[CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1].State = CS_STATE_ENABLED;
-    CS_AppData.HkPacket.CurrentEntryInTable                               = 1;
+    CS_AppData.HkPacket.Payload.CurrentEntryInTable                               = 1;
 
     UtAssert_BOOL_TRUE(CS_FindEnabledMemoryEntry(&EnabledEntry));
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1);
     UtAssert_UINT16_EQ(EnabledEntry, CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -269,16 +269,16 @@ void CS_FindEnabledTablesEntry_Test(void)
 
     /* Call with zeros */
     UtAssert_BOOL_FALSE(CS_FindEnabledTablesEntry(&EnabledEntry));
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, CS_MAX_NUM_TABLES_TABLE_ENTRIES);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, CS_MAX_NUM_TABLES_TABLE_ENTRIES);
     UtAssert_UINT16_EQ(EnabledEntry, CS_MAX_NUM_TABLES_TABLE_ENTRIES);
 
     /* Set up to find last entry (skip first) */
     CS_AppData.ResTablesTblPtr[0].State                                   = CS_STATE_ENABLED;
     CS_AppData.ResTablesTblPtr[CS_MAX_NUM_TABLES_TABLE_ENTRIES - 1].State = CS_STATE_ENABLED;
-    CS_AppData.HkPacket.CurrentEntryInTable                               = 1;
+    CS_AppData.HkPacket.Payload.CurrentEntryInTable                               = 1;
 
     UtAssert_BOOL_TRUE(CS_FindEnabledTablesEntry(&EnabledEntry));
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, CS_MAX_NUM_TABLES_TABLE_ENTRIES - 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, CS_MAX_NUM_TABLES_TABLE_ENTRIES - 1);
     UtAssert_UINT16_EQ(EnabledEntry, CS_MAX_NUM_TABLES_TABLE_ENTRIES - 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -290,16 +290,16 @@ void CS_FindEnabledAppEntry_Test(void)
 
     /* Call with zeros */
     UtAssert_BOOL_FALSE(CS_FindEnabledAppEntry(&EnabledEntry));
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, CS_MAX_NUM_APP_TABLE_ENTRIES);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, CS_MAX_NUM_APP_TABLE_ENTRIES);
     UtAssert_UINT16_EQ(EnabledEntry, CS_MAX_NUM_APP_TABLE_ENTRIES);
 
     /* Set up to find last entry (skip first) */
     CS_AppData.ResAppTblPtr[0].State                                = CS_STATE_ENABLED;
     CS_AppData.ResAppTblPtr[CS_MAX_NUM_APP_TABLE_ENTRIES - 1].State = CS_STATE_ENABLED;
-    CS_AppData.HkPacket.CurrentEntryInTable                         = 1;
+    CS_AppData.HkPacket.Payload.CurrentEntryInTable                         = 1;
 
     UtAssert_BOOL_TRUE(CS_FindEnabledAppEntry(&EnabledEntry));
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, CS_MAX_NUM_APP_TABLE_ENTRIES - 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, CS_MAX_NUM_APP_TABLE_ENTRIES - 1);
     UtAssert_UINT16_EQ(EnabledEntry, CS_MAX_NUM_APP_TABLE_ENTRIES - 1);
 
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
@@ -333,232 +333,232 @@ void CS_VerifyCmdLength_Test(void)
 void CS_BackgroundCfeCore_Test(void)
 {
     /* Entirely disabled */
-    CS_AppData.HkPacket.CfeCoreCSState = CS_STATE_DISABLED;
+    CS_AppData.HkPacket.Payload.CfeCoreCSState = CS_STATE_DISABLED;
     UtAssert_BOOL_FALSE(CS_BackgroundCfeCore());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 1);
 
     /* Segment disabled */
-    CS_AppData.HkPacket.CfeCoreCSState = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.CfeCoreCSState = CS_STATE_ENABLED;
     CS_AppData.CfeCoreCodeSeg.State    = CS_STATE_DISABLED;
     UtAssert_BOOL_FALSE(CS_BackgroundCfeCore());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 2);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 2);
 
     /* Enabled, miscompare, not done with entry */
     CS_AppData.CfeCoreCodeSeg.State = CS_STATE_ENABLED;
     UT_SetDeferredRetcode(UT_KEY(CS_ComputeEepromMemory), 1, CS_ERROR);
     UtAssert_BOOL_TRUE(CS_BackgroundCfeCore());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CfeCoreCSErrCounter, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CfeCoreCSErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_CFECORE_MISCOMPARE_ERR_EID);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 2);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 2);
 
     /* Enabled, compares, done with entry */
     UT_SetHandlerFunction(UT_KEY(CS_ComputeEepromMemory), CS_UTILS_TEST_CS_ComputeHandler, NULL);
     UtAssert_BOOL_TRUE(CS_BackgroundCfeCore());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CfeCoreCSErrCounter, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CfeCoreCSErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 3);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 3);
 }
 
 void CS_BackgroundOS_Test(void)
 {
     /* Entirely disabled */
-    CS_AppData.HkPacket.OSCSState = CS_STATE_DISABLED;
+    CS_AppData.HkPacket.Payload.OSCSState = CS_STATE_DISABLED;
     UtAssert_BOOL_FALSE(CS_BackgroundOS());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 1);
 
     /* Segment disabled */
-    CS_AppData.HkPacket.OSCSState = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.OSCSState = CS_STATE_ENABLED;
     CS_AppData.OSCodeSeg.State    = CS_STATE_DISABLED;
     UtAssert_BOOL_FALSE(CS_BackgroundOS());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 2);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 2);
 
     /* Enabled, miscompare, not done with entry */
     CS_AppData.OSCodeSeg.State = CS_STATE_ENABLED;
     UT_SetDeferredRetcode(UT_KEY(CS_ComputeEepromMemory), 1, CS_ERROR);
     UtAssert_BOOL_TRUE(CS_BackgroundOS());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.OSCSErrCounter, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.OSCSErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_OS_MISCOMPARE_ERR_EID);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 2);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 2);
 
     /* Enabled, compares, done with entry */
     UT_SetHandlerFunction(UT_KEY(CS_ComputeEepromMemory), CS_UTILS_TEST_CS_ComputeHandler, NULL);
     UtAssert_BOOL_TRUE(CS_BackgroundOS());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.OSCSErrCounter, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.OSCSErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 3);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 3);
 }
 
 void CS_BackgroundEeprom_Test(void)
 {
     /* Entirely disabled */
-    CS_AppData.HkPacket.EepromCSState = CS_STATE_DISABLED;
+    CS_AppData.HkPacket.Payload.EepromCSState = CS_STATE_DISABLED;
     UtAssert_BOOL_FALSE(CS_BackgroundEeprom());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 1);
 
     /* All entries disabled */
-    CS_AppData.HkPacket.EepromCSState             = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.EepromCSState             = CS_STATE_ENABLED;
     CS_AppData.ResEepromTblPtr[0].ComparisonValue = 1;
     CS_AppData.ResEepromTblPtr[1].ComparisonValue = 2;
     UtAssert_BOOL_FALSE(CS_BackgroundEeprom());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 2);
-    UtAssert_UINT32_EQ(CS_AppData.HkPacket.EepromBaseline, 3);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 2);
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.Payload.EepromBaseline, 3);
 
     /* Enabled, miscompare, not done with entry */
     CS_AppData.ResEepromTblPtr[0].State = CS_STATE_ENABLED;
     UT_SetDeferredRetcode(UT_KEY(CS_ComputeEepromMemory), 1, CS_ERROR);
     UtAssert_BOOL_TRUE(CS_BackgroundEeprom());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.EepromCSErrCounter, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.EepromCSErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_EEPROM_MISCOMPARE_ERR_EID);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 2);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 2);
 
     /* Last entry, Enabled, compares, done with entry */
-    CS_AppData.HkPacket.CurrentEntryInTable                                   = CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1;
-    CS_AppData.ResEepromTblPtr[CS_AppData.HkPacket.CurrentEntryInTable].State = CS_STATE_ENABLED;
-    CS_AppData.ResEepromTblPtr[CS_AppData.HkPacket.CurrentEntryInTable].ComparisonValue = 3;
+    CS_AppData.HkPacket.Payload.CurrentEntryInTable                                   = CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1;
+    CS_AppData.ResEepromTblPtr[CS_AppData.HkPacket.Payload.CurrentEntryInTable].State = CS_STATE_ENABLED;
+    CS_AppData.ResEepromTblPtr[CS_AppData.HkPacket.Payload.CurrentEntryInTable].ComparisonValue = 3;
     UT_SetHandlerFunction(UT_KEY(CS_ComputeEepromMemory), CS_UTILS_TEST_CS_ComputeHandler, NULL);
     UtAssert_BOOL_TRUE(CS_BackgroundEeprom());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.EepromCSErrCounter, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.EepromCSErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 3);
-    UtAssert_UINT32_EQ(CS_AppData.HkPacket.EepromBaseline, 6);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 3);
+    UtAssert_UINT32_EQ(CS_AppData.HkPacket.Payload.EepromBaseline, 6);
 }
 
 void CS_BackgroundMemory_Test(void)
 {
     /* Entirely disabled */
-    CS_AppData.HkPacket.MemoryCSState = CS_STATE_DISABLED;
+    CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_DISABLED;
     UtAssert_BOOL_FALSE(CS_BackgroundMemory());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 1);
 
     /* All entries disabled */
-    CS_AppData.HkPacket.MemoryCSState = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_ENABLED;
     UtAssert_BOOL_FALSE(CS_BackgroundMemory());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 2);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 2);
 
     /* Enabled, miscompare, not done with entry */
     CS_AppData.ResMemoryTblPtr[0].State = CS_STATE_ENABLED;
     UT_SetDeferredRetcode(UT_KEY(CS_ComputeEepromMemory), 1, CS_ERROR);
     UtAssert_BOOL_TRUE(CS_BackgroundMemory());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.MemoryCSErrCounter, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.MemoryCSErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_MEMORY_MISCOMPARE_ERR_EID);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 2);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 2);
 
     /* Last entry, Enabled, compares, done with entry */
-    CS_AppData.HkPacket.CurrentEntryInTable                                   = CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1;
-    CS_AppData.ResMemoryTblPtr[CS_AppData.HkPacket.CurrentEntryInTable].State = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.CurrentEntryInTable                                   = CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1;
+    CS_AppData.ResMemoryTblPtr[CS_AppData.HkPacket.Payload.CurrentEntryInTable].State = CS_STATE_ENABLED;
     UT_SetHandlerFunction(UT_KEY(CS_ComputeEepromMemory), CS_UTILS_TEST_CS_ComputeHandler, NULL);
     UtAssert_BOOL_TRUE(CS_BackgroundMemory());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.MemoryCSErrCounter, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.MemoryCSErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 3);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 3);
 }
 
 void CS_BackgroundTables_Test(void)
 {
     /* Entirely disabled */
-    CS_AppData.HkPacket.TablesCSState = CS_STATE_DISABLED;
+    CS_AppData.HkPacket.Payload.TablesCSState = CS_STATE_DISABLED;
     UtAssert_BOOL_FALSE(CS_BackgroundTables());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 1);
 
     /* All entries disabled */
-    CS_AppData.HkPacket.TablesCSState = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.TablesCSState = CS_STATE_ENABLED;
     UtAssert_BOOL_FALSE(CS_BackgroundTables());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 2);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 2);
 
     /* Enabled, miscompare, not done with entry */
     CS_AppData.ResTablesTblPtr[0].State = CS_STATE_ENABLED;
     UT_SetDeferredRetcode(UT_KEY(CS_ComputeTables), 1, CS_ERROR);
     UtAssert_BOOL_TRUE(CS_BackgroundTables());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.TablesCSErrCounter, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.TablesCSErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_TABLES_MISCOMPARE_ERR_EID);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 2);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 2);
 
     /* Enabled, not found, not done with entry */
     UT_SetDeferredRetcode(UT_KEY(CS_ComputeTables), 1, CS_ERR_NOT_FOUND);
     UtAssert_BOOL_TRUE(CS_BackgroundTables());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.TablesCSErrCounter, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.TablesCSErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_COMPUTE_TABLES_NOT_FOUND_ERR_EID);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 1);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 2);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 2);
 
     /* Last entry, Enabled, compares, done with entry */
-    CS_AppData.HkPacket.CurrentEntryInTable                                   = CS_MAX_NUM_TABLES_TABLE_ENTRIES - 1;
-    CS_AppData.ResTablesTblPtr[CS_AppData.HkPacket.CurrentEntryInTable].State = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.CurrentEntryInTable                                   = CS_MAX_NUM_TABLES_TABLE_ENTRIES - 1;
+    CS_AppData.ResTablesTblPtr[CS_AppData.HkPacket.Payload.CurrentEntryInTable].State = CS_STATE_ENABLED;
     UT_SetHandlerFunction(UT_KEY(CS_ComputeTables), CS_UTILS_TEST_CS_ComputeHandler, NULL);
     UtAssert_BOOL_TRUE(CS_BackgroundTables());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.TablesCSErrCounter, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.TablesCSErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 3);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 3);
 }
 
 void CS_BackgroundApp_Test(void)
 {
     /* Entirely disabled */
-    CS_AppData.HkPacket.AppCSState = CS_STATE_DISABLED;
+    CS_AppData.HkPacket.Payload.AppCSState = CS_STATE_DISABLED;
     UtAssert_BOOL_FALSE(CS_BackgroundApp());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 1);
 
     /* All entries disabled */
-    CS_AppData.HkPacket.AppCSState = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.AppCSState = CS_STATE_ENABLED;
     UtAssert_BOOL_FALSE(CS_BackgroundApp());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 2);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 2);
 
     /* Enabled, miscompare, not done with entry */
     CS_AppData.ResAppTblPtr[0].State = CS_STATE_ENABLED;
     UT_SetDeferredRetcode(UT_KEY(CS_ComputeApp), 1, CS_ERROR);
     UtAssert_BOOL_TRUE(CS_BackgroundApp());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.AppCSErrCounter, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.AppCSErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_APP_MISCOMPARE_ERR_EID);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 2);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 2);
 
     /* Enabled, not found, not done with entry */
     UT_SetDeferredRetcode(UT_KEY(CS_ComputeApp), 1, CS_ERR_NOT_FOUND);
     UtAssert_BOOL_TRUE(CS_BackgroundApp());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.AppCSErrCounter, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.AppCSErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_COMPUTE_APP_NOT_FOUND_ERR_EID);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 1);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 2);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 2);
 
     /* Last entry, Enabled, compares, done with entry */
-    CS_AppData.HkPacket.CurrentEntryInTable                                = CS_MAX_NUM_APP_TABLE_ENTRIES - 1;
-    CS_AppData.ResAppTblPtr[CS_AppData.HkPacket.CurrentEntryInTable].State = CS_STATE_ENABLED;
+    CS_AppData.HkPacket.Payload.CurrentEntryInTable                                = CS_MAX_NUM_APP_TABLE_ENTRIES - 1;
+    CS_AppData.ResAppTblPtr[CS_AppData.HkPacket.Payload.CurrentEntryInTable].State = CS_STATE_ENABLED;
     UT_SetHandlerFunction(UT_KEY(CS_ComputeApp), CS_UTILS_TEST_CS_ComputeHandler, NULL);
     UtAssert_BOOL_TRUE(CS_BackgroundApp());
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.AppCSErrCounter, 1);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.AppCSErrCounter, 1);
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentEntryInTable, 0);
-    UtAssert_UINT16_EQ(CS_AppData.HkPacket.CurrentCSTable, 3);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentEntryInTable, 0);
+    UtAssert_UINT16_EQ(CS_AppData.HkPacket.Payload.CurrentCSTable, 3);
 }
 
 void CS_ResetTablesTblResultEntry_Test(void)
@@ -585,8 +585,8 @@ void CS_HandleRoutineTableUpdates_Test(void)
     uint16 i;
 
     /* Cycle through each all true case */
-    CS_AppData.HkPacket.RecomputeInProgress = true;
-    CS_AppData.HkPacket.OneShotInProgress   = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
+    CS_AppData.HkPacket.Payload.OneShotInProgress   = false;
     for (i = 0; i < TblMax; i++)
     {
         CS_AppData.ChildTaskTable = ChildTaskTable[i];
@@ -607,7 +607,7 @@ void CS_HandleRoutineTableUpdates_Test(void)
     }
 
     /* OneShotInProgress true case will update all */
-    CS_AppData.HkPacket.OneShotInProgress = true;
+    CS_AppData.HkPacket.Payload.OneShotInProgress = true;
     for (i = 0; i < TblMax; i++)
     {
         CS_AppData.ChildTaskTable = ChildTaskTable[i];
@@ -619,8 +619,8 @@ void CS_HandleRoutineTableUpdates_Test(void)
     }
 
     /* Recompute false will update all */
-    CS_AppData.HkPacket.RecomputeInProgress = false;
-    CS_AppData.HkPacket.OneShotInProgress   = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.OneShotInProgress   = false;
     for (i = 0; i < TblMax; i++)
     {
         CS_AppData.ChildTaskTable = ChildTaskTable[i];
@@ -682,27 +682,27 @@ void CS_AttemptTableReshare_Test(void)
 void CS_CheckRecomputeOneShot_Test(void)
 {
     /* Set up for false return */
-    CS_AppData.HkPacket.RecomputeInProgress = false;
-    CS_AppData.HkPacket.OneShotInProgress   = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+    CS_AppData.HkPacket.Payload.OneShotInProgress   = false;
 
     UtAssert_BOOL_FALSE(CS_CheckRecomputeOneshot());
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_UINT8_EQ(CS_AppData.HkPacket.CmdErrCounter, 0);
+    UtAssert_UINT8_EQ(CS_AppData.HkPacket.Payload.CmdErrCounter, 0);
 
     /* One shot in progress */
-    CS_AppData.HkPacket.OneShotInProgress = true;
+    CS_AppData.HkPacket.Payload.OneShotInProgress = true;
     UtAssert_BOOL_TRUE(CS_CheckRecomputeOneshot());
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_CMD_COMPUTE_PROG_ERR_EID);
-    UtAssert_UINT8_EQ(CS_AppData.HkPacket.CmdErrCounter, 1);
+    UtAssert_UINT8_EQ(CS_AppData.HkPacket.Payload.CmdErrCounter, 1);
 
     /* Recompute in progress */
-    CS_AppData.HkPacket.RecomputeInProgress = true;
-    CS_AppData.HkPacket.OneShotInProgress   = false;
+    CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
+    CS_AppData.HkPacket.Payload.OneShotInProgress   = false;
     UtAssert_BOOL_TRUE(CS_CheckRecomputeOneshot());
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_CMD_COMPUTE_PROG_ERR_EID);
-    UtAssert_UINT8_EQ(CS_AppData.HkPacket.CmdErrCounter, 2);
+    UtAssert_UINT8_EQ(CS_AppData.HkPacket.Payload.CmdErrCounter, 2);
 }
 
 void UtTest_Setup(void)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/CS/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fix #74, adds Payload substructure to all command and telemetry messages

**Testing performed**
unit testing

**Expected behavior changes**
 no impact to behavior

**System(s) tested on**
 - OS: Ubuntu 18.04


**Contributor Info - All information REQUIRED for consideration of pull request**
Haven Carlson - NASA
