### PR TITLE
Fix #95, Standardize command responses

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ A clear and concise description of what the contribution is.
 **Testing performed**
 Steps taken to test the contribution:
 1. Build steps '...'
-1. Execution steps '...'
+2. Execution steps '...'
 
 **Expected behavior changes**
 A clear and concise description of how this contribution will change behavior and level of impact.

--- a/fsw/inc/cs_events.h
+++ b/fsw/inc/cs_events.h
@@ -189,7 +189,7 @@
 /**
  * \brief CS cFE Core Checksum Recompute Started Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
@@ -197,7 +197,7 @@
  *  for the cFE core command has been received and the
  *  recompute task has been started.
  */
-#define CS_RECOMPUTE_CFECORE_STARTED_DBG_EID 14
+#define CS_RECOMPUTE_CFECORE_STARTED_INF_EID 14
 
 /**
  * \brief CS cFE Core Checksum Failed Child Task Create Event ID
@@ -230,7 +230,7 @@
 /**
  * \brief CS OS Code Checksum Recompute Started Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
@@ -238,7 +238,7 @@
  *  for the OS code segment command has been received and the
  *  recompute task has been started.
  */
-#define CS_RECOMPUTE_OS_STARTED_DBG_EID 17
+#define CS_RECOMPUTE_OS_STARTED_INF_EID 17
 
 /**
  * \brief CS OS Code Checksum Recompute Failed Child Task Create Event ID
@@ -271,14 +271,14 @@
 /**
  * \brief CS Oneshot Checksum Started Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  This event message is issued when a OneShot calculation
  *  command has been received and the OneShot task has been started.
  */
-#define CS_ONESHOT_STARTED_DBG_EID 20
+#define CS_ONESHOT_STARTED_INF_EID 20
 
 /**
  * \brief CS Oneshot Checksum Failed Child Task Create Event ID
@@ -547,7 +547,7 @@
 /**
  * \brief CS EEPROM Checksum Recompute Started Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
@@ -555,7 +555,7 @@
  *  for the specified EEPROM Entry ID command has been received and the
  *  recompute task has been started.
  */
-#define CS_RECOMPUTE_EEPROM_STARTED_DBG_EID 42
+#define CS_RECOMPUTE_EEPROM_STARTED_INF_EID 42
 
 /**
  * \brief CS EEPROM Checksum Recompute Failed Child Task Create Event ID
@@ -746,7 +746,7 @@
 /**
  * \brief CS Memory Checksum Recompute Started Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
@@ -754,7 +754,7 @@
  *  for the specified Memory Entry ID command has been received and the
  *  recompute task has been started.
  */
-#define CS_RECOMPUTE_MEMORY_STARTED_DBG_EID 57
+#define CS_RECOMPUTE_MEMORY_STARTED_INF_EID 57
 
 /**
  * \brief CS Memory Checksum Recompute Failed Child Task Create Event ID
@@ -947,7 +947,7 @@
 /**
  * \brief CS Table Checksum Recompute Started Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
@@ -955,7 +955,7 @@
  *  for the specified table command has been received and the
  *  recompute task has been started.
  */
-#define CS_RECOMPUTE_TABLES_STARTED_DBG_EID 72
+#define CS_RECOMPUTE_TABLES_STARTED_INF_EID 72
 
 /**
  * \brief CS Table Checksum Recompute Failed Child Task Create Event ID
@@ -1120,7 +1120,7 @@
 /**
  * \brief CS App Checksum Recompute Started Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
@@ -1128,7 +1128,7 @@
  *  for the specified app command has been received and the
  *  recompute task has been started.
  */
-#define CS_RECOMPUTE_APP_STARTED_DBG_EID 85
+#define CS_RECOMPUTE_APP_STARTED_INF_EID 85
 
 /**
  * \brief CS App Checksum Recompute Failed Create Child Task Event ID
@@ -1657,7 +1657,7 @@
 /**
  * \brief CS Table Enable Checksum Unable To Find Entry In Definition Table Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: ERROR
  *
  *  \par Cause:
  *
@@ -1665,12 +1665,12 @@
  *  by name) in the Tables results table but is unable to find the same entry
  *  in the definition table (or the entry is marked as #CS_STATE_EMPTY).
  */
-#define CS_ENABLE_TABLE_DEF_NOT_FOUND_DBG_EID 129
+#define CS_ENABLE_TABLE_DEF_NOT_FOUND_ERR_EID 129
 
 /**
  * \brief CS Table Disable Checksum Unable To Find Entry In Definition Table Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: ERROR
  *
  *  \par Cause:
  *
@@ -1678,12 +1678,12 @@
  *  by name) in the Tables results table but is unable to find the same entry
  *  in the definition table (or the entry is marked as #CS_STATE_EMPTY).
  */
-#define CS_DISABLE_TABLE_DEF_NOT_FOUND_DBG_EID 130
+#define CS_DISABLE_TABLE_DEF_NOT_FOUND_ERR_EID 130
 
 /**
  * \brief CS App Enable Checksum Unable To Find Entry In Definition Table Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: ERROR
  *
  *  \par Cause:
  *
@@ -1691,12 +1691,12 @@
  *  by name) in the Apps results table but is unable to find the same entry
  *  in the definition table (or the entry is marked as #CS_STATE_EMPTY).
  */
-#define CS_ENABLE_APP_DEF_NOT_FOUND_DBG_EID 131
+#define CS_ENABLE_APP_DEF_NOT_FOUND_ERR_EID 131
 
 /**
  * \brief CS App Disable Checksum Unable To Find Entry In Definition Table Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: ERROR
  *
  *  \par Cause:
  *
@@ -1704,12 +1704,12 @@
  *  by name) in the Apps results table but is unable to find the same entry
  *  in the definition table (or the entry is marked as #CS_STATE_EMPTY).
  */
-#define CS_DISABLE_APP_DEF_NOT_FOUND_DBG_EID 132
+#define CS_DISABLE_APP_DEF_NOT_FOUND_ERR_EID 132
 
 /**
  * \brief CS Memory Disable Checksum Unable To Find Entry In Definition Table Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: ERROR
  *
  *  \par Cause:
  *
@@ -1717,12 +1717,12 @@
  *  by name) in the Memory results table but identifies the corresponding entry in
  *  the definitions table to be set to #CS_STATE_EMPTY.
  */
-#define CS_DISABLE_MEMORY_DEF_EMPTY_DBG_EID 133
+#define CS_DISABLE_MEMORY_DEF_EMPTY_ERR_EID 133
 
 /**
  * \brief CS Memory Enable Checksum Unable To Find Entry In Definition Table Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: ERROR
  *
  *  \par Cause:
  *
@@ -1730,12 +1730,12 @@
  *  by name) in the Memory results table but identifies the corresponding entry in
  *  the definitions table to be set to #CS_STATE_EMPTY.
  */
-#define CS_ENABLE_MEMORY_DEF_EMPTY_DBG_EID 134
+#define CS_ENABLE_MEMORY_DEF_EMPTY_ERR_EID 134
 
 /**
  * \brief CS EEPROM Disable Checksum Unable To Find Entry In Definition Table Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: ERROR
  *
  *  \par Cause:
  *
@@ -1743,12 +1743,12 @@
  *  by name) in the EEPROM results table but identifies the corresponding entry in
  *  the definitions table to be set to #CS_STATE_EMPTY.
  */
-#define CS_DISABLE_EEPROM_DEF_EMPTY_DBG_EID 135
+#define CS_DISABLE_EEPROM_DEF_EMPTY_ERR_EID 135
 
 /**
  * \brief CS EEPROM Enable Checksum Unable To Find Entry In Definition Table Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: ERROR
  *
  *  \par Cause:
  *
@@ -1756,7 +1756,7 @@
  *  by name) in the EEPROM results table but identifies the corresponding entry in
  *  the definitions table to be set to #CS_STATE_EMPTY.
  */
-#define CS_ENABLE_EEPROM_DEF_EMPTY_DBG_EID 136
+#define CS_ENABLE_EEPROM_DEF_EMPTY_ERR_EID 136
 
 /**
  * \brief CS Tables Table Validate Failed Duplicate Name Event ID

--- a/fsw/inc/cs_msgdefs.h
+++ b/fsw/inc/cs_msgdefs.h
@@ -111,10 +111,10 @@
  *       Successful execution of this command may be verified with
  *       the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdCounter will increment
- *       - The #CS_ONESHOT_STARTED_DBG_EID debug event message will be
+ *       - The #CS_ONESHOT_STARTED_INF_EID informational event message will be
  *         generated when the command is received
  *       - The CS_ONESHOT_FINISHED_INF_EID informational message will
- *         be generated when the compuation finishes.
+ *         be generated when the computation finishes.
  *       - #CS_HkPacket_Payload_t.LastOneShotChecksum will be updated to the new value
  *
  *  \par Error Conditions
@@ -356,8 +356,8 @@
  *       Successful execution of this command may be verified with
  *       the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdCounter will increment
- *       - The #CS_RECOMPUTE_CFECORE_STARTED_DBG_EID debug event message will be
- *         generated when the command is received
+ *       - The #CS_RECOMPUTE_CFECORE_STARTED_INF_EID informational event message
+ *         will be generated when the command is received
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
@@ -495,8 +495,8 @@
  *       Successful execution of this command may be verified with
  *       the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdCounter will increment
- *       - The #CS_RECOMPUTE_OS_STARTED_DBG_EID debug event message will be
- *         generated when the command is received
+ *       - The #CS_RECOMPUTE_OS_STARTED_INF_EID informational event message
+ *         will be generated when the command is received
  *
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
@@ -637,7 +637,7 @@
  *       Successful execution of this command may be verified with
  *       the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdCounter will increment
- *       - The #CS_RECOMPUTE_EEPROM_STARTED_DBG_EID debug event
+ *       - The #CS_RECOMPUTE_EEPROM_STARTED_INF_EID informational event
  *         message will be generated when the command is received
  *       - The #CS_RECOMPUTE_FINISH_EEPROM_MEMORY_INF_EID informational event
  *         message will be generated when the recompute is finished
@@ -881,7 +881,7 @@
  *       Successful execution of this command may be verified with
  *       the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdCounter will increment
- *       - The #CS_RECOMPUTE_MEMORY_STARTED_DBG_EID debug event
+ *       - The #CS_RECOMPUTE_MEMORY_STARTED_INF_EID informational event
  *         message will be generated when the command is received
  *       - The #CS_RECOMPUTE_FINISH_EEPROM_MEMORY_INF_EID informational event
  *         message will be generated when the recompute is finished
@@ -1126,7 +1126,7 @@
  *       Successful execution of this command may be verified with
  *       the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdCounter will increment
- *       - The #CS_RECOMPUTE_TABLES_STARTED_DBG_EID debug event
+ *       - The #CS_RECOMPUTE_TABLES_STARTED_INF_EID informational event
  *         message will be generated when the command is received
  *       - The #CS_RECOMPUTE_FINISH_TABLES_INF_EID informational event
  *         message will be generated when the recompute is finished.
@@ -1344,7 +1344,7 @@
  *       Successful execution of this command may be verified with
  *       the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdCounter will increment
- *       - The #CS_RECOMPUTE_APP_STARTED_DBG_EID debug event
+ *       - The #CS_RECOMPUTE_APP_STARTED_INF_EID informational event
  *         message will be generated when the command is received
  *       - The #CS_RECOMPUTE_FINISH_APP_INF_EID informational event
  *         message will be generated when the recompute is finished

--- a/fsw/inc/cs_tbldefs.h
+++ b/fsw/inc/cs_tbldefs.h
@@ -119,7 +119,7 @@ typedef struct
     uint32           ComparisonValue;                 /**< \brief The Memory Integrity Value */
     uint32           ByteOffset;                      /**< \brief Where a previous unfinished calc left off */
     uint32           TempChecksumValue;               /**< \brief The unfinished caluculation */
-    CFE_TBL_Handle_t TblHandle;                       /**< \brief handle recieved from CFE_TBL */
+    CFE_TBL_Handle_t TblHandle;                       /**< \brief handle received from CFE_TBL */
     bool             IsCSOwner;                       /**< \brief Is CS the original owner of this table */
     bool             Filler8;                         /**< \brief Padding */
     char             Name[CFE_TBL_MAX_FULL_NAME_LEN]; /**< \brief name of the table */

--- a/fsw/src/cs_app_cmds.c
+++ b/fsw/src/cs_app_cmds.c
@@ -151,7 +151,7 @@ void CS_RecomputeBaselineAppCmd(const CS_AppNameCmd_t *CmdPtr)
                                                 CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
                 if (Status == CFE_SUCCESS)
                 {
-                    CFE_EVS_SendEvent(CS_RECOMPUTE_APP_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
+                    CFE_EVS_SendEvent(CS_RECOMPUTE_APP_STARTED_INF_EID, CFE_EVS_EventType_INFORMATION,
                                       "Recompute baseline of app %s started", Name);
                     CS_AppData.HkPacket.Payload.CmdCounter++;
                 }
@@ -214,7 +214,7 @@ void CS_DisableNameAppCmd(const CS_AppNameCmd_t *CmdPtr)
                 }
                 else
                 {
-                    CFE_EVS_SendEvent(CS_DISABLE_APP_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
+                    CFE_EVS_SendEvent(CS_DISABLE_APP_DEF_NOT_FOUND_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "CS unable to update apps definition table for entry %s", Name);
                 }
 
@@ -262,7 +262,7 @@ void CS_EnableNameAppCmd(const CS_AppNameCmd_t *CmdPtr)
                 }
                 else
                 {
-                    CFE_EVS_SendEvent(CS_ENABLE_APP_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
+                    CFE_EVS_SendEvent(CS_ENABLE_APP_DEF_NOT_FOUND_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "CS unable to update apps definition table for entry %s", Name);
                 }
 

--- a/fsw/src/cs_cmds.c
+++ b/fsw/src/cs_cmds.c
@@ -72,7 +72,7 @@ void CS_ResetCmd(const CS_NoArgsCmd_t *CmdPtr)
     CS_AppData.HkPacket.Payload.OSCSErrCounter      = 0;
     CS_AppData.HkPacket.Payload.PassCounter         = 0;
 
-    CFE_EVS_SendEvent(CS_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command recieved");
+    CFE_EVS_SendEvent(CS_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "Reset Counters command received");
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -366,7 +366,7 @@ void CS_RecomputeBaselineCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
 
         if (Status == CFE_SUCCESS)
         {
-            CFE_EVS_SendEvent(CS_RECOMPUTE_CFECORE_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
+            CFE_EVS_SendEvent(CS_RECOMPUTE_CFECORE_STARTED_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Recompute of cFE core started");
             CS_AppData.HkPacket.Payload.CmdCounter++;
         }
@@ -414,7 +414,7 @@ void CS_RecomputeBaselineOSCmd(const CS_NoArgsCmd_t *CmdPtr)
                                         CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
         if (Status == CFE_SUCCESS)
         {
-            CFE_EVS_SendEvent(CS_RECOMPUTE_OS_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
+            CFE_EVS_SendEvent(CS_RECOMPUTE_OS_STARTED_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Recompute of OS code segment started");
             CS_AppData.HkPacket.Payload.CmdCounter++;
         }
@@ -476,7 +476,7 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
                                             CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
             if (Status == CFE_SUCCESS)
             {
-                CFE_EVS_SendEvent(CS_ONESHOT_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
+                CFE_EVS_SendEvent(CS_ONESHOT_STARTED_INF_EID, CFE_EVS_EventType_INFORMATION,
                                   "OneShot checksum started on address: 0x%08X, size: %d",
                                   (unsigned int)(CmdPtr->Payload.Address), (int)(CmdPtr->Payload.Size));
 

--- a/fsw/src/cs_compute.c
+++ b/fsw/src/cs_compute.c
@@ -174,7 +174,7 @@ CFE_Status_t CS_ComputeTables(CS_Res_Tables_Table_Entry_t *ResultsEntry, uint32 
         CFE_TBL_ReleaseAddress(LocalTblHandle);
     }
 
-    /* The table has dissapeared since the last time CS looked.
+    /* The table has disappeared since the last time CS looked.
        We are checking to see if the table came back */
     if (Result == CFE_TBL_ERR_UNREGISTERED)
     {
@@ -281,8 +281,8 @@ CFE_Status_t CS_ComputeTables(CS_Res_Tables_Table_Entry_t *ResultsEntry, uint32 
         if (Result != CFE_SUCCESS)
         {
             CFE_EVS_SendEvent(CS_COMPUTE_TABLES_RELEASE_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "CS Tables: Could not release addresss for table %s, returned: 0x%08X",
-                              ResultsEntry->Name, (unsigned int)Result);
+                              "CS Tables: Could not release address for table %s, returned: 0x%08X", ResultsEntry->Name,
+                              (unsigned int)Result);
         }
 
     } /* end if tabled was success or updated */

--- a/fsw/src/cs_eeprom_cmds.c
+++ b/fsw/src/cs_eeprom_cmds.c
@@ -173,7 +173,7 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
                                            NULL, CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
                 if (Status == CFE_SUCCESS)
                 {
-                    CFE_EVS_SendEvent(CS_RECOMPUTE_EEPROM_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
+                    CFE_EVS_SendEvent(CS_RECOMPUTE_EEPROM_STARTED_INF_EID, CFE_EVS_EventType_INFORMATION,
                                       "Recompute baseline of EEPROM Entry ID %d started", EntryID);
                     CS_AppData.HkPacket.Payload.CmdCounter++;
                 }
@@ -249,7 +249,7 @@ void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 }
                 else
                 {
-                    CFE_EVS_SendEvent(CS_ENABLE_EEPROM_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
+                    CFE_EVS_SendEvent(CS_ENABLE_EEPROM_DEF_EMPTY_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "CS unable to update EEPROM definition table for entry %d, State: %d", EntryID,
                                       State);
                 }
@@ -311,7 +311,7 @@ void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 }
                 else
                 {
-                    CFE_EVS_SendEvent(CS_DISABLE_EEPROM_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
+                    CFE_EVS_SendEvent(CS_DISABLE_EEPROM_DEF_EMPTY_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "CS unable to update EEPROM definition table for entry %d, State: %d", EntryID,
                                       State);
                 }

--- a/fsw/src/cs_init.c
+++ b/fsw/src/cs_init.c
@@ -181,7 +181,7 @@ void CS_InitSegments(void)
     uint32  KernelSize;
     cpuaddr KernelAddress;
 
-    /* Initalize the CFE core segments */
+    /* Initialize the CFE core segments */
     ResultSegment = CFE_PSP_GetCFETextSegmentInfo(&CFEAddress, &CFESize);
 
     if (ResultSegment != OS_SUCCESS)

--- a/fsw/src/cs_memory_cmds.c
+++ b/fsw/src/cs_memory_cmds.c
@@ -173,7 +173,7 @@ void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                                            NULL, CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
                 if (Status == CFE_SUCCESS)
                 {
-                    CFE_EVS_SendEvent(CS_RECOMPUTE_MEMORY_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
+                    CFE_EVS_SendEvent(CS_RECOMPUTE_MEMORY_STARTED_INF_EID, CFE_EVS_EventType_INFORMATION,
                                       "Recompute baseline of Memory Entry ID %d started", EntryID);
                     CS_AppData.HkPacket.Payload.CmdCounter++;
                 }
@@ -249,7 +249,7 @@ void CS_EnableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                 }
                 else
                 {
-                    CFE_EVS_SendEvent(CS_ENABLE_MEMORY_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
+                    CFE_EVS_SendEvent(CS_ENABLE_MEMORY_DEF_EMPTY_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "CS unable to update memory definition table for entry %d, State: %d", EntryID,
                                       State);
                 }
@@ -311,7 +311,7 @@ void CS_DisableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                 }
                 else
                 {
-                    CFE_EVS_SendEvent(CS_DISABLE_MEMORY_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
+                    CFE_EVS_SendEvent(CS_DISABLE_MEMORY_DEF_EMPTY_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "CS unable to update memory definition table for entry %d, State: %d", EntryID,
                                       State);
                 }

--- a/fsw/src/cs_table_cmds.c
+++ b/fsw/src/cs_table_cmds.c
@@ -151,7 +151,7 @@ void CS_RecomputeBaselineTablesCmd(const CS_TableNameCmd_t *CmdPtr)
                                                 NULL, CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
                 if (Status == CFE_SUCCESS)
                 {
-                    CFE_EVS_SendEvent(CS_RECOMPUTE_TABLES_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
+                    CFE_EVS_SendEvent(CS_RECOMPUTE_TABLES_STARTED_INF_EID, CFE_EVS_EventType_INFORMATION,
                                       "Recompute baseline of table %s started", Name);
                     CS_AppData.HkPacket.Payload.CmdCounter++;
                 }
@@ -213,7 +213,7 @@ void CS_DisableNameTablesCmd(const CS_TableNameCmd_t *CmdPtr)
                 }
                 else
                 {
-                    CFE_EVS_SendEvent(CS_DISABLE_TABLE_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
+                    CFE_EVS_SendEvent(CS_DISABLE_TABLE_DEF_NOT_FOUND_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "CS unable to update tables definition table for entry %s", Name);
                 }
 
@@ -259,7 +259,7 @@ void CS_EnableNameTablesCmd(const CS_TableNameCmd_t *CmdPtr)
                 }
                 else
                 {
-                    CFE_EVS_SendEvent(CS_ENABLE_TABLE_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
+                    CFE_EVS_SendEvent(CS_ENABLE_TABLE_DEF_NOT_FOUND_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "CS unable to update tables definition table for entry %s", Name);
                 }
 

--- a/fsw/src/cs_utils.c
+++ b/fsw/src/cs_utils.c
@@ -41,7 +41,7 @@
  **************************************************************************/
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Zero out the temp chcksum values of EEPROM                   */
+/* CS Zero out the temp checksum values of EEPROM                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_ZeroEepromTempValues(void)
@@ -57,7 +57,7 @@ void CS_ZeroEepromTempValues(void)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Zero out the temp chcksum values of Memory                   */
+/* CS Zero out the temp checksum values of Memory                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_ZeroMemoryTempValues(void)
@@ -73,7 +73,7 @@ void CS_ZeroMemoryTempValues(void)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Zero out the temp chcksum values of Tables                   */
+/* CS Zero out the temp checksum values of Tables                  */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_ZeroTablesTempValues(void)
@@ -89,7 +89,7 @@ void CS_ZeroTablesTempValues(void)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Zero out the temp chcksum values of Applications             */
+/* CS Zero out the temp checksum values of Applications            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_ZeroAppTempValues(void)
@@ -105,7 +105,7 @@ void CS_ZeroAppTempValues(void)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Zero out the temp chcksum values ofthe cFE core              */
+/* CS Zero out the temp checksum values of the cFE core            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_ZeroCfeCoreTempValues(void)
@@ -116,7 +116,7 @@ void CS_ZeroCfeCoreTempValues(void)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Zero out the temp chcksum values of the OS code segment      */
+/* CS Zero out the temp checksum values of the OS code segment     */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_ZeroOSTempValues(void)

--- a/unit-test/cs_app_cmds_tests.c
+++ b/unit-test/cs_app_cmds_tests.c
@@ -353,7 +353,7 @@ void CS_RecomputeBaselineAppCmd_Test_Nominal(void)
     /* Needed to make subfunction CS_GetAppResTblEntryByName behave properly */
     CS_AppData.ResAppTblPtr->State = 1;
 
-    /* Set to generate event message CS_RECOMPUTE_APP_STARTED_DBG_EID */
+    /* Set to generate event message CS_RECOMPUTE_APP_STARTED_INF_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CreateChildTask), 1, CFE_SUCCESS);
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
@@ -368,8 +368,8 @@ void CS_RecomputeBaselineAppCmd_Test_Nominal(void)
     UtAssert_True(CS_AppData.ResAppTblPtr == CS_AppData.RecomputeAppEntryPtr,
                   "CS_AppData.ResAppTblPtr == CS_AppData.RecomputeAppEntryPtr");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_APP_STARTED_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_APP_STARTED_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
@@ -595,8 +595,8 @@ void CS_DisableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_DISABLE_APP_DEF_NOT_FOUND_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_DISABLE_APP_DEF_NOT_FOUND_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult =
         strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -757,8 +757,8 @@ void CS_EnableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_ENABLE_APP_DEF_NOT_FOUND_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_ENABLE_APP_DEF_NOT_FOUND_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult =
         strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);

--- a/unit-test/cs_cmds_tests.c
+++ b/unit-test/cs_cmds_tests.c
@@ -85,7 +85,7 @@ void CS_ResetCmd_Test(void)
     int32          strCmpResult;
     char           ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Reset Counters command recieved");
+    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Reset Counters command received");
 
     CS_AppData.HkPacket.Payload.CmdCounter          = 1;
     CS_AppData.HkPacket.Payload.CmdErrCounter       = 2;
@@ -114,7 +114,7 @@ void CS_ResetCmd_Test(void)
     UtAssert_True(CS_AppData.HkPacket.Payload.PassCounter == 0, "CS_AppData.HkPacket.Payload.PassCounter == 0");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RESET_INF_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
@@ -901,8 +901,8 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_Nominal(void)
     UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.CfeCoreCodeSeg,
                   "CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.CfeCoreCodeSeg");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_CFECORE_STARTED_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_CFECORE_STARTED_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
@@ -1045,8 +1045,8 @@ void CS_RecomputeBaselineOSCmd_Test_Nominal(void)
     UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.OSCodeSeg,
                   "CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.OSCodeSeg");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_OS_STARTED_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_OS_STARTED_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
@@ -1201,8 +1201,8 @@ void CS_OneShotCmd_Test_Nominal(void)
     UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotMaxBytesPerCycle == CS_AppData.MaxBytesPerCycle,
                   "CS_AppData.HkPacket.Payload.LastOneShotMaxBytesPerCycle == CS_AppData.MaxBytesPerCycle");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ONESHOT_STARTED_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ONESHOT_STARTED_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
@@ -1250,8 +1250,8 @@ void CS_OneShotCmd_Test_MaxBytesPerCycleNonZero(void)
     UtAssert_True(CS_AppData.HkPacket.Payload.LastOneShotMaxBytesPerCycle == CmdPacket.Payload.MaxBytesPerCycle,
                   "CS_AppData.HkPacket.Payload.LastOneShotMaxBytesPerCycle == CmdPacket.Payload.MaxBytesPerCycle");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ONESHOT_STARTED_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ONESHOT_STARTED_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 

--- a/unit-test/cs_compute_tests.c
+++ b/unit-test/cs_compute_tests.c
@@ -612,7 +612,7 @@ void CS_ComputeTables_Test_ComputeTablesReleaseError(void)
     memset(&TblInfo, 0, sizeof(TblInfo));
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "CS Tables: Could not release addresss for table %%s, returned: 0x%%08X");
+             "CS Tables: Could not release address for table %%s, returned: 0x%%08X");
 
     ResultsEntry.TblHandle = CFE_TBL_BAD_TABLE_HANDLE;
 

--- a/unit-test/cs_eeprom_cmds_tests.c
+++ b/unit-test/cs_eeprom_cmds_tests.c
@@ -309,8 +309,8 @@ void CS_RecomputeBaselineEepromCmd_Test_Nominal(void)
     UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID],
                   "CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResEepromTblPtr[CmdPacket.Payload.EntryID]");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_EEPROM_STARTED_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_EEPROM_STARTED_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
@@ -578,8 +578,8 @@ void CS_EnableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_ENABLE_EEPROM_DEF_EMPTY_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_ENABLE_EEPROM_DEF_EMPTY_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult =
         strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -762,8 +762,8 @@ void CS_DisableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_DISABLE_EEPROM_DEF_EMPTY_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_DISABLE_EEPROM_DEF_EMPTY_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult =
         strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);

--- a/unit-test/cs_memory_cmds_tests.c
+++ b/unit-test/cs_memory_cmds_tests.c
@@ -309,8 +309,8 @@ void CS_RecomputeBaselineMemoryCmd_Test_Nominal(void)
     UtAssert_True(CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID],
                   "CS_AppData.RecomputeEepromMemoryEntryPtr == &CS_AppData.ResMemoryTblPtr[CmdPacket.Payload.EntryID]");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_MEMORY_STARTED_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_MEMORY_STARTED_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
@@ -578,8 +578,8 @@ void CS_EnableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_ENABLE_MEMORY_DEF_EMPTY_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_ENABLE_MEMORY_DEF_EMPTY_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult =
         strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -762,8 +762,8 @@ void CS_DisableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_DISABLE_MEMORY_DEF_EMPTY_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_DISABLE_MEMORY_DEF_EMPTY_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult =
         strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);

--- a/unit-test/cs_table_cmds_tests.c
+++ b/unit-test/cs_table_cmds_tests.c
@@ -325,8 +325,8 @@ void CS_RecomputeBaselineTablesCmd_Test_Nominal(void)
 
     UtAssert_True(CS_AppData.ChildTaskTable == CS_TABLES_TABLE, "CS_AppData.ChildTaskTable == CS_TABLES_TABLE");
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_TABLES_STARTED_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_TABLES_STARTED_INF_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
 
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
@@ -582,8 +582,8 @@ void CS_DisableNameTablesCmd_Test_TableDefNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_DISABLE_TABLE_DEF_NOT_FOUND_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_DISABLE_TABLE_DEF_NOT_FOUND_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult =
         strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
@@ -734,8 +734,8 @@ void CS_EnableNameTablesCmd_Test_TableDefNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_ENABLE_TABLE_DEF_NOT_FOUND_DBG_EID);
-    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_DEBUG);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_ENABLE_TABLE_DEF_NOT_FOUND_ERR_EID);
+    UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventType, CFE_EVS_EventType_ERROR);
 
     strCmpResult =
         strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #95
  - Standardization of the command response events as per the issue description

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Event types are standardized as per the issue description.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt