### PR TITLE
Fix-91-buffer-overflow-unit-test

### DIFF
--- a/unit-test/cs_compute_tests.c
+++ b/unit-test/cs_compute_tests.c
@@ -1456,7 +1456,7 @@ void CS_RecomputeAppChildTask_Test_Nominal(void)
 void CS_RecomputeAppChildTask_Test_CouldNotGetAddress(void)
 {
     CS_Res_App_Table_Entry_t RecomputeAppEntry;
-    CS_Def_App_Table_Entry_t DefAppTbl[10];
+    CS_Def_App_Table_Entry_t DefAppTbl[CS_MAX_NUM_APP_TABLE_ENTRIES];
 
     memset(&RecomputeAppEntry, 0, sizeof(RecomputeAppEntry));
     memset(&DefAppTbl, 0, sizeof(DefAppTbl));
@@ -1637,7 +1637,7 @@ void CS_RecomputeTablesChildTask_Test_Nominal(void)
 void CS_RecomputeTablesChildTask_Test_CouldNotGetAddress(void)
 {
     CS_Res_Tables_Table_Entry_t RecomputeTablesEntry;
-    CS_Def_Tables_Table_Entry_t DefTablesTbl[10];
+    CS_Def_Tables_Table_Entry_t DefTablesTbl[CS_MAX_NUM_APP_TABLE_ENTRIES];
 
     memset(&RecomputeTablesEntry, 0, sizeof(RecomputeTablesEntry));
     memset(&DefTablesTbl, 0, sizeof(DefTablesTbl));


### PR DESCRIPTION
Fix #91, Resolve buffer overflow in CS_RecomputeAppChildTask_Test_CouldNotGetAddress and CS_RecomputeTablesChildTask_Test_CouldNotGetAddress

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CS/blob/main/CONTRIBUTING.md).
* [ x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
Fix #91, update the unit test table array to be the same length as the actual. 

**Testing performed**
Steps taken to test the contribution:
1. Add add_compile_options(-fsanitize=address -g) and add_link_options(-fsanitize=address) to arch_build_custom.cmake file
2. Make SIMULATION=native ENABLE_UNIT_TESTS=true SANTIZE=true prep
3. make install
4. make test

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
no impact to behavior. only unit test changed. 

**System(s) tested on**
gcc (Ubuntu 10.5.0-1ubuntu1~20.04) 10.5.0


**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLA's apply to software contributions.
 
Anh Van, GSFC
