### PR TITLE
Fix #93, Replaces strncpy and strlen

### DIFF
--- a/fsw/src/cs_compute.c
+++ b/fsw/src/cs_compute.c
@@ -536,20 +536,20 @@ void CS_RecomputeEepromMemoryChildTask(void)
 
     if (Table == CS_EEPROM_TABLE)
     {
-        strncpy(TableType, "EEPROM", CS_TABLETYPE_NAME_SIZE);
+        snprintf(TableType, CS_TABLETYPE_NAME_SIZE, "%s", "EEPROM");
     }
     if (Table == CS_MEMORY_TABLE)
     {
-        strncpy(TableType, "Memory", CS_TABLETYPE_NAME_SIZE);
+        snprintf(TableType, CS_TABLETYPE_NAME_SIZE, "%s", "Memory");
     }
     if (Table == CS_CFECORE)
     {
-        strncpy(TableType, "cFE Core", CS_TABLETYPE_NAME_SIZE);
+        snprintf(TableType, CS_TABLETYPE_NAME_SIZE, "%s", "cFE Core");
         CS_AppData.HkPacket.Payload.CfeCoreBaseline = NewChecksumValue;
     }
     if (Table == CS_OSCORE)
     {
-        strncpy(TableType, "OS", CS_TABLETYPE_NAME_SIZE);
+        snprintf(TableType, CS_TABLETYPE_NAME_SIZE, "%s", "OS");
         CS_AppData.HkPacket.Payload.OSBaseline = NewChecksumValue;
     }
 

--- a/fsw/src/cs_init.c
+++ b/fsw/src/cs_init.c
@@ -42,7 +42,7 @@ CFE_Status_t CS_SbInit(void)
     CFE_Status_t Result = CFE_SUCCESS;
 
     /* Initialize app configuration data */
-    strncpy(CS_AppData.PipeName, CS_CMD_PIPE_NAME, CS_CMD_PIPE_NAME_LEN);
+    snprintf(CS_AppData.PipeName, sizeof(CS_AppData.PipeName), "%s", CS_CMD_PIPE_NAME);
 
     CS_AppData.PipeDepth = CS_PIPE_DEPTH;
 

--- a/fsw/src/cs_table_processing.c
+++ b/fsw/src/cs_table_processing.c
@@ -231,7 +231,7 @@ CFE_Status_t CS_ValidateTablesChecksumDefinitionTable(void *TblPtr)
         StateField = OuterEntry->State;
 
         /* Check for non-zero length for table name */
-        if (strlen(OuterEntry->Name) != 0)
+        if (OS_strnlen(OuterEntry->Name, CFE_TBL_MAX_FULL_NAME_LEN) != 0)
         {
             /* Verify valid state definition */
             if (((StateField == CS_STATE_EMPTY) || (StateField == CS_STATE_ENABLED) ||
@@ -357,7 +357,7 @@ CFE_Status_t CS_ValidateAppChecksumDefinitionTable(void *TblPtr)
             }
             BadCount++;
         }
-        else if (strlen(OuterEntry->Name) != 0)
+        else if (OS_strnlen(OuterEntry->Name, CFE_TBL_MAX_FULL_NAME_LEN) != 0)
         {
             /* Verify valid state definition */
             if (((StateField == CS_STATE_EMPTY) || (StateField == CS_STATE_ENABLED) ||
@@ -466,7 +466,7 @@ void CS_ProcessNewEepromMemoryDefinitionTable(const CS_Def_EepromMemory_Table_En
     memcpy(&StartOfResultsTable, ResultsTblPtr, sizeof(StartOfResultsTable));
     memcpy(&StartOfDefTable, DefinitionTblPtr, sizeof(StartOfDefTable));
 
-    strncpy(&TableType[0], "Undef Tbl", CS_TABLETYPE_NAME_SIZE); /* Init the table type string */
+    snprintf(&TableType[0], CS_TABLETYPE_NAME_SIZE, "%s", "Undef Tbl"); /* Init the table type string */
 
     /* We don't want to be doing chekcksums while changing the table out */
     if (Table == CS_EEPROM_TABLE)
@@ -528,11 +528,11 @@ void CS_ProcessNewEepromMemoryDefinitionTable(const CS_Def_EepromMemory_Table_En
     {
         if (Table == CS_EEPROM_TABLE)
         {
-            strncpy(&TableType[0], "EEPROM", CS_TABLETYPE_NAME_SIZE);
+            snprintf(&TableType[0], CS_TABLETYPE_NAME_SIZE, "%s", "EEPROM");
         }
         if (Table == CS_MEMORY_TABLE)
         {
-            strncpy(&TableType[0], "Memory", CS_TABLETYPE_NAME_SIZE);
+            snprintf(&TableType[0], CS_TABLETYPE_NAME_SIZE, "%s", "Memory");
         }
 
         CFE_EVS_SendEvent(CS_PROCESS_EEPROM_MEMORY_NO_ENTRIES_INF_EID, CFE_EVS_EventType_INFORMATION,
@@ -825,7 +825,7 @@ CFE_Status_t CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handl
     osal_id_t    Fd               = OS_OBJECT_ID_UNDEFINED;
     char         TableType[CS_TABLETYPE_NAME_SIZE];
 
-    strncpy(TableType, "Undef Tbl", CS_TABLETYPE_NAME_SIZE); /* Init table type */
+    snprintf(TableType, CS_TABLETYPE_NAME_SIZE, "%s", "Undef Tbl"); /* Init table type */
 
     SizeOfTable = NumEntries * SizeofResultsTableEntry;
 
@@ -904,19 +904,19 @@ CFE_Status_t CS_TableInit(CFE_TBL_Handle_t *DefinitionTableHandle, CFE_TBL_Handl
     {
         if (Table == CS_EEPROM_TABLE)
         {
-            strncpy(TableType, "EEPROM", CS_TABLETYPE_NAME_SIZE);
+            snprintf(TableType, CS_TABLETYPE_NAME_SIZE, "%s", "EEPROM");
         }
         if (Table == CS_MEMORY_TABLE)
         {
-            strncpy(TableType, "Memory", CS_TABLETYPE_NAME_SIZE);
+            snprintf(TableType, CS_TABLETYPE_NAME_SIZE, "%s", "Memory");
         }
         if (Table == CS_TABLES_TABLE)
         {
-            strncpy(TableType, "Tables", CS_TABLETYPE_NAME_SIZE);
+            snprintf(TableType, CS_TABLETYPE_NAME_SIZE, "%s", "Tables");
         }
         if (Table == CS_APP_TABLE)
         {
-            strncpy(TableType, "Apps", CS_TABLETYPE_NAME_SIZE);
+            snprintf(TableType, CS_TABLETYPE_NAME_SIZE, "%s", "Apps");
         }
 
         CFE_EVS_SendEvent(CS_TBL_INIT_ERR_EID, CFE_EVS_EventType_ERROR,
@@ -967,7 +967,7 @@ CFE_Status_t CS_HandleTableUpdate(void *DefinitionTblPtr, void *ResultsTblPtr, C
     int32        Loop           = 0;
     char         TableType[CS_TABLETYPE_NAME_SIZE];
 
-    strncpy(TableType, "Undef Tbl", CS_TABLETYPE_NAME_SIZE); /* Init table type */
+    snprintf(TableType, CS_TABLETYPE_NAME_SIZE, "%s", "Undef Tbl"); /* Init table type */
 
     /* Below, there are several values that are returned and assigned, but never evaluated. */
     /* This is done so intentionally, as it helps us with Source-Level debugging this functions. */
@@ -1031,19 +1031,19 @@ CFE_Status_t CS_HandleTableUpdate(void *DefinitionTblPtr, void *ResultsTblPtr, C
         {
             if (Table == CS_EEPROM_TABLE)
             {
-                strncpy(TableType, "EEPROM", CS_TABLETYPE_NAME_SIZE);
+                snprintf(TableType, CS_TABLETYPE_NAME_SIZE, "%s", "EEPROM");
             }
             if (Table == CS_MEMORY_TABLE)
             {
-                strncpy(TableType, "Memory", CS_TABLETYPE_NAME_SIZE);
+                snprintf(TableType, CS_TABLETYPE_NAME_SIZE, "%s", "Memory");
             }
             if (Table == CS_TABLES_TABLE)
             {
-                strncpy(TableType, "Table", CS_TABLETYPE_NAME_SIZE);
+                snprintf(TableType, CS_TABLETYPE_NAME_SIZE, "%s", "Table");
             }
             if (Table == CS_APP_TABLE)
             {
-                strncpy(TableType, "App", CS_TABLETYPE_NAME_SIZE);
+                snprintf(TableType, CS_TABLETYPE_NAME_SIZE, "%s", "App");
             }
 
             /* There was a problem somewhere, generate an event */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/CS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #93. Adds dispositions to line of code in question from static analysis stating why it's safe to keep as-is. Replacing strncpy with snprintf to enhance safety and compliance. Replaces strlen for purposes of verifying non-empty string with memchr.

**Testing performed**
build, lcov

**Expected behavior changes**
None

**System(s) tested on**
 - OS: Ubuntu 22.04

**Additional context**
`snprintf()` guarentees null-termination at the line whereas `strncpy()` does not. This change helps comply with safety assurance. 

Depends on https://github.com/nasa/osal/pull/1465

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems