### PR TITLE
Fix #97, Remove dead code checks: `NULL` `bufptr` and `RunStatus_SYS_EXCEPTION`

### DIFF
--- a/fsw/inc/cs_msg.h
+++ b/fsw/inc/cs_msg.h
@@ -37,8 +37,8 @@
  */
 typedef struct
 {
-    uint8   CmdCounter;                  /**< \brief CS Application Command Counter */
-    uint8   CmdErrCounter;               /**< \brief CS Application Command Error Counter */
+    uint8   CommandCounter;              /**< \brief CS Application Command Counter */
+    uint8   CommandErrorCounter;         /**< \brief CS Application Command Error Counter */
     uint8   ChecksumState;               /**< \brief CS Application global checksum state */
     uint8   EepromCSState;               /**< \brief CS EEPROM table checksum state */
     uint8   MemoryCSState;               /**< \brief CS Memory table checksum state */

--- a/fsw/inc/cs_msgdefs.h
+++ b/fsw/inc/cs_msgdefs.h
@@ -44,7 +44,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_NOOP_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -53,7 +53,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -75,8 +75,8 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will be cleared
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will be cleared
+ *       - #CS_HkPacket_Payload_t.CommandCounter will be cleared
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will be cleared
  *       - The #CS_RESET_INF_EID informational event message will be
  *         generated when the command is executed
  *
@@ -85,7 +85,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -110,7 +110,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_ONESHOT_STARTED_DBG_EID debug event message will be
  *         generated when the command is received
  *       - The CS_ONESHOT_FINISHED_INF_EID informational message will
@@ -127,7 +127,7 @@
  *       - The child task failed to be created
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_ONESHOT_MEMVALIDATE_ERR_EID
  *       - Error specific event message #CS_ONESHOT_CHDTASK_ERR_EID
@@ -158,7 +158,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_ONESHOT_CANCELLED_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -169,7 +169,7 @@
  *       - The child task could not be deleted
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_ONESHOT_CANCEL_NO_CHDTASK_ERR_EID
  *       - Error specific event message #CS_ONESHOT_CANCEL_DELETE_CHDTASK_ERR_EID
@@ -193,7 +193,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_ENABLE_ALL_INF_EID informational event message will be
  *         generated when the command is received
  *       - #CS_HkPacket_Payload_t.ChecksumState set to #CS_STATE_ENABLED
@@ -203,7 +203,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -225,7 +225,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_DISABLE_ALL_INF_EID informational event message will be
  *         generated when the command is received
  *       - #CS_HkPacket_Payload_t.ChecksumState set to #CS_STATE_DISABLED
@@ -235,7 +235,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -257,7 +257,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_ENABLE_CFECORE_INF_EID informational event message will be
  *         generated when the command is received
  *       - #CS_HkPacket_Payload_t.CfeCoreCSState set to #CS_STATE_ENABLED
@@ -267,7 +267,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -289,7 +289,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_DISABLE_CFECORE_INF_EID informational event message will be
  *         generated when the command is received
  *       - #CS_HkPacket_Payload_t.CfeCoreCSState set to #CS_STATE_DISABLED
@@ -299,7 +299,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -322,7 +322,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_BASELINE_CFECORE_INF_EID informational event message will be
  *         generated when the command is received, or
  *       - The #CS_NO_BASELINE_CFECORE_INF_EID informational event message will be
@@ -333,7 +333,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -355,7 +355,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_RECOMPUTE_CFECORE_STARTED_DBG_EID debug event message will be
  *         generated when the command is received
  *
@@ -368,7 +368,7 @@
  *       - The child task failed to be created by Executive Services (ES)
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_CFECORE_CREATE_CHDTASK_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_CFECORE_CHDTASK_ERR_EID
@@ -397,7 +397,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_ENABLE_OS_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -406,7 +406,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - #CS_HkPacket_Payload_t.OSCSState set to #CS_STATE_ENABLED
  *
@@ -429,7 +429,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_DISABLE_OS_INF_EID informational event message will be
  *         generated when the command is received
  *       - #CS_HkPacket_Payload_t.OSCSState set to #CS_STATE_DISABLED
@@ -439,7 +439,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -462,7 +462,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_BASELINE_OS_INF_EID informational event message will be
  *         generated when the command is received, or
  *       - The #CS_NO_BASELINE_OS_INF_EID informational event message will be
@@ -473,7 +473,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -494,7 +494,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_RECOMPUTE_OS_STARTED_DBG_EID debug event message will be
  *         generated when the command is received
  *
@@ -507,7 +507,7 @@
  *       - The child task failed to be created by Executive Services (ES)
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_OS_CREATE_CHDTASK_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_OS_CHDTASK_ERR_EID
@@ -535,7 +535,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_ENABLE_EEPROM_INF_EID informational event message will be
  *         generated when the command is received
  *       - #CS_HkPacket_Payload_t.EepromCSState set to #CS_STATE_ENABLED
@@ -545,7 +545,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -567,7 +567,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_DISABLE_EEPROM_INF_EID informational event message will be
  *         generated when the command is received
  *       - #CS_HkPacket_Payload_t.EepromCSState set to #CS_STATE_DISABLED
@@ -577,7 +577,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -600,7 +600,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_BASELINE_EEPROM_INF_EID informational event message will be
  *         generated when the command is received, or
  *       - The #CS_NO_BASELINE_EEPROM_INF_EID informational event message will be
@@ -612,7 +612,7 @@
  *       - The command specified Entry ID is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_BASELINE_INVALID_ENTRY_EEPROM_ERR_EID
  *
@@ -636,7 +636,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_RECOMPUTE_EEPROM_STARTED_DBG_EID debug event
  *         message will be generated when the command is received
  *       - The #CS_RECOMPUTE_FINISH_EEPROM_MEMORY_INF_EID informational event
@@ -652,7 +652,7 @@
  *       - The child task failed to be created by Executive Services (ES)
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_INVALID_ENTRY_EEPROM_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_EEPROM_CREATE_CHDTASK_ERR_EID
@@ -682,7 +682,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_ENABLE_EEPROM_ENTRY_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -692,7 +692,7 @@
  *       - Command specified entry was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_ENABLE_EEPROM_INVALID_ENTRY_ERR_EID
  *
@@ -715,7 +715,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_DISABLE_EEPROM_ENTRY_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -725,7 +725,7 @@
  *       - Command specified entry was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_DISABLE_EEPROM_INVALID_ENTRY_ERR_EID
  *
@@ -749,7 +749,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_GET_ENTRY_ID_EEPROM_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -759,7 +759,7 @@
  *       - Command specified address was not found in the table
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_GET_ENTRY_ID_EEPROM_NOT_FOUND_INF_EID
  *
@@ -780,7 +780,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_ENABLE_MEMORY_INF_EID informational event message will be
  *         generated when the command is received
  *       - #CS_HkPacket_Payload_t.MemoryCSState set to #CS_STATE_ENABLED
@@ -790,7 +790,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -812,7 +812,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_DISABLE_MEMORY_INF_EID informational event message will be
  *         generated when the command is received
  *       - #CS_HkPacket_Payload_t.MemoryCSState set to #CS_STATE_DISABLED
@@ -822,7 +822,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -845,7 +845,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_BASELINE_MEMORY_INF_EID informational event message will be
  *         generated when the command is received, or
  *       - The #CS_NO_BASELINE_MEMORY_INF_EID informational event message will be
@@ -857,7 +857,7 @@
  *       - The command specified Entry ID is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_BASELINE_INVALID_ENTRY_MEMORY_ERR_EID
  *
@@ -880,7 +880,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_RECOMPUTE_MEMORY_STARTED_DBG_EID debug event
  *         message will be generated when the command is received
  *       - The #CS_RECOMPUTE_FINISH_EEPROM_MEMORY_INF_EID informational event
@@ -896,7 +896,7 @@
  *       - The child task failed to be created by Executive Services (ES)
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_INVALID_ENTRY_MEMORY_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_MEMORY_CREATE_CHDTASK_ERR_EID
@@ -926,7 +926,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_ENABLE_MEMORY_ENTRY_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -936,7 +936,7 @@
  *       - Command specified entry was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_ENABLE_MEMORY_INVALID_ENTRY_ERR_EID
  *
@@ -959,7 +959,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_DISABLE_MEMORY_ENTRY_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -969,7 +969,7 @@
  *       - Command specified entry was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_DISABLE_MEMORY_INVALID_ENTRY_ERR_EID
  *
@@ -993,7 +993,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_GET_ENTRY_ID_MEMORY_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -1003,7 +1003,7 @@
  *       - Command specified address was not found in the table
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_GET_ENTRY_ID_MEMORY_NOT_FOUND_INF_EID
  *
@@ -1025,7 +1025,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_ENABLE_TABLES_INF_EID informational event message will be
  *         generated when the command is received
  *       - #CS_HkPacket_Payload_t.TablesCSState set to #CS_STATE_ENABLED
@@ -1035,7 +1035,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -1057,7 +1057,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_DISABLE_TABLES_INF_EID informational event message will be
  *         generated when the command is received
  *       - #CS_HkPacket_Payload_t.TablesCSState set to #CS_STATE_DISABLED
@@ -1067,7 +1067,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -1090,7 +1090,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_BASELINE_TABLES_INF_EID informational event message will be
  *         generated when the command is received, or
  *       - The #CS_NO_BASELINE_TABLES_INF_EID informational event message will be
@@ -1102,7 +1102,7 @@
  *       - The command specified able name is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_BASELINE_INVALID_NAME_TABLES_ERR_EID
  *
@@ -1125,7 +1125,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_RECOMPUTE_TABLES_STARTED_DBG_EID debug event
  *         message will be generated when the command is received
  *       - The #CS_RECOMPUTE_FINISH_TABLES_INF_EID informational event
@@ -1147,7 +1147,7 @@
  *       - The child task failed to be created by Executive Services (ES)
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_UNKNOWN_NAME_TABLES_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_TABLES_CREATE_CHDTASK_ERR_EID
@@ -1177,7 +1177,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_ENABLE_TABLES_NAME_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -1187,7 +1187,7 @@
  *       - Command specified table name was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_ENABLE_TABLES_UNKNOWN_NAME_ERR_EID
  *
@@ -1210,7 +1210,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_DISABLE_TABLES_NAME_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -1220,7 +1220,7 @@
  *       - Command specified table name was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_DISABLE_TABLES_NAME_INF_EID
  *       - Error specific event message #CS_DISABLE_TABLES_UNKNOWN_NAME_ERR_EID
  *
@@ -1243,7 +1243,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_ENABLE_APP_INF_EID informational event message will be
  *         generated when the command is received
  *       - #CS_HkPacket_Payload_t.AppCSState set to #CS_STATE_ENABLED
@@ -1253,7 +1253,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -1275,7 +1275,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_DISABLE_APP_INF_EID informational event message will be
  *         generated when the command is received
  *       - #CS_HkPacket_Payload_t.AppCSState set to #CS_STATE_DISABLED
@@ -1285,7 +1285,7 @@
  *       - Command packet length not as expected
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *
  *  \par Criticality
@@ -1308,7 +1308,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_BASELINE_APP_INF_EID informational event message will be
  *         generated when the command is received, or
  *       - The #CS_NO_BASELINE_APP_INF_EID informational event message will be
@@ -1320,7 +1320,7 @@
  *       - The command specified able name is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_BASELINE_INVALID_NAME_APP_ERR_EID
  *
@@ -1343,7 +1343,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_RECOMPUTE_APP_STARTED_DBG_EID debug event
  *         message will be generated when the command is received
  *       - The #CS_RECOMPUTE_FINISH_APP_INF_EID informational event
@@ -1359,7 +1359,7 @@
  *       - The child task failed to be created by Executive Services (ES)
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_UNKNOWN_NAME_APP_ERR_EID
  *       - Error specific event message #CS_RECOMPUTE_APP_CREATE_CHDTASK_ERR_EID
@@ -1389,7 +1389,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_ENABLE_APP_NAME_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -1399,7 +1399,7 @@
  *       - Command specified app name was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_ENABLE_APP_UNKNOWN_NAME_ERR_EID
  *
@@ -1422,7 +1422,7 @@
  *  \par Command Verification
  *       Successful execution of this command may be verified with
  *       the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandCounter will increment
  *       - The #CS_DISABLE_APP_NAME_INF_EID informational event message will be
  *         generated when the command is received
  *
@@ -1432,7 +1432,7 @@
  *       - Command specified app name was invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
- *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
+ *       - #CS_HkPacket_Payload_t.CommandErrorCounter will increment
  *       - Error specific event message #CS_DISABLE_APP_NAME_INF_EID
  *       - Error specific event message #CS_DISABLE_APP_UNKNOWN_NAME_ERR_EID
  *

--- a/fsw/src/cs_app.c
+++ b/fsw/src/cs_app.c
@@ -88,7 +88,7 @@ void CS_AppMain(void)
         /* Performance Log (start time counter)  */
         CFE_ES_PerfLogEntry(CS_APPMAIN_PERF_ID);
 
-        if ((Result == CFE_SUCCESS) && (BufPtr != NULL))
+        if (Result == CFE_SUCCESS)
         {
             /* Process Software Bus message */
             Result = CS_AppPipe(BufPtr);
@@ -116,7 +116,7 @@ void CS_AppMain(void)
     } /* end run loop */
 
     /* Check for "fatal" process error */
-    if (CS_AppData.RunStatus == CFE_ES_RunStatus_APP_ERROR || CS_AppData.RunStatus == CFE_ES_RunStatus_SYS_EXCEPTION)
+    if (CS_AppData.RunStatus == CFE_ES_RunStatus_APP_ERROR)
     {
         /* Send an error event with run status and result */
         CFE_EVS_SendEvent(CS_EXIT_ERR_EID, CFE_EVS_EventType_ERROR, "App terminating, RunStatus:0x%08X, RC:0x%08X",
@@ -249,7 +249,7 @@ CFE_Status_t CS_AppPipe(const CFE_SB_Buffer_t *BufPtr)
             CFE_EVS_SendEvent(CS_MID_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid command pipe message ID: 0x%08lX",
                               (unsigned long)CFE_SB_MsgIdToValue(MessageID));
 
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             break;
     }
 
@@ -284,7 +284,7 @@ void CS_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
         case CS_RESET_CC:
             if (CS_VerifyCmdLength(&BufPtr->Msg, sizeof(CS_NoArgsCmd_t)))
             {
-                CS_ResetCmd((CS_NoArgsCmd_t *)BufPtr);
+                CS_ResetCountersCmd((CS_NoArgsCmd_t *)BufPtr);
             }
             break;
 
@@ -565,7 +565,7 @@ void CS_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
                               "Invalid ground command code: ID = 0x%08lX, CC = %d",
                               (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode);
 
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             break;
     } /* end switch */
 }

--- a/fsw/src/cs_app_cmds.c
+++ b/fsw/src/cs_app_cmds.c
@@ -56,7 +56,7 @@ void CS_DisableAppCmd(const CS_NoArgsCmd_t *CmdPtr)
 #endif
 
             CFE_EVS_SendEvent(CS_DISABLE_APP_INF_EID, CFE_EVS_EventType_INFORMATION, "Checksumming of App is Disabled");
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CommandCounter++;
         }
 }
 
@@ -76,7 +76,7 @@ void CS_EnableAppCmd(const CS_NoArgsCmd_t *CmdPtr)
 #endif
 
             CFE_EVS_SendEvent(CS_ENABLE_APP_INF_EID, CFE_EVS_EventType_INFORMATION, "Checksumming of App is Enabled");
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CommandCounter++;
         }
 }
 
@@ -108,13 +108,13 @@ void CS_ReportBaselineAppCmd(const CS_AppNameCmd_t *CmdPtr)
                 CFE_EVS_SendEvent(CS_NO_BASELINE_APP_INF_EID, CFE_EVS_EventType_INFORMATION,
                                   "Report baseline of app %s has not been computed yet", Name);
             }
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CommandCounter++;
         }
         else
         {
             CFE_EVS_SendEvent(CS_BASELINE_INVALID_NAME_APP_ERR_EID, CFE_EVS_EventType_ERROR,
                               "App report baseline failed, app %s not found", Name);
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CommandErrorCounter++;
         }
 }
 
@@ -153,14 +153,14 @@ void CS_RecomputeBaselineAppCmd(const CS_AppNameCmd_t *CmdPtr)
                 {
                     CFE_EVS_SendEvent(CS_RECOMPUTE_APP_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
                                       "Recompute baseline of app %s started", Name);
-                    CS_AppData.HkPacket.Payload.CmdCounter++;
+                    CS_AppData.HkPacket.Payload.CommandCounter++;
                 }
                 else /* child task creation failed */
                 {
                     CFE_EVS_SendEvent(CS_RECOMPUTE_APP_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "Recompute baseline of app %s failed, CFE_ES_CreateChildTask returned: 0x%08X",
                                       Name, (unsigned int)Status);
-                    CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                    CS_AppData.HkPacket.Payload.CommandErrorCounter++;
                     CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
                 }
             }
@@ -168,7 +168,7 @@ void CS_RecomputeBaselineAppCmd(const CS_AppNameCmd_t *CmdPtr)
             {
                 CFE_EVS_SendEvent(CS_RECOMPUTE_UNKNOWN_NAME_APP_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "App recompute baseline failed, app %s not found", Name);
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             }
         }
         else
@@ -176,7 +176,7 @@ void CS_RecomputeBaselineAppCmd(const CS_AppNameCmd_t *CmdPtr)
             /*send event that we can't start another task right now */
             CFE_EVS_SendEvent(CS_RECOMPUTE_APP_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                               "App recompute baseline for app %s failed: child task in use", Name);
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CommandErrorCounter++;
         }
 }
 
@@ -218,14 +218,14 @@ void CS_DisableNameAppCmd(const CS_AppNameCmd_t *CmdPtr)
                                       "CS unable to update apps definition table for entry %s", Name);
                 }
 
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                CS_AppData.HkPacket.Payload.CommandCounter++;
             }
 
             else
             {
                 CFE_EVS_SendEvent(CS_DISABLE_APP_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "App disable app command failed, app %s not found", Name);
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             }
         } /* end InProgress if */
 }
@@ -266,13 +266,13 @@ void CS_EnableNameAppCmd(const CS_AppNameCmd_t *CmdPtr)
                                       "CS unable to update apps definition table for entry %s", Name);
                 }
 
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                CS_AppData.HkPacket.Payload.CommandCounter++;
             }
             else
             {
                 CFE_EVS_SendEvent(CS_ENABLE_APP_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "App enable app command failed, app %s not found", Name);
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             }
         } /* end InProgress if */
 }

--- a/fsw/src/cs_cmds.c
+++ b/fsw/src/cs_cmds.c
@@ -48,7 +48,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_NoopCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-    CS_AppData.HkPacket.Payload.CmdCounter++;
+    CS_AppData.HkPacket.Payload.CommandCounter++;
 
     CFE_EVS_SendEvent(CS_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op command. Version %d.%d.%d.%d",
                       CS_MAJOR_VERSION, CS_MINOR_VERSION, CS_REVISION, CS_MISSION_REV);
@@ -59,10 +59,10 @@ void CS_NoopCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* CS Reset Application counters command                           */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void CS_ResetCmd(const CS_NoArgsCmd_t *CmdPtr)
+void CS_ResetCountersCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-    CS_AppData.HkPacket.Payload.CmdCounter    = 0;
-    CS_AppData.HkPacket.Payload.CmdErrCounter = 0;
+    CS_AppData.HkPacket.Payload.CommandCounter      = 0;
+    CS_AppData.HkPacket.Payload.CommandErrorCounter = 0;
 
     CS_AppData.HkPacket.Payload.EepromCSErrCounter  = 0;
     CS_AppData.HkPacket.Payload.MemoryCSErrCounter  = 0;
@@ -203,7 +203,7 @@ void CS_DisableAllCSCmd(const CS_NoArgsCmd_t *CmdPtr)
     CS_ZeroCfeCoreTempValues();
     CS_ZeroOSTempValues();
 
-    CS_AppData.HkPacket.Payload.CmdCounter++;
+    CS_AppData.HkPacket.Payload.CommandCounter++;
 
     CFE_EVS_SendEvent(CS_DISABLE_ALL_INF_EID, CFE_EVS_EventType_INFORMATION, "Background Checksumming Disabled");
 }
@@ -217,7 +217,7 @@ void CS_EnableAllCSCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
     CS_AppData.HkPacket.Payload.ChecksumState = CS_STATE_ENABLED;
 
-    CS_AppData.HkPacket.Payload.CmdCounter++;
+    CS_AppData.HkPacket.Payload.CommandCounter++;
 
     CFE_EVS_SendEvent(CS_ENABLE_ALL_INF_EID, CFE_EVS_EventType_INFORMATION, "Background Checksumming Enabled");
 }
@@ -239,7 +239,7 @@ void CS_DisableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
     CFE_EVS_SendEvent(CS_DISABLE_CFECORE_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "Checksumming of cFE Core is Disabled");
 
-    CS_AppData.HkPacket.Payload.CmdCounter++;
+    CS_AppData.HkPacket.Payload.CommandCounter++;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -257,7 +257,7 @@ void CS_EnableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
 
     CFE_EVS_SendEvent(CS_ENABLE_CFECORE_INF_EID, CFE_EVS_EventType_INFORMATION, "Checksumming of cFE Core is Enabled");
 
-    CS_AppData.HkPacket.Payload.CmdCounter++;
+    CS_AppData.HkPacket.Payload.CommandCounter++;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -277,7 +277,7 @@ void CS_DisableOSCmd(const CS_NoArgsCmd_t *CmdPtr)
     CFE_EVS_SendEvent(CS_DISABLE_OS_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "Checksumming of OS code segment is Disabled");
 
-    CS_AppData.HkPacket.Payload.CmdCounter++;
+    CS_AppData.HkPacket.Payload.CommandCounter++;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -296,7 +296,7 @@ void CS_EnableOSCmd(const CS_NoArgsCmd_t *CmdPtr)
     CFE_EVS_SendEvent(CS_ENABLE_OS_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "Checksumming of OS code segment is Enabled");
 
-    CS_AppData.HkPacket.Payload.CmdCounter++;
+    CS_AppData.HkPacket.Payload.CommandCounter++;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -316,7 +316,7 @@ void CS_ReportBaselineCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
         CFE_EVS_SendEvent(CS_NO_BASELINE_CFECORE_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Baseline of cFE Core has not been computed yet");
     }
-    CS_AppData.HkPacket.Payload.CmdCounter++;
+    CS_AppData.HkPacket.Payload.CommandCounter++;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -336,7 +336,7 @@ void CS_ReportBaselineOSCmd(const CS_NoArgsCmd_t *CmdPtr)
         CFE_EVS_SendEvent(CS_NO_BASELINE_OS_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Baseline of OS code segment has not been computed yet");
     }
-    CS_AppData.HkPacket.Payload.CmdCounter++;
+    CS_AppData.HkPacket.Payload.CommandCounter++;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -368,14 +368,14 @@ void CS_RecomputeBaselineCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
         {
             CFE_EVS_SendEvent(CS_RECOMPUTE_CFECORE_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
                               "Recompute of cFE core started");
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CommandCounter++;
         }
         else /* child task creation failed */
         {
             CFE_EVS_SendEvent(CS_RECOMPUTE_CFECORE_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Recompute cFE core failed, CFE_ES_CreateChildTask returned: 0x%08X",
                               (unsigned int)Status);
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
         }
     }
@@ -384,7 +384,7 @@ void CS_RecomputeBaselineCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
         /*send event that we can't start another task right now */
         CFE_EVS_SendEvent(CS_RECOMPUTE_CFECORE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Recompute cFE core failed: child task in use");
-        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        CS_AppData.HkPacket.Payload.CommandErrorCounter++;
     }
 }
 
@@ -416,14 +416,14 @@ void CS_RecomputeBaselineOSCmd(const CS_NoArgsCmd_t *CmdPtr)
         {
             CFE_EVS_SendEvent(CS_RECOMPUTE_OS_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
                               "Recompute of OS code segment started");
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CommandCounter++;
         }
         else /* child task creation failed */
         {
             CFE_EVS_SendEvent(CS_RECOMPUTE_OS_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Recompute OS code segment failed, CFE_ES_CreateChildTask returned: 0x%08X",
                               (unsigned int)Status);
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
         }
     }
@@ -432,7 +432,7 @@ void CS_RecomputeBaselineOSCmd(const CS_NoArgsCmd_t *CmdPtr)
         /*send event that we can't start another task right now */
         CFE_EVS_SendEvent(CS_RECOMPUTE_OS_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Recompute OS code segment failed: child task in use");
-        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        CS_AppData.HkPacket.Payload.CommandErrorCounter++;
     }
 }
 
@@ -481,7 +481,7 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
                                   (unsigned int)(CmdPtr->Payload.Address), (int)(CmdPtr->Payload.Size));
 
                 CS_AppData.ChildTaskID = ChildTaskID;
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                CS_AppData.HkPacket.Payload.CommandCounter++;
             }
             else /* child task creation failed */
             {
@@ -489,7 +489,7 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
                                   "OneShot checkum failed, CFE_ES_CreateChildTask returned: 0x%08X",
                                   (unsigned int)Status);
 
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CommandErrorCounter++;
                 CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
                 CS_AppData.HkPacket.Payload.OneShotInProgress   = false;
             }
@@ -500,7 +500,7 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_ONESHOT_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                               "OneShot checksum failed: child task in use");
 
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CommandErrorCounter++;
         }
     } /* end if CFE_PSP_MemValidateRange */
     else
@@ -508,7 +508,7 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
         CFE_EVS_SendEvent(CS_ONESHOT_MEMVALIDATE_ERR_EID, CFE_EVS_EventType_ERROR,
                           "OneShot checksum failed, CFE_PSP_MemValidateRange returned: 0x%08X", (unsigned int)Status);
 
-        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        CS_AppData.HkPacket.Payload.CommandErrorCounter++;
     }
 }
 
@@ -533,7 +533,7 @@ void CS_CancelOneShotCmd(const CS_NoArgsCmd_t *CmdPtr)
             CS_AppData.ChildTaskID                          = CFE_ES_TASKID_UNDEFINED;
             CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
             CS_AppData.HkPacket.Payload.OneShotInProgress   = false;
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CommandCounter++;
             CFE_EVS_SendEvent(CS_ONESHOT_CANCELLED_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "OneShot checksum calculation has been cancelled");
         }
@@ -542,13 +542,13 @@ void CS_CancelOneShotCmd(const CS_NoArgsCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_ONESHOT_CANCEL_DELETE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Cancel OneShot checksum failed, CFE_ES_DeleteChildTask returned:  0x%08X",
                               (unsigned int)Status);
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CommandErrorCounter++;
         }
     }
     else
     {
         CFE_EVS_SendEvent(CS_ONESHOT_CANCEL_NO_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Cancel OneShot checksum failed. No OneShot active");
-        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        CS_AppData.HkPacket.Payload.CommandErrorCounter++;
     }
 }

--- a/fsw/src/cs_cmds.h
+++ b/fsw/src/cs_cmds.h
@@ -63,7 +63,7 @@ void CS_NoopCmd(const CS_NoArgsCmd_t *CmdPtr);
  *
  *  \sa #CS_RESET_CC
  */
-void CS_ResetCmd(const CS_NoArgsCmd_t *CmdPtr);
+void CS_ResetCountersCmd(const CS_NoArgsCmd_t *CmdPtr);
 
 /**
  * \brief process a background checking cycle

--- a/fsw/src/cs_eeprom_cmds.c
+++ b/fsw/src/cs_eeprom_cmds.c
@@ -60,7 +60,7 @@ void CS_DisableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_DISABLE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Checksumming of EEPROM is Disabled");
 
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CommandCounter++;
         }
 }
 
@@ -82,7 +82,7 @@ void CS_EnableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_ENABLE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Checksumming of EEPROM is Enabled");
 
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CommandCounter++;
         }
 }
 
@@ -118,7 +118,7 @@ void CS_ReportBaselineEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 CFE_EVS_SendEvent(CS_NO_BASELINE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
                                   "Report baseline of EEPROM Entry %d has not been computed yet", EntryID);
             }
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CommandCounter++;
         }
         else
         {
@@ -134,7 +134,7 @@ void CS_ReportBaselineEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_BASELINE_INVALID_ENTRY_EEPROM_ERR_EID, CFE_EVS_EventType_ERROR,
                               "EEPROM report baseline failed, Entry ID invalid: %d, State: %d Max ID: %d", EntryID,
                               State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CommandErrorCounter++;
         }
 }
 
@@ -175,7 +175,7 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 {
                     CFE_EVS_SendEvent(CS_RECOMPUTE_EEPROM_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
                                       "Recompute baseline of EEPROM Entry ID %d started", EntryID);
-                    CS_AppData.HkPacket.Payload.CmdCounter++;
+                    CS_AppData.HkPacket.Payload.CommandCounter++;
                 }
                 else /* child task creation failed */
                 {
@@ -183,7 +183,7 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
                         CS_RECOMPUTE_EEPROM_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                         "Recompute baseline of EEPROM Entry ID %d failed, CFE_ES_CreateChildTask returned:  0x%08X",
                         EntryID, (unsigned int)Status);
-                    CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                    CS_AppData.HkPacket.Payload.CommandErrorCounter++;
                     CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
                 }
             }
@@ -203,7 +203,7 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
                     "EEPROM recompute baseline of entry failed, Entry ID invalid: %d, State: %d, Max ID: %d", EntryID,
                     State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
 
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             }
         }
         else
@@ -211,7 +211,7 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
             /*send event that we can't start another task right now */
             CFE_EVS_SendEvent(CS_RECOMPUTE_EEPROM_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Recompute baseline of EEPROM Entry ID %d failed: child task in use", EntryID);
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CommandErrorCounter++;
         }
 }
 
@@ -254,7 +254,7 @@ void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                                       State);
                 }
 
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                CS_AppData.HkPacket.Payload.CommandCounter++;
             }
             else
             {
@@ -270,7 +270,7 @@ void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                 CFE_EVS_SendEvent(CS_ENABLE_EEPROM_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Enable EEPROM entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
                                   State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             }
         } /* end InProgress if */
 }
@@ -316,7 +316,7 @@ void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                                       State);
                 }
 
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                CS_AppData.HkPacket.Payload.CommandCounter++;
             }
             else
             {
@@ -333,7 +333,7 @@ void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
                                   "Disable EEPROM entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
                                   State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
 
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             }
         } /* end InProgress if */
 }
@@ -372,5 +372,5 @@ void CS_GetEntryIDEepromCmd(const CS_GetEntryIDCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_GET_ENTRY_ID_EEPROM_NOT_FOUND_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Address 0x%08X was not found in EEPROM table", (unsigned int)(CmdPtr->Payload.Address));
         }
-        CS_AppData.HkPacket.Payload.CmdCounter++;
+        CS_AppData.HkPacket.Payload.CommandCounter++;
 }

--- a/fsw/src/cs_memory_cmds.c
+++ b/fsw/src/cs_memory_cmds.c
@@ -60,7 +60,7 @@ void CS_DisableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_DISABLE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Checksumming of Memory is Disabled");
 
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CommandCounter++;
         }
 }
 
@@ -82,7 +82,7 @@ void CS_EnableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_ENABLE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Checksumming of Memory is Enabled");
 
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CommandCounter++;
         }
 }
 
@@ -118,7 +118,7 @@ void CS_ReportBaselineEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                 CFE_EVS_SendEvent(CS_NO_BASELINE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
                                   "Report baseline of Memory Entry %d has not been computed yet", EntryID);
             }
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CommandCounter++;
         }
         else
         {
@@ -134,7 +134,7 @@ void CS_ReportBaselineEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_BASELINE_INVALID_ENTRY_MEMORY_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Memory report baseline failed, Entry ID invalid: %d, State: %d Max ID: %d", EntryID,
                               State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CommandErrorCounter++;
         }
 }
 
@@ -175,7 +175,7 @@ void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                 {
                     CFE_EVS_SendEvent(CS_RECOMPUTE_MEMORY_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
                                       "Recompute baseline of Memory Entry ID %d started", EntryID);
-                    CS_AppData.HkPacket.Payload.CmdCounter++;
+                    CS_AppData.HkPacket.Payload.CommandCounter++;
                 }
                 else /* child task creation failed */
                 {
@@ -183,7 +183,7 @@ void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                         CS_RECOMPUTE_MEMORY_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                         "Recompute baseline of Memory Entry ID %d failed, ES_CreateChildTask returned:  0x%08X",
                         EntryID, (unsigned int)Status);
-                    CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                    CS_AppData.HkPacket.Payload.CommandErrorCounter++;
                     CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
                 }
             }
@@ -203,7 +203,7 @@ void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                     "Memory recompute baseline of entry failed, Entry ID invalid: %d, State: %d, Max ID: %d", EntryID,
                     State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
 
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             }
         }
         else
@@ -211,7 +211,7 @@ void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
             /*send event that we can't start another task right now */
             CFE_EVS_SendEvent(CS_RECOMPUTE_MEMORY_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Recompute baseline of Memory Entry ID %d failed: child task in use", EntryID);
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CommandErrorCounter++;
         }
 }
 
@@ -254,7 +254,7 @@ void CS_EnableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                                       State);
                 }
 
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                CS_AppData.HkPacket.Payload.CommandCounter++;
             }
             else
             {
@@ -270,7 +270,7 @@ void CS_EnableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                 CFE_EVS_SendEvent(CS_ENABLE_MEMORY_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Enable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
                                   State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             }
         } /* end InProgress if */
 }
@@ -316,7 +316,7 @@ void CS_DisableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                                       State);
                 }
 
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                CS_AppData.HkPacket.Payload.CommandCounter++;
             }
             else
             {
@@ -333,7 +333,7 @@ void CS_DisableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                                   "Disable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
                                   State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
 
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             }
         } /* end InProgress if */
 }
@@ -372,5 +372,5 @@ void CS_GetEntryIDMemoryCmd(const CS_GetEntryIDCmd_t *CmdPtr)
             CFE_EVS_SendEvent(CS_GET_ENTRY_ID_MEMORY_NOT_FOUND_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Address 0x%08X was not found in Memory table", (unsigned int)(CmdPtr->Payload.Address));
         }
-        CS_AppData.HkPacket.Payload.CmdCounter++;
+        CS_AppData.HkPacket.Payload.CommandCounter++;
 }

--- a/fsw/src/cs_table_cmds.c
+++ b/fsw/src/cs_table_cmds.c
@@ -57,7 +57,7 @@ void CS_DisableTablesCmd(const CS_NoArgsCmd_t *CmdPtr)
 
             CFE_EVS_SendEvent(CS_DISABLE_TABLES_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Checksumming of Tables is Disabled");
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CommandCounter++;
         }
 }
 
@@ -78,7 +78,7 @@ void CS_EnableTablesCmd(const CS_NoArgsCmd_t *CmdPtr)
 
             CFE_EVS_SendEvent(CS_ENABLE_TABLES_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Checksumming of Tables is Enabled");
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CommandCounter++;
         }
 }
 
@@ -109,13 +109,13 @@ void CS_ReportBaselineTablesCmd(const CS_TableNameCmd_t *CmdPtr)
                 CFE_EVS_SendEvent(CS_NO_BASELINE_TABLES_INF_EID, CFE_EVS_EventType_INFORMATION,
                                   "Report baseline of table %s has not been computed yet", Name);
             }
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CS_AppData.HkPacket.Payload.CommandCounter++;
         }
         else
         {
             CFE_EVS_SendEvent(CS_BASELINE_INVALID_NAME_TABLES_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Tables report baseline failed, table %s not found", Name);
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CommandErrorCounter++;
         }
 }
 
@@ -153,14 +153,14 @@ void CS_RecomputeBaselineTablesCmd(const CS_TableNameCmd_t *CmdPtr)
                 {
                     CFE_EVS_SendEvent(CS_RECOMPUTE_TABLES_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
                                       "Recompute baseline of table %s started", Name);
-                    CS_AppData.HkPacket.Payload.CmdCounter++;
+                    CS_AppData.HkPacket.Payload.CommandCounter++;
                 }
                 else /* child task creation failed */
                 {
                     CFE_EVS_SendEvent(CS_RECOMPUTE_TABLES_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "Recompute baseline of table %s failed, CFE_ES_CreateChildTask returned: 0x%08X",
                                       Name, (unsigned int)Status);
-                    CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                    CS_AppData.HkPacket.Payload.CommandErrorCounter++;
                     CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
                 }
             }
@@ -168,7 +168,7 @@ void CS_RecomputeBaselineTablesCmd(const CS_TableNameCmd_t *CmdPtr)
             {
                 CFE_EVS_SendEvent(CS_RECOMPUTE_UNKNOWN_NAME_TABLES_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Tables recompute baseline failed, table %s not found", Name);
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             }
         }
         else
@@ -176,7 +176,7 @@ void CS_RecomputeBaselineTablesCmd(const CS_TableNameCmd_t *CmdPtr)
             /*send event that we can't start another task right now */
             CFE_EVS_SendEvent(CS_RECOMPUTE_TABLES_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Tables recompute baseline for table %s failed: child task in use", Name);
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CS_AppData.HkPacket.Payload.CommandErrorCounter++;
         }
 }
 
@@ -217,13 +217,13 @@ void CS_DisableNameTablesCmd(const CS_TableNameCmd_t *CmdPtr)
                                       "CS unable to update tables definition table for entry %s", Name);
                 }
 
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                CS_AppData.HkPacket.Payload.CommandCounter++;
             }
             else
             {
                 CFE_EVS_SendEvent(CS_DISABLE_TABLES_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Tables disable table command failed, table %s not found", Name);
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             }
         } /* end InProgress if */
 }
@@ -263,13 +263,13 @@ void CS_EnableNameTablesCmd(const CS_TableNameCmd_t *CmdPtr)
                                       "CS unable to update tables definition table for entry %s", Name);
                 }
 
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                CS_AppData.HkPacket.Payload.CommandCounter++;
             }
             else
             {
                 CFE_EVS_SendEvent(CS_ENABLE_TABLES_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Tables enable table command failed, table %s not found", Name);
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.CommandErrorCounter++;
             }
         } /* end InProgress if */
 }

--- a/fsw/src/cs_utils.c
+++ b/fsw/src/cs_utils.c
@@ -464,7 +464,7 @@ bool CS_VerifyCmdLength(const CFE_MSG_Message_t *msg, size_t ExpectedLength)
                           (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode, (unsigned long)ActualLength,
                           (unsigned long)ExpectedLength);
         Result = false;
-        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        CS_AppData.HkPacket.Payload.CommandErrorCounter++;
     }
     return Result;
 }
@@ -1038,7 +1038,7 @@ bool CS_CheckRecomputeOneshot(void)
         CFE_EVS_SendEvent(CS_CMD_COMPUTE_PROG_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Cannot perform command. Recompute or oneshot in progress.");
 
-        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        CS_AppData.HkPacket.Payload.CommandErrorCounter++;
 
         Result = true;
     }

--- a/unit-test/cs_app_cmds_tests.c
+++ b/unit-test/cs_app_cmds_tests.c
@@ -98,7 +98,7 @@ void CS_DisableAppCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -118,7 +118,7 @@ void CS_DisableAppCmd_Test_OneShot(void)
     CS_DisableAppCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -150,9 +150,9 @@ void CS_EnableAppCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -172,7 +172,7 @@ void CS_EnableAppCmd_Test_OneShot(void)
     CS_EnableAppCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -212,7 +212,7 @@ void CS_ReportBaselineAppCmd_Test_Baseline(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -252,9 +252,9 @@ void CS_ReportBaselineAppCmd_Test_NoBaseline(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -290,7 +290,7 @@ void CS_ReportBaselineAppCmd_Test_BaselineInvalidName(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -329,7 +329,7 @@ void CS_ReportBaselineAppCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -375,9 +375,9 @@ void CS_RecomputeBaselineAppCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -424,7 +424,7 @@ void CS_RecomputeBaselineAppCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -463,7 +463,7 @@ void CS_RecomputeBaselineAppCmd_Test_UnknownNameError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -501,7 +501,7 @@ void CS_RecomputeBaselineAppCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -547,9 +547,9 @@ void CS_DisableNameAppCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -603,9 +603,9 @@ void CS_DisableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -643,7 +643,7 @@ void CS_DisableNameAppCmd_Test_UnknownNameError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -663,7 +663,7 @@ void CS_DisableNameAppCmd_Test_OneShot(void)
     CS_DisableNameAppCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -709,9 +709,9 @@ void CS_EnableNameAppCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -765,9 +765,9 @@ void CS_EnableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -799,7 +799,7 @@ void CS_EnableNameAppCmd_Test_UnknownNameError(void)
     CS_EnableNameAppCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ENABLE_APP_UNKNOWN_NAME_ERR_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_ERROR);
@@ -826,7 +826,7 @@ void CS_EnableNameAppCmd_Test_OneShot(void)
     CS_EnableNameAppCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 

--- a/unit-test/cs_cmds_tests.c
+++ b/unit-test/cs_cmds_tests.c
@@ -79,7 +79,7 @@ void CS_NoopCmd_Test(void)
                   call_count_CFE_EVS_SendEvent);
 }
 
-void CS_ResetCmd_Test(void)
+void CS_ResetCountersCmd_Test(void)
 {
     CS_NoArgsCmd_t CmdPacket;
     int32          strCmpResult;
@@ -87,8 +87,8 @@ void CS_ResetCmd_Test(void)
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Reset Counters command recieved");
 
-    CS_AppData.HkPacket.Payload.CmdCounter          = 1;
-    CS_AppData.HkPacket.Payload.CmdErrCounter       = 2;
+    CS_AppData.HkPacket.Payload.CommandCounter      = 1;
+    CS_AppData.HkPacket.Payload.CommandErrorCounter = 2;
     CS_AppData.HkPacket.Payload.EepromCSErrCounter  = 3;
     CS_AppData.HkPacket.Payload.MemoryCSErrCounter  = 4;
     CS_AppData.HkPacket.Payload.TablesCSErrCounter  = 5;
@@ -100,11 +100,12 @@ void CS_ResetCmd_Test(void)
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
     /* Execute the function being tested */
-    CS_ResetCmd(&CmdPacket);
+    CS_ResetCountersCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 0, "CS_AppData.HkPacket.Payload.CmdErrCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 0,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 0");
     UtAssert_True(CS_AppData.HkPacket.Payload.EepromCSErrCounter == 0, "CS_AppData.HkPacket.Payload.EepromCSErrCounter == 0");
     UtAssert_True(CS_AppData.HkPacket.Payload.MemoryCSErrCounter == 0, "CS_AppData.HkPacket.Payload.MemoryCSErrCounter == 0");
     UtAssert_True(CS_AppData.HkPacket.Payload.TablesCSErrCounter == 0, "CS_AppData.HkPacket.Payload.TablesCSErrCounter == 0");
@@ -577,7 +578,7 @@ void CS_DisableAllCSCmd_Test(void)
     /* Verify results */
     UtAssert_True(CS_AppData.HkPacket.Payload.ChecksumState == CS_STATE_DISABLED,
                   "CS_AppData.HkPacket.Payload.ChecksumState == CS_STATE_DISABLED");
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_DISABLE_ALL_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -608,7 +609,7 @@ void CS_EnableAllCSCmd_Test(void)
     /* Verify results */
     UtAssert_True(CS_AppData.HkPacket.Payload.ChecksumState == CS_STATE_ENABLED,
                   "CS_AppData.HkPacket.Payload.ChecksumState == CS_STATE_ENABLED");
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ENABLE_ALL_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -647,7 +648,7 @@ void CS_DisableCfeCoreCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -679,7 +680,7 @@ void CS_EnableCfeCoreCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -711,7 +712,7 @@ void CS_DisableOSCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -743,7 +744,7 @@ void CS_EnableOSCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -775,7 +776,7 @@ void CS_ReportBaselineCfeCoreCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -806,7 +807,7 @@ void CS_ReportBaselineCfeCoreCmd_Test_NotComputedYet(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -838,7 +839,7 @@ void CS_ReportBaselineOSCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -870,7 +871,7 @@ void CS_ReportBaselineOSCmd_Test_NotComputedYet(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -908,7 +909,7 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -949,7 +950,8 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
     UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
@@ -981,7 +983,8 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_ChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1014,7 +1017,8 @@ void CS_RecomputeBaselineCfeCoreCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1052,7 +1056,7 @@ void CS_RecomputeBaselineOSCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1093,7 +1097,8 @@ void CS_RecomputeBaselineOSCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
     UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
@@ -1126,7 +1131,8 @@ void CS_RecomputeBaselineOSCmd_Test_ChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1160,7 +1166,8 @@ void CS_RecomputeBaselineOSCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1209,7 +1216,7 @@ void CS_OneShotCmd_Test_Nominal(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
     UtAssert_BOOL_TRUE(CFE_RESOURCEID_TEST_DEFINED(CS_AppData.ChildTaskID));
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1258,7 +1265,7 @@ void CS_OneShotCmd_Test_MaxBytesPerCycleNonZero(void)
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
     UtAssert_BOOL_TRUE(CFE_RESOURCEID_TEST_DEFINED(CS_AppData.ChildTaskID));
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1301,7 +1308,8 @@ void CS_OneShotCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
     UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
     UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == false, "CS_AppData.HkPacket.Payload.OneShotInProgress == false");
 
@@ -1334,7 +1342,8 @@ void CS_OneShotCmd_Test_ChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1369,7 +1378,8 @@ void CS_OneShotCmd_Test_MemValidateRangeError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1402,7 +1412,8 @@ void CS_OneShotCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1431,7 +1442,7 @@ void CS_CancelOneShotCmd_Test_Nominal(void)
     UtAssert_BOOL_FALSE(CFE_RESOURCEID_TEST_DEFINED(CS_AppData.ChildTaskID));
     UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
     UtAssert_True(CS_AppData.HkPacket.Payload.OneShotInProgress == false, "CS_AppData.HkPacket.Payload.OneShotInProgress == false");
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_ONESHOT_CANCELLED_INF_EID);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventType, CFE_EVS_EventType_INFORMATION);
@@ -1474,7 +1485,8 @@ void CS_CancelOneShotCmd_Test_DeleteChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1510,7 +1522,8 @@ void CS_CancelOneShotCmd_Test_NoChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1546,7 +1559,8 @@ void CS_CancelOneShotCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -1558,7 +1572,7 @@ void UtTest_Setup(void)
 {
     UtTest_Add(CS_NoopCmd_Test, CS_Test_Setup, CS_Test_TearDown, "CS_NoopCmd_Test");
 
-    UtTest_Add(CS_ResetCmd_Test, CS_Test_Setup, CS_Test_TearDown, "CS_ResetCmd_Test");
+    UtTest_Add(CS_ResetCountersCmd_Test, CS_Test_Setup, CS_Test_TearDown, "CS_ResetCountersCmd_Test");
 
     UtTest_Add(CS_BackgroundCheckCycle_Test_InvalidMsgLength, CS_Test_Setup, CS_Test_TearDown,
                "CS_BackgroundCheckCycle_Test_InvalidMsgLength");

--- a/unit-test/cs_eeprom_cmds_tests.c
+++ b/unit-test/cs_eeprom_cmds_tests.c
@@ -67,7 +67,7 @@ void CS_DisableEepromCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -86,7 +86,7 @@ void CS_DisableEepromCmd_Test_OneShot(void)
     CS_DisableEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -118,7 +118,7 @@ void CS_EnableEepromCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -137,7 +137,7 @@ void CS_EnableEepromCmd_Test_OneShot(void)
     CS_EnableEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -172,7 +172,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_Computed(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -208,7 +208,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_NotYetComputed(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -240,7 +240,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -274,7 +274,7 @@ void CS_ReportBaselineEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -316,7 +316,7 @@ void CS_RecomputeBaselineEepromCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -360,7 +360,7 @@ void CS_RecomputeBaselineEepromCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
     UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
@@ -393,7 +393,7 @@ void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -427,7 +427,7 @@ void CS_RecomputeBaselineEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -461,7 +461,7 @@ void CS_RecomputeBaselineEepromCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -496,7 +496,7 @@ void CS_RecomputeBaselineEepromCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -536,7 +536,7 @@ void CS_EnableEntryIDEepromCmd_Test_Nominal(void)
     UtAssert_True(CS_AppData.DefEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED,
                   "CS_AppData.DefEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED");
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -586,7 +586,7 @@ void CS_EnableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -618,7 +618,7 @@ void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -652,7 +652,7 @@ void CS_EnableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -671,7 +671,7 @@ void CS_EnableEntryIDEepromCmd_Test_OneShot(void)
     CS_EnableEntryIDEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -716,7 +716,7 @@ void CS_DisableEntryIDEepromCmd_Test_Nominal(void)
     UtAssert_True(CS_AppData.DefEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED,
                   "CS_AppData.DefEepromTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED");
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -770,7 +770,7 @@ void CS_DisableEntryIDEepromCmd_Test_DefEepromTblPtrStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -802,7 +802,7 @@ void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -836,7 +836,7 @@ void CS_DisableEntryIDEepromCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -855,7 +855,7 @@ void CS_DisableEntryIDEepromCmd_Test_OneShot(void)
     CS_DisableEntryIDEepromCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -891,7 +891,7 @@ void CS_GetEntryIDEepromCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -922,7 +922,7 @@ void CS_GetEntryIDEepromCmd_Test_AddressNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -958,7 +958,7 @@ void CS_GetEntryIDEepromCmd_Test_AddressPtr(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -994,7 +994,7 @@ void CS_GetEntryIDEepromCmd_Test_State(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 

--- a/unit-test/cs_memory_cmds_tests.c
+++ b/unit-test/cs_memory_cmds_tests.c
@@ -67,7 +67,7 @@ void CS_DisableMemoryCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -86,7 +86,7 @@ void CS_DisableMemoryCmd_Test_OneShot(void)
     CS_DisableMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -118,7 +118,7 @@ void CS_EnableMemoryCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -137,7 +137,7 @@ void CS_EnableMemoryCmd_Test_OneShot(void)
     CS_EnableMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -172,7 +172,7 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_Computed(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -208,7 +208,7 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_NotYetComputed(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -240,7 +240,7 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -274,7 +274,7 @@ void CS_ReportBaselineEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -316,7 +316,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -360,7 +360,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
     UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
@@ -393,7 +393,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -427,7 +427,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -461,7 +461,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -496,7 +496,7 @@ void CS_RecomputeBaselineMemoryCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -536,7 +536,7 @@ void CS_EnableEntryIDMemoryCmd_Test_Nominal(void)
     UtAssert_True(CS_AppData.DefMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED,
                   "CS_AppData.DefMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_ENABLED");
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -586,7 +586,7 @@ void CS_EnableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -618,7 +618,7 @@ void CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -652,7 +652,7 @@ void CS_EnableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -671,7 +671,7 @@ void CS_EnableEntryIDMemoryCmd_Test_OneShot(void)
     CS_EnableEntryIDMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -716,7 +716,7 @@ void CS_DisableEntryIDMemoryCmd_Test_Nominal(void)
     UtAssert_True(CS_AppData.DefMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED,
                   "CS_AppData.DefMemoryTblPtr[CmdPacket.Payload.EntryID].State == CS_STATE_DISABLED");
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -770,7 +770,7 @@ void CS_DisableEntryIDMemoryCmd_Test_DefMemoryTblPtrStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -802,7 +802,7 @@ void CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorEntryIDTooHigh(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -836,7 +836,7 @@ void CS_DisableEntryIDMemoryCmd_Test_InvalidEntryErrorStateEmpty(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1, "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -855,7 +855,7 @@ void CS_DisableEntryIDMemoryCmd_Test_OneShot(void)
     CS_DisableEntryIDMemoryCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -891,7 +891,7 @@ void CS_GetEntryIDMemoryCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -922,7 +922,7 @@ void CS_GetEntryIDMemoryCmd_Test_AddressNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -958,7 +958,7 @@ void CS_GetEntryIDMemoryCmd_Test_AddressPtr(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -994,7 +994,7 @@ void CS_GetEntryIDMemoryCmd_Test_State(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 

--- a/unit-test/cs_table_cmds_tests.c
+++ b/unit-test/cs_table_cmds_tests.c
@@ -101,7 +101,7 @@ void CS_DisableTablesCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -120,7 +120,7 @@ void CS_DisableTablesCmd_Test_OneShot(void)
     CS_DisableTablesCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -153,7 +153,7 @@ void CS_EnableTablesCmd_Test(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -172,7 +172,7 @@ void CS_EnableTablesCmd_Test_OneShot(void)
     CS_EnableTablesCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -213,7 +213,7 @@ void CS_ReportBaselineTablesCmd_Test_Computed(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -254,7 +254,7 @@ void CS_ReportBaselineTablesCmd_Test_NotYetComputed(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -289,7 +289,8 @@ void CS_ReportBaselineTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -332,7 +333,7 @@ void CS_RecomputeBaselineTablesCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -378,7 +379,8 @@ void CS_RecomputeBaselineTablesCmd_Test_CreateChildTaskError(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     UtAssert_True(CS_AppData.HkPacket.Payload.RecomputeInProgress == false, "CS_AppData.HkPacket.Payload.RecomputeInProgress == false");
 
@@ -414,7 +416,8 @@ void CS_RecomputeBaselineTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -450,7 +453,8 @@ void CS_RecomputeBaselineTablesCmd_Test_RecomputeInProgress(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -486,7 +490,8 @@ void CS_RecomputeBaselineTablesCmd_Test_OneShot(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -535,7 +540,7 @@ void CS_DisableNameTablesCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -590,7 +595,7 @@ void CS_DisableNameTablesCmd_Test_TableDefNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -625,7 +630,8 @@ void CS_DisableNameTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -644,7 +650,7 @@ void CS_DisableNameTablesCmd_Test_OneShot(void)
     CS_DisableNameTablesCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -690,7 +696,7 @@ void CS_EnableNameTablesCmd_Test_Nominal(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -742,7 +748,7 @@ void CS_EnableNameTablesCmd_Test_TableDefNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 1, "CS_AppData.HkPacket.Payload.CommandCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -777,7 +783,8 @@ void CS_EnableNameTablesCmd_Test_TableNotFound(void)
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdErrCounter == 1, "CS_AppData.HkPacket.Payload.CmdErrCounter == 1");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandErrorCounter == 1,
+                  "CS_AppData.HkPacket.Payload.CommandErrorCounter == 1");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
@@ -796,7 +803,7 @@ void CS_EnableNameTablesCmd_Test_OneShot(void)
     CS_EnableNameTablesCmd(&CmdPacket);
 
     /* Verify results */
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 0, "CS_AppData.HkPacket.Payload.CmdCounter == 0");
+    UtAssert_True(CS_AppData.HkPacket.Payload.CommandCounter == 0, "CS_AppData.HkPacket.Payload.CommandCounter == 0");
 
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 

--- a/unit-test/cs_utils_tests.c
+++ b/unit-test/cs_utils_tests.c
@@ -687,14 +687,14 @@ void CS_CheckRecomputeOneShot_Test(void)
 
     UtAssert_BOOL_FALSE(CS_CheckRecomputeOneshot());
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0);
-    UtAssert_UINT8_EQ(CS_AppData.HkPacket.Payload.CmdErrCounter, 0);
+    UtAssert_UINT8_EQ(CS_AppData.HkPacket.Payload.CommandErrorCounter, 0);
 
     /* One shot in progress */
     CS_AppData.HkPacket.Payload.OneShotInProgress = true;
     UtAssert_BOOL_TRUE(CS_CheckRecomputeOneshot());
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 1);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_CMD_COMPUTE_PROG_ERR_EID);
-    UtAssert_UINT8_EQ(CS_AppData.HkPacket.Payload.CmdErrCounter, 1);
+    UtAssert_UINT8_EQ(CS_AppData.HkPacket.Payload.CommandErrorCounter, 1);
 
     /* Recompute in progress */
     CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
@@ -702,7 +702,7 @@ void CS_CheckRecomputeOneShot_Test(void)
     UtAssert_BOOL_TRUE(CS_CheckRecomputeOneshot());
     UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 2);
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[1].EventID, CS_CMD_COMPUTE_PROG_ERR_EID);
-    UtAssert_UINT8_EQ(CS_AppData.HkPacket.Payload.CmdErrCounter, 2);
+    UtAssert_UINT8_EQ(CS_AppData.HkPacket.Payload.CommandErrorCounter, 2);
 }
 
 void UtTest_Setup(void)

--- a/unit-test/stubs/cs_cmds_stubs.c
+++ b/unit-test/stubs/cs_cmds_stubs.c
@@ -35,10 +35,10 @@ void CS_NoopCmd(const CS_NoArgsCmd_t *CmdPtr)
     UT_DEFAULT_IMPL(CS_NoopCmd);
 }
 
-void CS_ResetCmd(const CS_NoArgsCmd_t *CmdPtr)
+void CS_ResetCountersCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-    UT_Stub_RegisterContext(UT_KEY(CS_ResetCmd), CmdPtr);
-    UT_DEFAULT_IMPL(CS_ResetCmd);
+    UT_Stub_RegisterContext(UT_KEY(CS_ResetCountersCmd), CmdPtr);
+    UT_DEFAULT_IMPL(CS_ResetCountersCmd);
 }
 
 void CS_BackgroundCheckCycle(const CS_NoArgsCmd_t *CmdPtr)


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #97

Dead Code removed (along with their accompanying tests):
- `bufptr` cannot be `NULL` after a successful return from `CFE_SB_ReceiveBuffer`
- status check for `CFE_ES_RunStatus_SYS_EXCEPTION` not necessary (and impossible to reach other than through forced test conditions) given that the code setting that status was removed at some point in the past

Minor changes to improve consistency and use the preferred symbol naming conventions:
- rename `CmdCounter` to `ComandCounter`
- rename `CmdErrCounter` to `CommandErrorCounter`
- rename `CS_ResetCmd` to `CS_ResetCountersCmd`

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Remove dead code to reduce unnecessary clutter.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt