### PR TITLE
Fix #99, Fill in `Name` variable to avoid being used uninitialized

### DIFF
--- a/fsw/src/cs_app_cmds.c
+++ b/fsw/src/cs_app_cmds.c
@@ -46,18 +46,18 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableAppCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.AppCSState = CS_STATE_DISABLED;
-            CS_ZeroAppTempValues();
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        CS_AppData.HkPacket.Payload.AppCSState = CS_STATE_DISABLED;
+        CS_ZeroAppTempValues();
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
+        CS_UpdateCDS();
 #endif
 
-            CFE_EVS_SendEvent(CS_DISABLE_APP_INF_EID, CFE_EVS_EventType_INFORMATION, "Checksumming of App is Disabled");
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+        CFE_EVS_SendEvent(CS_DISABLE_APP_INF_EID, CFE_EVS_EventType_INFORMATION, "Checksumming of App is Disabled");
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -67,17 +67,17 @@ void CS_DisableAppCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableAppCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.AppCSState = CS_STATE_ENABLED;
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        CS_AppData.HkPacket.Payload.AppCSState = CS_STATE_ENABLED;
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
+        CS_UpdateCDS();
 #endif
 
-            CFE_EVS_SendEvent(CS_ENABLE_APP_INF_EID, CFE_EVS_EventType_INFORMATION, "Checksumming of App is Enabled");
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+        CFE_EVS_SendEvent(CS_ENABLE_APP_INF_EID, CFE_EVS_EventType_INFORMATION, "Checksumming of App is Enabled");
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -89,33 +89,31 @@ void CS_ReportBaselineAppCmd(const CS_AppNameCmd_t *CmdPtr)
 {
     /* command verification variables */
     CS_Res_App_Table_Entry_t *ResultsEntry;
-    uint32                    Baseline;
     char                      Name[OS_MAX_API_NAME];
 
-        strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
-        Name[sizeof(Name) - 1] = '\0';
+    strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
+    Name[sizeof(Name) - 1] = '\0';
 
-        if (CS_GetAppResTblEntryByName(&ResultsEntry, Name))
+    if (CS_GetAppResTblEntryByName(&ResultsEntry, Name))
+    {
+        if (ResultsEntry->ComputedYet == true)
         {
-            if (ResultsEntry->ComputedYet == true)
-            {
-                Baseline = ResultsEntry->ComparisonValue;
-                CFE_EVS_SendEvent(CS_BASELINE_APP_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Report baseline of app %s is 0x%08X", Name, (unsigned int)Baseline);
-            }
-            else
-            {
-                CFE_EVS_SendEvent(CS_NO_BASELINE_APP_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Report baseline of app %s has not been computed yet", Name);
-            }
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CFE_EVS_SendEvent(CS_BASELINE_APP_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Report baseline of app %s is 0x%08X", Name, (unsigned int)ResultsEntry->ComparisonValue);
         }
         else
         {
-            CFE_EVS_SendEvent(CS_BASELINE_INVALID_NAME_APP_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "App report baseline failed, app %s not found", Name);
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CFE_EVS_SendEvent(CS_NO_BASELINE_APP_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Report baseline of app %s has not been computed yet", Name);
         }
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
+    else
+    {
+        CFE_EVS_SendEvent(CS_BASELINE_INVALID_NAME_APP_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "App report baseline failed, app %s not found", Name);
+        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -131,53 +129,54 @@ void CS_RecomputeBaselineAppCmd(const CS_AppNameCmd_t *CmdPtr)
     CS_Res_App_Table_Entry_t *ResultsEntry;
     char                      Name[OS_MAX_API_NAME];
 
-        if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false && CS_AppData.HkPacket.Payload.OneShotInProgress == false)
+    strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
+    Name[sizeof(Name) - 1] = '\0';
+
+    if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false &&
+        CS_AppData.HkPacket.Payload.OneShotInProgress == false)
+    {
+        /* make sure the entry is a valid number and is defined in the table */
+        if (CS_GetAppResTblEntryByName(&ResultsEntry, Name))
         {
-            strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
-            Name[sizeof(Name) - 1] = '\0';
+            /* There is no child task running right now, we can use it*/
+            CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
-            /* make sure the entry is a valid number and is defined in the table */
-            if (CS_GetAppResTblEntryByName(&ResultsEntry, Name))
+            /* fill in child task variables */
+            CS_AppData.ChildTaskTable = CS_APP_TABLE;
+
+            CS_AppData.RecomputeAppEntryPtr = ResultsEntry;
+
+            Status = CFE_ES_CreateChildTask(&ChildTaskID, CS_RECOMP_APP_TASK_NAME, CS_RecomputeAppChildTask, NULL,
+                                            CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
+            if (Status == CFE_SUCCESS)
             {
-                /* There is no child task running right now, we can use it*/
-                CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
-
-                /* fill in child task variables */
-                CS_AppData.ChildTaskTable = CS_APP_TABLE;
-
-                CS_AppData.RecomputeAppEntryPtr = ResultsEntry;
-
-                Status = CFE_ES_CreateChildTask(&ChildTaskID, CS_RECOMP_APP_TASK_NAME, CS_RecomputeAppChildTask, NULL,
-                                                CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
-                if (Status == CFE_SUCCESS)
-                {
-                    CFE_EVS_SendEvent(CS_RECOMPUTE_APP_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "Recompute baseline of app %s started", Name);
-                    CS_AppData.HkPacket.Payload.CmdCounter++;
-                }
-                else /* child task creation failed */
-                {
-                    CFE_EVS_SendEvent(CS_RECOMPUTE_APP_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
-                                      "Recompute baseline of app %s failed, CFE_ES_CreateChildTask returned: 0x%08X",
-                                      Name, (unsigned int)Status);
-                    CS_AppData.HkPacket.Payload.CmdErrCounter++;
-                    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
-                }
+                CFE_EVS_SendEvent(CS_RECOMPUTE_APP_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
+                                  "Recompute baseline of app %s started", Name);
+                CS_AppData.HkPacket.Payload.CmdCounter++;
             }
-            else
+            else /* child task creation failed */
             {
-                CFE_EVS_SendEvent(CS_RECOMPUTE_UNKNOWN_NAME_APP_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "App recompute baseline failed, app %s not found", Name);
+                CFE_EVS_SendEvent(CS_RECOMPUTE_APP_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
+                                  "Recompute baseline of app %s failed, CFE_ES_CreateChildTask returned: 0x%08X", Name,
+                                  (unsigned int)Status);
                 CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
             }
         }
         else
         {
-            /*send event that we can't start another task right now */
-            CFE_EVS_SendEvent(CS_RECOMPUTE_APP_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "App recompute baseline for app %s failed: child task in use", Name);
+            CFE_EVS_SendEvent(CS_RECOMPUTE_UNKNOWN_NAME_APP_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "App recompute baseline failed, app %s not found", Name);
             CS_AppData.HkPacket.Payload.CmdErrCounter++;
         }
+    }
+    else
+    {
+        /*send event that we can't start another task right now */
+        CFE_EVS_SendEvent(CS_RECOMPUTE_APP_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "App recompute baseline for app %s failed: child task in use", Name);
+        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -192,42 +191,42 @@ void CS_DisableNameAppCmd(const CS_AppNameCmd_t *CmdPtr)
     CS_Def_App_Table_Entry_t *DefinitionEntry;
     char                      Name[OS_MAX_API_NAME];
 
-        if (CS_CheckRecomputeOneshot() == false)
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
+        Name[sizeof(Name) - 1] = '\0';
+
+        if (CS_GetAppResTblEntryByName(&ResultsEntry, Name))
         {
-            strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
-            Name[sizeof(Name) - 1] = '\0';
+            ResultsEntry->State             = CS_STATE_DISABLED;
+            ResultsEntry->TempChecksumValue = 0;
+            ResultsEntry->ByteOffset        = 0;
 
-            if (CS_GetAppResTblEntryByName(&ResultsEntry, Name))
+            CFE_EVS_SendEvent(CS_DISABLE_APP_NAME_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Checksumming of app %s is Disabled", Name);
+
+            if (CS_GetAppDefTblEntryByName(&DefinitionEntry, Name))
             {
-                ResultsEntry->State             = CS_STATE_DISABLED;
-                ResultsEntry->TempChecksumValue = 0;
-                ResultsEntry->ByteOffset        = 0;
-
-                CFE_EVS_SendEvent(CS_DISABLE_APP_NAME_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of app %s is Disabled", Name);
-
-                if (CS_GetAppDefTblEntryByName(&DefinitionEntry, Name))
-                {
-                    DefinitionEntry->State = CS_STATE_DISABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.AppResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefAppTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_DISABLE_APP_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update apps definition table for entry %s", Name);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                DefinitionEntry->State = CS_STATE_DISABLED;
+                CS_ResetTablesTblResultEntry(CS_AppData.AppResTablesTblPtr);
+                CFE_TBL_Modified(CS_AppData.DefAppTableHandle);
             }
-
             else
             {
-                CFE_EVS_SendEvent(CS_DISABLE_APP_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "App disable app command failed, app %s not found", Name);
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CFE_EVS_SendEvent(CS_DISABLE_APP_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
+                                  "CS unable to update apps definition table for entry %s", Name);
             }
-        } /* end InProgress if */
+
+            CS_AppData.HkPacket.Payload.CmdCounter++;
+        }
+
+        else
+        {
+            CFE_EVS_SendEvent(CS_DISABLE_APP_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "App disable app command failed, app %s not found", Name);
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        }
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -242,37 +241,37 @@ void CS_EnableNameAppCmd(const CS_AppNameCmd_t *CmdPtr)
     CS_Def_App_Table_Entry_t *DefinitionEntry;
     char                      Name[OS_MAX_API_NAME];
 
-        if (CS_CheckRecomputeOneshot() == false)
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
+        Name[sizeof(Name) - 1] = '\0';
+
+        if (CS_GetAppResTblEntryByName(&ResultsEntry, Name))
         {
-            strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
-            Name[sizeof(Name) - 1] = '\0';
+            ResultsEntry->State = CS_STATE_ENABLED;
 
-            if (CS_GetAppResTblEntryByName(&ResultsEntry, Name))
+            CFE_EVS_SendEvent(CS_ENABLE_APP_NAME_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Checksumming of app %s is Enabled", Name);
+
+            if (CS_GetAppDefTblEntryByName(&DefinitionEntry, Name))
             {
-                ResultsEntry->State = CS_STATE_ENABLED;
-
-                CFE_EVS_SendEvent(CS_ENABLE_APP_NAME_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of app %s is Enabled", Name);
-
-                if (CS_GetAppDefTblEntryByName(&DefinitionEntry, Name))
-                {
-                    DefinitionEntry->State = CS_STATE_ENABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.AppResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefAppTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_ENABLE_APP_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update apps definition table for entry %s", Name);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                DefinitionEntry->State = CS_STATE_ENABLED;
+                CS_ResetTablesTblResultEntry(CS_AppData.AppResTablesTblPtr);
+                CFE_TBL_Modified(CS_AppData.DefAppTableHandle);
             }
             else
             {
-                CFE_EVS_SendEvent(CS_ENABLE_APP_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "App enable app command failed, app %s not found", Name);
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CFE_EVS_SendEvent(CS_ENABLE_APP_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
+                                  "CS unable to update apps definition table for entry %s", Name);
             }
-        } /* end InProgress if */
+
+            CS_AppData.HkPacket.Payload.CmdCounter++;
+        }
+        else
+        {
+            CFE_EVS_SendEvent(CS_ENABLE_APP_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "App enable app command failed, app %s not found", Name);
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        }
+    }
 }

--- a/fsw/src/cs_eeprom_cmds.c
+++ b/fsw/src/cs_eeprom_cmds.c
@@ -48,20 +48,20 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.EepromCSState = CS_STATE_DISABLED;
-            CS_ZeroEepromTempValues();
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        CS_AppData.HkPacket.Payload.EepromCSState = CS_STATE_DISABLED;
+        CS_ZeroEepromTempValues();
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
+        CS_UpdateCDS();
 #endif
 
-            CFE_EVS_SendEvent(CS_DISABLE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of EEPROM is Disabled");
+        CFE_EVS_SendEvent(CS_DISABLE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Checksumming of EEPROM is Disabled");
 
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -71,19 +71,18 @@ void CS_DisableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.EepromCSState = CS_STATE_ENABLED;
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        CS_AppData.HkPacket.Payload.EepromCSState = CS_STATE_ENABLED;
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
+        CS_UpdateCDS();
 #endif
 
-            CFE_EVS_SendEvent(CS_ENABLE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of EEPROM is Enabled");
+        CFE_EVS_SendEvent(CS_ENABLE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION, "Checksumming of EEPROM is Enabled");
 
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -94,48 +93,38 @@ void CS_EnableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
 void CS_ReportBaselineEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
 {
     /* command verification variables */
-    uint32                            Baseline = 0;
-    uint16                            EntryID  = 0;
-    uint16                            State    = CS_STATE_EMPTY;
-    CS_Res_EepromMemory_Table_Entry_t ResultsEntry;
+    uint16 EntryID = 0;
+    uint16 State   = CS_STATE_UNDEFINED;
 
-        EntryID = CmdPtr->Payload.EntryID;
+    EntryID = CmdPtr->Payload.EntryID;
 
-        if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
-            (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
+    if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) && (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
+    {
+        if (CS_AppData.ResEepromTblPtr[EntryID].ComputedYet == true)
         {
-            ResultsEntry = CS_AppData.ResEepromTblPtr[EntryID];
-
-            if (ResultsEntry.ComputedYet == true)
-            {
-                Baseline = ResultsEntry.ComparisonValue;
-
-                CFE_EVS_SendEvent(CS_BASELINE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Report baseline of EEPROM Entry %d is 0x%08X", EntryID, (unsigned int)Baseline);
-            }
-            else
-            {
-                CFE_EVS_SendEvent(CS_NO_BASELINE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Report baseline of EEPROM Entry %d has not been computed yet", EntryID);
-            }
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CFE_EVS_SendEvent(CS_BASELINE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Report baseline of EEPROM Entry %d is 0x%08X", EntryID,
+                              (unsigned int)CS_AppData.ResEepromTblPtr[EntryID].ComparisonValue);
         }
         else
         {
-            if (EntryID >= CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
-            {
-                State = CS_STATE_UNDEFINED;
-            }
-            else
-            {
-                State = CS_AppData.ResEepromTblPtr[EntryID].State;
-            }
-
-            CFE_EVS_SendEvent(CS_BASELINE_INVALID_ENTRY_EEPROM_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "EEPROM report baseline failed, Entry ID invalid: %d, State: %d Max ID: %d", EntryID,
-                              State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CFE_EVS_SendEvent(CS_NO_BASELINE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Report baseline of EEPROM Entry %d has not been computed yet", EntryID);
         }
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
+    else
+    {
+        if (EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
+        {
+            State = CS_AppData.ResEepromTblPtr[EntryID].State;
+        }
+
+        CFE_EVS_SendEvent(CS_BASELINE_INVALID_ENTRY_EEPROM_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "EEPROM report baseline failed, Entry ID invalid: %d, State: %d Max ID: %d", EntryID, State,
+                          (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
+        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -151,68 +140,67 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
     uint16          EntryID     = 0;
     uint16          State       = CS_STATE_EMPTY;
 
-        EntryID = CmdPtr->Payload.EntryID;
+    EntryID = CmdPtr->Payload.EntryID;
 
-        if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false && CS_AppData.HkPacket.Payload.OneShotInProgress == false)
+    if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false &&
+        CS_AppData.HkPacket.Payload.OneShotInProgress == false)
+    {
+        /* make sure the entry is a valid number and is defined in the table */
+        if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
+            (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
         {
-            /* make sure the entry is a valid number and is defined in the table */
-            if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
-                (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
+            /* There is no child task running right now, we can use it*/
+            CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
+
+            /* fill in child task variables */
+            CS_AppData.ChildTaskTable   = CS_EEPROM_TABLE;
+            CS_AppData.ChildTaskEntryID = EntryID;
+
+            CS_AppData.RecomputeEepromMemoryEntryPtr = &CS_AppData.ResEepromTblPtr[EntryID];
+
+            Status = CFE_ES_CreateChildTask(&ChildTaskID, CS_RECOMP_EEPROM_TASK_NAME, CS_RecomputeEepromMemoryChildTask,
+                                            NULL, CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
+            if (Status == CFE_SUCCESS)
             {
-                /* There is no child task running right now, we can use it*/
-                CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
-
-                /* fill in child task variables */
-                CS_AppData.ChildTaskTable   = CS_EEPROM_TABLE;
-                CS_AppData.ChildTaskEntryID = EntryID;
-
-                CS_AppData.RecomputeEepromMemoryEntryPtr = &CS_AppData.ResEepromTblPtr[EntryID];
-
-                Status =
-                    CFE_ES_CreateChildTask(&ChildTaskID, CS_RECOMP_EEPROM_TASK_NAME, CS_RecomputeEepromMemoryChildTask,
-                                           NULL, CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
-                if (Status == CFE_SUCCESS)
-                {
-                    CFE_EVS_SendEvent(CS_RECOMPUTE_EEPROM_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "Recompute baseline of EEPROM Entry ID %d started", EntryID);
-                    CS_AppData.HkPacket.Payload.CmdCounter++;
-                }
-                else /* child task creation failed */
-                {
-                    CFE_EVS_SendEvent(
-                        CS_RECOMPUTE_EEPROM_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
-                        "Recompute baseline of EEPROM Entry ID %d failed, CFE_ES_CreateChildTask returned:  0x%08X",
-                        EntryID, (unsigned int)Status);
-                    CS_AppData.HkPacket.Payload.CmdErrCounter++;
-                    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
-                }
+                CFE_EVS_SendEvent(CS_RECOMPUTE_EEPROM_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
+                                  "Recompute baseline of EEPROM Entry ID %d started", EntryID);
+                CS_AppData.HkPacket.Payload.CmdCounter++;
             }
-            else
+            else /* child task creation failed */
             {
-                if (EntryID >= CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
-                {
-                    State = CS_STATE_UNDEFINED;
-                }
-                else
-                {
-                    State = CS_AppData.ResEepromTblPtr[EntryID].State;
-                }
-
                 CFE_EVS_SendEvent(
-                    CS_RECOMPUTE_INVALID_ENTRY_EEPROM_ERR_EID, CFE_EVS_EventType_ERROR,
-                    "EEPROM recompute baseline of entry failed, Entry ID invalid: %d, State: %d, Max ID: %d", EntryID,
-                    State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
-
+                    CS_RECOMPUTE_EEPROM_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
+                    "Recompute baseline of EEPROM Entry ID %d failed, CFE_ES_CreateChildTask returned:  0x%08X",
+                    EntryID, (unsigned int)Status);
                 CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
             }
         }
         else
         {
-            /*send event that we can't start another task right now */
-            CFE_EVS_SendEvent(CS_RECOMPUTE_EEPROM_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Recompute baseline of EEPROM Entry ID %d failed: child task in use", EntryID);
+            if (EntryID >= CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
+            {
+                State = CS_STATE_UNDEFINED;
+            }
+            else
+            {
+                State = CS_AppData.ResEepromTblPtr[EntryID].State;
+            }
+
+            CFE_EVS_SendEvent(CS_RECOMPUTE_INVALID_ENTRY_EEPROM_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "EEPROM recompute baseline of entry failed, Entry ID invalid: %d, State: %d, Max ID: %d",
+                              EntryID, State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
+
             CS_AppData.HkPacket.Payload.CmdErrCounter++;
         }
+    }
+    else
+    {
+        /*send event that we can't start another task right now */
+        CFE_EVS_SendEvent(CS_RECOMPUTE_EEPROM_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Recompute baseline of EEPROM Entry ID %d failed: child task in use", EntryID);
+        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -227,52 +215,52 @@ void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
     uint16                             EntryID      = 0;
     uint16                             State        = CS_STATE_EMPTY;
 
-        if (CS_CheckRecomputeOneshot() == false)
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        EntryID = CmdPtr->Payload.EntryID;
+
+        if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
+            (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
         {
-            EntryID = CmdPtr->Payload.EntryID;
+            ResultsEntry = &CS_AppData.ResEepromTblPtr[EntryID];
 
-            if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
-                (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
+            ResultsEntry->State = CS_STATE_ENABLED;
+
+            CFE_EVS_SendEvent(CS_ENABLE_EEPROM_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Checksumming of EEPROM Entry ID %d is Enabled", EntryID);
+
+            if (CS_AppData.DefEepromTblPtr[EntryID].State != CS_STATE_EMPTY)
             {
-                ResultsEntry = &CS_AppData.ResEepromTblPtr[EntryID];
-
-                ResultsEntry->State = CS_STATE_ENABLED;
-
-                CFE_EVS_SendEvent(CS_ENABLE_EEPROM_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of EEPROM Entry ID %d is Enabled", EntryID);
-
-                if (CS_AppData.DefEepromTblPtr[EntryID].State != CS_STATE_EMPTY)
-                {
-                    CS_AppData.DefEepromTblPtr[EntryID].State = CS_STATE_ENABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.EepResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefEepromTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_ENABLE_EEPROM_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update EEPROM definition table for entry %d, State: %d", EntryID,
-                                      State);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                CS_AppData.DefEepromTblPtr[EntryID].State = CS_STATE_ENABLED;
+                CS_ResetTablesTblResultEntry(CS_AppData.EepResTablesTblPtr);
+                CFE_TBL_Modified(CS_AppData.DefEepromTableHandle);
             }
             else
             {
-                if (EntryID >= CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
-                {
-                    State = CS_STATE_UNDEFINED;
-                }
-                else
-                {
-                    State = CS_AppData.ResEepromTblPtr[EntryID].State;
-                }
-
-                CFE_EVS_SendEvent(CS_ENABLE_EEPROM_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Enable EEPROM entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
-                                  State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CFE_EVS_SendEvent(CS_ENABLE_EEPROM_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
+                                  "CS unable to update EEPROM definition table for entry %d, State: %d", EntryID,
+                                  State);
             }
-        } /* end InProgress if */
+
+            CS_AppData.HkPacket.Payload.CmdCounter++;
+        }
+        else
+        {
+            if (EntryID >= CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
+            {
+                State = CS_STATE_UNDEFINED;
+            }
+            else
+            {
+                State = CS_AppData.ResEepromTblPtr[EntryID].State;
+            }
+
+            CFE_EVS_SendEvent(CS_ENABLE_EEPROM_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Enable EEPROM entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
+                              State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        }
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -287,55 +275,55 @@ void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
     uint16                             EntryID      = 0;
     uint16                             State        = CS_STATE_EMPTY;
 
-        if (CS_CheckRecomputeOneshot() == false)
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        EntryID = CmdPtr->Payload.EntryID;
+
+        if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
+            (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
         {
-            EntryID = CmdPtr->Payload.EntryID;
+            ResultsEntry = &CS_AppData.ResEepromTblPtr[EntryID];
 
-            if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
-                (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
+            ResultsEntry->State             = CS_STATE_DISABLED;
+            ResultsEntry->TempChecksumValue = 0;
+            ResultsEntry->ByteOffset        = 0;
+
+            CFE_EVS_SendEvent(CS_DISABLE_EEPROM_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Checksumming of EEPROM Entry ID %d is Disabled", EntryID);
+
+            if (CS_AppData.DefEepromTblPtr[EntryID].State != CS_STATE_EMPTY)
             {
-                ResultsEntry = &CS_AppData.ResEepromTblPtr[EntryID];
-
-                ResultsEntry->State             = CS_STATE_DISABLED;
-                ResultsEntry->TempChecksumValue = 0;
-                ResultsEntry->ByteOffset        = 0;
-
-                CFE_EVS_SendEvent(CS_DISABLE_EEPROM_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of EEPROM Entry ID %d is Disabled", EntryID);
-
-                if (CS_AppData.DefEepromTblPtr[EntryID].State != CS_STATE_EMPTY)
-                {
-                    CS_AppData.DefEepromTblPtr[EntryID].State = CS_STATE_DISABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.EepResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefEepromTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_DISABLE_EEPROM_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update EEPROM definition table for entry %d, State: %d", EntryID,
-                                      State);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                CS_AppData.DefEepromTblPtr[EntryID].State = CS_STATE_DISABLED;
+                CS_ResetTablesTblResultEntry(CS_AppData.EepResTablesTblPtr);
+                CFE_TBL_Modified(CS_AppData.DefEepromTableHandle);
             }
             else
             {
-                if (EntryID >= CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
-                {
-                    State = CS_STATE_UNDEFINED;
-                }
-                else
-                {
-                    State = CS_AppData.ResEepromTblPtr[EntryID].State;
-                }
-
-                CFE_EVS_SendEvent(CS_DISABLE_EEPROM_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Disable EEPROM entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
-                                  State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
-
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CFE_EVS_SendEvent(CS_DISABLE_EEPROM_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
+                                  "CS unable to update EEPROM definition table for entry %d, State: %d", EntryID,
+                                  State);
             }
-        } /* end InProgress if */
+
+            CS_AppData.HkPacket.Payload.CmdCounter++;
+        }
+        else
+        {
+            if (EntryID >= CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
+            {
+                State = CS_STATE_UNDEFINED;
+            }
+            else
+            {
+                State = CS_AppData.ResEepromTblPtr[EntryID].State;
+            }
+
+            CFE_EVS_SendEvent(CS_DISABLE_EEPROM_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Disable EEPROM entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
+                              State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
+
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        }
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -351,26 +339,27 @@ void CS_GetEntryIDEepromCmd(const CS_GetEntryIDCmd_t *CmdPtr)
     bool                               EntryFound          = false;
     CS_Res_EepromMemory_Table_Entry_t  ResultsEntry;
 
-        StartOfResultsTable = CS_AppData.ResEepromTblPtr;
+    StartOfResultsTable = CS_AppData.ResEepromTblPtr;
 
-        for (Loop = 0; Loop < CS_MAX_NUM_EEPROM_TABLE_ENTRIES; Loop++)
+    for (Loop = 0; Loop < CS_MAX_NUM_EEPROM_TABLE_ENTRIES; Loop++)
+    {
+        ResultsEntry = StartOfResultsTable[Loop];
+
+        if ((ResultsEntry.StartAddress <= CmdPtr->Payload.Address) &&
+            CmdPtr->Payload.Address <= (ResultsEntry.StartAddress + ResultsEntry.NumBytesToChecksum) &&
+            ResultsEntry.State != CS_STATE_EMPTY)
         {
-            ResultsEntry = StartOfResultsTable[Loop];
-
-            if ((ResultsEntry.StartAddress <= CmdPtr->Payload.Address) &&
-                CmdPtr->Payload.Address <= (ResultsEntry.StartAddress + ResultsEntry.NumBytesToChecksum) &&
-                ResultsEntry.State != CS_STATE_EMPTY)
-            {
-                CFE_EVS_SendEvent(CS_GET_ENTRY_ID_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "EEPROM Found Address 0x%08X in Entry ID %d", (unsigned int)(CmdPtr->Payload.Address), Loop);
-                EntryFound = true;
-            }
+            CFE_EVS_SendEvent(CS_GET_ENTRY_ID_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "EEPROM Found Address 0x%08X in Entry ID %d", (unsigned int)(CmdPtr->Payload.Address),
+                              Loop);
+            EntryFound = true;
         }
+    }
 
-        if (EntryFound == false)
-        {
-            CFE_EVS_SendEvent(CS_GET_ENTRY_ID_EEPROM_NOT_FOUND_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Address 0x%08X was not found in EEPROM table", (unsigned int)(CmdPtr->Payload.Address));
-        }
-        CS_AppData.HkPacket.Payload.CmdCounter++;
+    if (EntryFound == false)
+    {
+        CFE_EVS_SendEvent(CS_GET_ENTRY_ID_EEPROM_NOT_FOUND_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Address 0x%08X was not found in EEPROM table", (unsigned int)(CmdPtr->Payload.Address));
+    }
+    CS_AppData.HkPacket.Payload.CmdCounter++;
 }

--- a/fsw/src/cs_memory_cmds.c
+++ b/fsw/src/cs_memory_cmds.c
@@ -48,20 +48,20 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_DISABLED;
-            CS_ZeroMemoryTempValues();
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_DISABLED;
+        CS_ZeroMemoryTempValues();
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
+        CS_UpdateCDS();
 #endif
 
-            CFE_EVS_SendEvent(CS_DISABLE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of Memory is Disabled");
+        CFE_EVS_SendEvent(CS_DISABLE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Checksumming of Memory is Disabled");
 
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -71,19 +71,18 @@ void CS_DisableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_ENABLED;
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_ENABLED;
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
+        CS_UpdateCDS();
 #endif
 
-            CFE_EVS_SendEvent(CS_ENABLE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of Memory is Enabled");
+        CFE_EVS_SendEvent(CS_ENABLE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION, "Checksumming of Memory is Enabled");
 
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -94,11 +93,130 @@ void CS_EnableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
 void CS_ReportBaselineEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 {
     /* command verification variables */
-    CS_Res_EepromMemory_Table_Entry_t *ResultsEntry   = NULL;
-    uint32                             Baseline       = 0;
-    uint16                             EntryID        = 0;
-    uint16                             State          = CS_STATE_EMPTY;
+    uint16 EntryID = 0;
+    uint16 State   = CS_STATE_UNDEFINED;
 
+    EntryID = CmdPtr->Payload.EntryID;
+
+    if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) && (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
+    {
+        if (CS_AppData.ResMemoryTblPtr[EntryID].ComputedYet == true)
+        {
+            CFE_EVS_SendEvent(CS_BASELINE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Report baseline of Memory Entry %d is 0x%08X", EntryID,
+                              (unsigned int)CS_AppData.ResMemoryTblPtr[EntryID].ComparisonValue);
+        }
+        else
+        {
+            CFE_EVS_SendEvent(CS_NO_BASELINE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Report baseline of Memory Entry %d has not been computed yet", EntryID);
+        }
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
+    else
+    {
+        if (EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
+        {
+            State = CS_AppData.ResMemoryTblPtr[EntryID].State;
+        }
+
+        CFE_EVS_SendEvent(CS_BASELINE_INVALID_ENTRY_MEMORY_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Memory report baseline failed, Entry ID invalid: %d, State: %d Max ID: %d", EntryID, State,
+                          (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
+        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CS Recompute the baseline of an entry in the Memory table cmd   */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
+{
+    /* command verification variables */
+    CFE_ES_TaskId_t ChildTaskID = CFE_ES_TASKID_UNDEFINED;
+    CFE_Status_t    Status      = CS_ERROR;
+    uint16          EntryID     = 0;
+    uint16          State       = CS_STATE_EMPTY;
+
+    EntryID = CmdPtr->Payload.EntryID;
+
+    if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false &&
+        CS_AppData.HkPacket.Payload.OneShotInProgress == false)
+    {
+        /* make sure the entry is a valid number and is defined in the table */
+        if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
+            (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
+        {
+            /* There is no child task running right now, we can use it*/
+            CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
+
+            /* fill in child task variables */
+            CS_AppData.ChildTaskTable   = CS_MEMORY_TABLE;
+            CS_AppData.ChildTaskEntryID = EntryID;
+
+            CS_AppData.RecomputeEepromMemoryEntryPtr = &CS_AppData.ResMemoryTblPtr[EntryID];
+
+            Status = CFE_ES_CreateChildTask(&ChildTaskID, CS_RECOMP_MEMORY_TASK_NAME, CS_RecomputeEepromMemoryChildTask,
+                                            NULL, CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
+            if (Status == CFE_SUCCESS)
+            {
+                CFE_EVS_SendEvent(CS_RECOMPUTE_MEMORY_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
+                                  "Recompute baseline of Memory Entry ID %d started", EntryID);
+                CS_AppData.HkPacket.Payload.CmdCounter++;
+            }
+            else /* child task creation failed */
+            {
+                CFE_EVS_SendEvent(
+                    CS_RECOMPUTE_MEMORY_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
+                    "Recompute baseline of Memory Entry ID %d failed, ES_CreateChildTask returned:  0x%08X", EntryID,
+                    (unsigned int)Status);
+                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+            }
+        }
+        else
+        {
+            if (EntryID >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
+            {
+                State = CS_STATE_UNDEFINED;
+            }
+            else
+            {
+                State = CS_AppData.ResMemoryTblPtr[EntryID].State;
+            }
+
+            CFE_EVS_SendEvent(CS_RECOMPUTE_INVALID_ENTRY_MEMORY_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Memory recompute baseline of entry failed, Entry ID invalid: %d, State: %d, Max ID: %d",
+                              EntryID, State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
+
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        }
+    }
+    else
+    {
+        /*send event that we can't start another task right now */
+        CFE_EVS_SendEvent(CS_RECOMPUTE_MEMORY_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Recompute baseline of Memory Entry ID %d failed: child task in use", EntryID);
+        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CS Enable a specific entry in the Memory table command          */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void CS_EnableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
+{
+    /* command verification variables */
+    CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
+    uint16                             EntryID      = 0;
+    uint16                             State        = CS_STATE_EMPTY;
+
+    if (CS_CheckRecomputeOneshot() == false)
+    {
         EntryID = CmdPtr->Payload.EntryID;
 
         if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
@@ -106,18 +224,24 @@ void CS_ReportBaselineEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
         {
             ResultsEntry = &CS_AppData.ResMemoryTblPtr[EntryID];
 
-            if (ResultsEntry->ComputedYet == true)
-            {
-                Baseline = ResultsEntry->ComparisonValue;
+            ResultsEntry->State = CS_STATE_ENABLED;
 
-                CFE_EVS_SendEvent(CS_BASELINE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Report baseline of Memory Entry %d is 0x%08X", EntryID, (unsigned int)Baseline);
+            CFE_EVS_SendEvent(CS_ENABLE_MEMORY_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Checksumming of Memory Entry ID %d is Enabled", EntryID);
+
+            if (CS_AppData.DefMemoryTblPtr[EntryID].State != CS_STATE_EMPTY)
+            {
+                CS_AppData.DefMemoryTblPtr[EntryID].State = CS_STATE_ENABLED;
+                CS_ResetTablesTblResultEntry(CS_AppData.MemResTablesTblPtr);
+                CFE_TBL_Modified(CS_AppData.DefMemoryTableHandle);
             }
             else
             {
-                CFE_EVS_SendEvent(CS_NO_BASELINE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Report baseline of Memory Entry %d has not been computed yet", EntryID);
+                CFE_EVS_SendEvent(CS_ENABLE_MEMORY_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
+                                  "CS unable to update memory definition table for entry %d, State: %d", EntryID,
+                                  State);
             }
+
             CS_AppData.HkPacket.Payload.CmdCounter++;
         }
         else
@@ -131,148 +255,12 @@ void CS_ReportBaselineEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                 State = CS_AppData.ResMemoryTblPtr[EntryID].State;
             }
 
-            CFE_EVS_SendEvent(CS_BASELINE_INVALID_ENTRY_MEMORY_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Memory report baseline failed, Entry ID invalid: %d, State: %d Max ID: %d", EntryID,
+            CFE_EVS_SendEvent(CS_ENABLE_MEMORY_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Enable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
                               State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
             CS_AppData.HkPacket.Payload.CmdErrCounter++;
         }
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CS Recompute the baseline of an entry in the Memory table cmd   */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
-{
-    /* command verification variables */
-    CFE_ES_TaskId_t ChildTaskID    = CFE_ES_TASKID_UNDEFINED;
-    CFE_Status_t    Status         = CS_ERROR;
-    uint16          EntryID        = 0;
-    uint16          State          = CS_STATE_EMPTY;
-
-        EntryID = CmdPtr->Payload.EntryID;
-
-        if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false && CS_AppData.HkPacket.Payload.OneShotInProgress == false)
-        {
-            /* make sure the entry is a valid number and is defined in the table */
-            if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
-                (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
-            {
-                /* There is no child task running right now, we can use it*/
-                CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
-
-                /* fill in child task variables */
-                CS_AppData.ChildTaskTable   = CS_MEMORY_TABLE;
-                CS_AppData.ChildTaskEntryID = EntryID;
-
-                CS_AppData.RecomputeEepromMemoryEntryPtr = &CS_AppData.ResMemoryTblPtr[EntryID];
-
-                Status =
-                    CFE_ES_CreateChildTask(&ChildTaskID, CS_RECOMP_MEMORY_TASK_NAME, CS_RecomputeEepromMemoryChildTask,
-                                           NULL, CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
-                if (Status == CFE_SUCCESS)
-                {
-                    CFE_EVS_SendEvent(CS_RECOMPUTE_MEMORY_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "Recompute baseline of Memory Entry ID %d started", EntryID);
-                    CS_AppData.HkPacket.Payload.CmdCounter++;
-                }
-                else /* child task creation failed */
-                {
-                    CFE_EVS_SendEvent(
-                        CS_RECOMPUTE_MEMORY_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
-                        "Recompute baseline of Memory Entry ID %d failed, ES_CreateChildTask returned:  0x%08X",
-                        EntryID, (unsigned int)Status);
-                    CS_AppData.HkPacket.Payload.CmdErrCounter++;
-                    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
-                }
-            }
-            else
-            {
-                if (EntryID >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
-                {
-                    State = CS_STATE_UNDEFINED;
-                }
-                else
-                {
-                    State = CS_AppData.ResMemoryTblPtr[EntryID].State;
-                }
-
-                CFE_EVS_SendEvent(
-                    CS_RECOMPUTE_INVALID_ENTRY_MEMORY_ERR_EID, CFE_EVS_EventType_ERROR,
-                    "Memory recompute baseline of entry failed, Entry ID invalid: %d, State: %d, Max ID: %d", EntryID,
-                    State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
-
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
-            }
-        }
-        else
-        {
-            /*send event that we can't start another task right now */
-            CFE_EVS_SendEvent(CS_RECOMPUTE_MEMORY_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Recompute baseline of Memory Entry ID %d failed: child task in use", EntryID);
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
-        }
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CS Enable a specific entry in the Memory table command          */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void CS_EnableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
-{
-    /* command verification variables */
-    CS_Res_EepromMemory_Table_Entry_t *ResultsEntry   = NULL;
-    uint16                             EntryID        = 0;
-    uint16                             State          = CS_STATE_EMPTY;
-
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            EntryID = CmdPtr->Payload.EntryID;
-
-            if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
-                (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
-            {
-                ResultsEntry = &CS_AppData.ResMemoryTblPtr[EntryID];
-
-                ResultsEntry->State = CS_STATE_ENABLED;
-
-                CFE_EVS_SendEvent(CS_ENABLE_MEMORY_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of Memory Entry ID %d is Enabled", EntryID);
-
-                if (CS_AppData.DefMemoryTblPtr[EntryID].State != CS_STATE_EMPTY)
-                {
-                    CS_AppData.DefMemoryTblPtr[EntryID].State = CS_STATE_ENABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.MemResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefMemoryTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_ENABLE_MEMORY_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update memory definition table for entry %d, State: %d", EntryID,
-                                      State);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
-            }
-            else
-            {
-                if (EntryID >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
-                {
-                    State = CS_STATE_UNDEFINED;
-                }
-                else
-                {
-                    State = CS_AppData.ResMemoryTblPtr[EntryID].State;
-                }
-
-                CFE_EVS_SendEvent(CS_ENABLE_MEMORY_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Enable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
-                                  State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
-            }
-        } /* end InProgress if */
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -283,59 +271,59 @@ void CS_EnableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 void CS_DisableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 {
     /* command verification variables */
-    CS_Res_EepromMemory_Table_Entry_t *ResultsEntry   = NULL;
-    uint16                             EntryID        = 0;
-    uint16                             State          = CS_STATE_EMPTY;
+    CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
+    uint16                             EntryID      = 0;
+    uint16                             State        = CS_STATE_EMPTY;
 
-        if (CS_CheckRecomputeOneshot() == false)
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        EntryID = CmdPtr->Payload.EntryID;
+
+        if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
+            (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
         {
-            EntryID = CmdPtr->Payload.EntryID;
+            ResultsEntry = &CS_AppData.ResMemoryTblPtr[EntryID];
 
-            if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
-                (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
+            ResultsEntry->State             = CS_STATE_DISABLED;
+            ResultsEntry->TempChecksumValue = 0;
+            ResultsEntry->ByteOffset        = 0;
+
+            CFE_EVS_SendEvent(CS_DISABLE_MEMORY_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Checksumming of Memory Entry ID %d is Disabled", EntryID);
+
+            if (CS_AppData.DefMemoryTblPtr[EntryID].State != CS_STATE_EMPTY)
             {
-                ResultsEntry = &CS_AppData.ResMemoryTblPtr[EntryID];
-
-                ResultsEntry->State             = CS_STATE_DISABLED;
-                ResultsEntry->TempChecksumValue = 0;
-                ResultsEntry->ByteOffset        = 0;
-
-                CFE_EVS_SendEvent(CS_DISABLE_MEMORY_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of Memory Entry ID %d is Disabled", EntryID);
-
-                if (CS_AppData.DefMemoryTblPtr[EntryID].State != CS_STATE_EMPTY)
-                {
-                    CS_AppData.DefMemoryTblPtr[EntryID].State = CS_STATE_DISABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.MemResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefMemoryTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_DISABLE_MEMORY_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update memory definition table for entry %d, State: %d", EntryID,
-                                      State);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                CS_AppData.DefMemoryTblPtr[EntryID].State = CS_STATE_DISABLED;
+                CS_ResetTablesTblResultEntry(CS_AppData.MemResTablesTblPtr);
+                CFE_TBL_Modified(CS_AppData.DefMemoryTableHandle);
             }
             else
             {
-                if (EntryID >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
-                {
-                    State = CS_STATE_UNDEFINED;
-                }
-                else
-                {
-                    State = CS_AppData.ResMemoryTblPtr[EntryID].State;
-                }
-
-                CFE_EVS_SendEvent(CS_DISABLE_MEMORY_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Disable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
-                                  State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
-
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CFE_EVS_SendEvent(CS_DISABLE_MEMORY_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
+                                  "CS unable to update memory definition table for entry %d, State: %d", EntryID,
+                                  State);
             }
-        } /* end InProgress if */
+
+            CS_AppData.HkPacket.Payload.CmdCounter++;
+        }
+        else
+        {
+            if (EntryID >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
+            {
+                State = CS_STATE_UNDEFINED;
+            }
+            else
+            {
+                State = CS_AppData.ResMemoryTblPtr[EntryID].State;
+            }
+
+            CFE_EVS_SendEvent(CS_DISABLE_MEMORY_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Disable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
+                              State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
+
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        }
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -351,26 +339,27 @@ void CS_GetEntryIDMemoryCmd(const CS_GetEntryIDCmd_t *CmdPtr)
     uint16                             Loop                = 0;
     bool                               EntryFound          = false;
 
-        StartOfResultsTable = CS_AppData.ResMemoryTblPtr;
+    StartOfResultsTable = CS_AppData.ResMemoryTblPtr;
 
-        for (Loop = 0; Loop < CS_MAX_NUM_MEMORY_TABLE_ENTRIES; Loop++)
+    for (Loop = 0; Loop < CS_MAX_NUM_MEMORY_TABLE_ENTRIES; Loop++)
+    {
+        ResultsEntry = &StartOfResultsTable[Loop];
+
+        if ((ResultsEntry->StartAddress <= CmdPtr->Payload.Address) &&
+            CmdPtr->Payload.Address <= (ResultsEntry->StartAddress + ResultsEntry->NumBytesToChecksum) &&
+            ResultsEntry->State != CS_STATE_EMPTY)
         {
-            ResultsEntry = &StartOfResultsTable[Loop];
-
-            if ((ResultsEntry->StartAddress <= CmdPtr->Payload.Address) &&
-                CmdPtr->Payload.Address <= (ResultsEntry->StartAddress + ResultsEntry->NumBytesToChecksum) &&
-                ResultsEntry->State != CS_STATE_EMPTY)
-            {
-                CFE_EVS_SendEvent(CS_GET_ENTRY_ID_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Memory Found Address 0x%08X in Entry ID %d", (unsigned int)(CmdPtr->Payload.Address), Loop);
-                EntryFound = true;
-            }
+            CFE_EVS_SendEvent(CS_GET_ENTRY_ID_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Memory Found Address 0x%08X in Entry ID %d", (unsigned int)(CmdPtr->Payload.Address),
+                              Loop);
+            EntryFound = true;
         }
+    }
 
-        if (EntryFound == false)
-        {
-            CFE_EVS_SendEvent(CS_GET_ENTRY_ID_MEMORY_NOT_FOUND_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Address 0x%08X was not found in Memory table", (unsigned int)(CmdPtr->Payload.Address));
-        }
-        CS_AppData.HkPacket.Payload.CmdCounter++;
+    if (EntryFound == false)
+    {
+        CFE_EVS_SendEvent(CS_GET_ENTRY_ID_MEMORY_NOT_FOUND_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Address 0x%08X was not found in Memory table", (unsigned int)(CmdPtr->Payload.Address));
+    }
+    CS_AppData.HkPacket.Payload.CmdCounter++;
 }

--- a/fsw/src/cs_table_cmds.c
+++ b/fsw/src/cs_table_cmds.c
@@ -46,19 +46,19 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableTablesCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.TablesCSState = CS_STATE_DISABLED;
-            CS_ZeroTablesTempValues();
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        CS_AppData.HkPacket.Payload.TablesCSState = CS_STATE_DISABLED;
+        CS_ZeroTablesTempValues();
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
+        CS_UpdateCDS();
 #endif
 
-            CFE_EVS_SendEvent(CS_DISABLE_TABLES_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of Tables is Disabled");
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+        CFE_EVS_SendEvent(CS_DISABLE_TABLES_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Checksumming of Tables is Disabled");
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -68,18 +68,17 @@ void CS_DisableTablesCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableTablesCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.TablesCSState = CS_STATE_ENABLED;
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        CS_AppData.HkPacket.Payload.TablesCSState = CS_STATE_ENABLED;
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
+        CS_UpdateCDS();
 #endif
 
-            CFE_EVS_SendEvent(CS_ENABLE_TABLES_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of Tables is Enabled");
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+        CFE_EVS_SendEvent(CS_ENABLE_TABLES_INF_EID, CFE_EVS_EventType_INFORMATION, "Checksumming of Tables is Enabled");
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -90,33 +89,32 @@ void CS_EnableTablesCmd(const CS_NoArgsCmd_t *CmdPtr)
 void CS_ReportBaselineTablesCmd(const CS_TableNameCmd_t *CmdPtr)
 {
     CS_Res_Tables_Table_Entry_t *ResultsEntry;
-    uint32                       Baseline;
     char                         Name[CFE_TBL_MAX_FULL_NAME_LEN];
 
-        strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
-        Name[sizeof(Name) - 1] = '\0';
+    strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
+    Name[sizeof(Name) - 1] = '\0';
 
-        if (CS_GetTableResTblEntryByName(&ResultsEntry, Name))
+    if (CS_GetTableResTblEntryByName(&ResultsEntry, Name))
+    {
+        if (ResultsEntry->ComputedYet == true)
         {
-            if (ResultsEntry->ComputedYet == true)
-            {
-                Baseline = ResultsEntry->ComparisonValue;
-                CFE_EVS_SendEvent(CS_BASELINE_TABLES_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Report baseline of table %s is 0x%08X", Name, (unsigned int)Baseline);
-            }
-            else
-            {
-                CFE_EVS_SendEvent(CS_NO_BASELINE_TABLES_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Report baseline of table %s has not been computed yet", Name);
-            }
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            CFE_EVS_SendEvent(CS_BASELINE_TABLES_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Report baseline of table %s is 0x%08X", Name,
+                              (unsigned int)ResultsEntry->ComparisonValue);
         }
         else
         {
-            CFE_EVS_SendEvent(CS_BASELINE_INVALID_NAME_TABLES_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Tables report baseline failed, table %s not found", Name);
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+            CFE_EVS_SendEvent(CS_NO_BASELINE_TABLES_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Report baseline of table %s has not been computed yet", Name);
         }
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
+    else
+    {
+        CFE_EVS_SendEvent(CS_BASELINE_INVALID_NAME_TABLES_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Tables report baseline failed, table %s not found", Name);
+        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -131,53 +129,54 @@ void CS_RecomputeBaselineTablesCmd(const CS_TableNameCmd_t *CmdPtr)
     CS_Res_Tables_Table_Entry_t *ResultsEntry;
     char                         Name[CFE_TBL_MAX_FULL_NAME_LEN];
 
-        if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false && CS_AppData.HkPacket.Payload.OneShotInProgress == false)
+    strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
+    Name[sizeof(Name) - 1] = '\0';
+
+    if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false &&
+        CS_AppData.HkPacket.Payload.OneShotInProgress == false)
+    {
+        /* make sure the entry is a valid number and is defined in the table */
+        if (CS_GetTableResTblEntryByName(&ResultsEntry, Name))
         {
-            strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
-            Name[sizeof(Name) - 1] = '\0';
+            /* There is no child task running right now, we can use it*/
+            CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
-            /* make sure the entry is a valid number and is defined in the table */
-            if (CS_GetTableResTblEntryByName(&ResultsEntry, Name))
+            /* fill in child task variables */
+            CS_AppData.ChildTaskTable = CS_TABLES_TABLE;
+
+            CS_AppData.RecomputeTablesEntryPtr = ResultsEntry;
+
+            Status = CFE_ES_CreateChildTask(&ChildTaskID, CS_RECOMP_TABLES_TASK_NAME, CS_RecomputeTablesChildTask, NULL,
+                                            CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
+            if (Status == CFE_SUCCESS)
             {
-                /* There is no child task running right now, we can use it*/
-                CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
-
-                /* fill in child task variables */
-                CS_AppData.ChildTaskTable = CS_TABLES_TABLE;
-
-                CS_AppData.RecomputeTablesEntryPtr = ResultsEntry;
-
-                Status = CFE_ES_CreateChildTask(&ChildTaskID, CS_RECOMP_TABLES_TASK_NAME, CS_RecomputeTablesChildTask,
-                                                NULL, CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
-                if (Status == CFE_SUCCESS)
-                {
-                    CFE_EVS_SendEvent(CS_RECOMPUTE_TABLES_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "Recompute baseline of table %s started", Name);
-                    CS_AppData.HkPacket.Payload.CmdCounter++;
-                }
-                else /* child task creation failed */
-                {
-                    CFE_EVS_SendEvent(CS_RECOMPUTE_TABLES_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
-                                      "Recompute baseline of table %s failed, CFE_ES_CreateChildTask returned: 0x%08X",
-                                      Name, (unsigned int)Status);
-                    CS_AppData.HkPacket.Payload.CmdErrCounter++;
-                    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
-                }
+                CFE_EVS_SendEvent(CS_RECOMPUTE_TABLES_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
+                                  "Recompute baseline of table %s started", Name);
+                CS_AppData.HkPacket.Payload.CmdCounter++;
             }
-            else
+            else /* child task creation failed */
             {
-                CFE_EVS_SendEvent(CS_RECOMPUTE_UNKNOWN_NAME_TABLES_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Tables recompute baseline failed, table %s not found", Name);
+                CFE_EVS_SendEvent(CS_RECOMPUTE_TABLES_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
+                                  "Recompute baseline of table %s failed, CFE_ES_CreateChildTask returned: 0x%08X",
+                                  Name, (unsigned int)Status);
                 CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
             }
         }
         else
         {
-            /*send event that we can't start another task right now */
-            CFE_EVS_SendEvent(CS_RECOMPUTE_TABLES_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Tables recompute baseline for table %s failed: child task in use", Name);
+            CFE_EVS_SendEvent(CS_RECOMPUTE_UNKNOWN_NAME_TABLES_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Tables recompute baseline failed, table %s not found", Name);
             CS_AppData.HkPacket.Payload.CmdErrCounter++;
         }
+    }
+    else
+    {
+        /*send event that we can't start another task right now */
+        CFE_EVS_SendEvent(CS_RECOMPUTE_TABLES_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Tables recompute baseline for table %s failed: child task in use", Name);
+        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -191,41 +190,41 @@ void CS_DisableNameTablesCmd(const CS_TableNameCmd_t *CmdPtr)
     CS_Def_Tables_Table_Entry_t *DefinitionEntry;
     char                         Name[CFE_TBL_MAX_FULL_NAME_LEN];
 
-        if (CS_CheckRecomputeOneshot() == false)
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
+        Name[sizeof(Name) - 1] = '\0';
+
+        if (CS_GetTableResTblEntryByName(&ResultsEntry, Name))
         {
-            strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
-            Name[sizeof(Name) - 1] = '\0';
+            ResultsEntry->State             = CS_STATE_DISABLED;
+            ResultsEntry->TempChecksumValue = 0;
+            ResultsEntry->ByteOffset        = 0;
 
-            if (CS_GetTableResTblEntryByName(&ResultsEntry, Name))
+            CFE_EVS_SendEvent(CS_DISABLE_TABLES_NAME_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Checksumming of table %s is Disabled", Name);
+
+            if (CS_GetTableDefTblEntryByName(&DefinitionEntry, Name))
             {
-                ResultsEntry->State             = CS_STATE_DISABLED;
-                ResultsEntry->TempChecksumValue = 0;
-                ResultsEntry->ByteOffset        = 0;
-
-                CFE_EVS_SendEvent(CS_DISABLE_TABLES_NAME_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of table %s is Disabled", Name);
-
-                if (CS_GetTableDefTblEntryByName(&DefinitionEntry, Name))
-                {
-                    DefinitionEntry->State = CS_STATE_DISABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.TblResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefTablesTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_DISABLE_TABLE_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update tables definition table for entry %s", Name);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                DefinitionEntry->State = CS_STATE_DISABLED;
+                CS_ResetTablesTblResultEntry(CS_AppData.TblResTablesTblPtr);
+                CFE_TBL_Modified(CS_AppData.DefTablesTableHandle);
             }
             else
             {
-                CFE_EVS_SendEvent(CS_DISABLE_TABLES_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Tables disable table command failed, table %s not found", Name);
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CFE_EVS_SendEvent(CS_DISABLE_TABLE_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
+                                  "CS unable to update tables definition table for entry %s", Name);
             }
-        } /* end InProgress if */
+
+            CS_AppData.HkPacket.Payload.CmdCounter++;
+        }
+        else
+        {
+            CFE_EVS_SendEvent(CS_DISABLE_TABLES_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Tables disable table command failed, table %s not found", Name);
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        }
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -239,37 +238,37 @@ void CS_EnableNameTablesCmd(const CS_TableNameCmd_t *CmdPtr)
     CS_Def_Tables_Table_Entry_t *DefinitionEntry;
     char                         Name[CFE_TBL_MAX_FULL_NAME_LEN];
 
-        if (CS_CheckRecomputeOneshot() == false)
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
+        Name[sizeof(Name) - 1] = '\0';
+
+        if (CS_GetTableResTblEntryByName(&ResultsEntry, Name))
         {
-            strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
-            Name[sizeof(Name) - 1] = '\0';
+            ResultsEntry->State = CS_STATE_ENABLED;
 
-            if (CS_GetTableResTblEntryByName(&ResultsEntry, Name))
+            CFE_EVS_SendEvent(CS_ENABLE_TABLES_NAME_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Checksumming of table %s is Enabled", Name);
+
+            if (CS_GetTableDefTblEntryByName(&DefinitionEntry, Name))
             {
-                ResultsEntry->State = CS_STATE_ENABLED;
-
-                CFE_EVS_SendEvent(CS_ENABLE_TABLES_NAME_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of table %s is Enabled", Name);
-
-                if (CS_GetTableDefTblEntryByName(&DefinitionEntry, Name))
-                {
-                    DefinitionEntry->State = CS_STATE_ENABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.TblResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefTablesTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_ENABLE_TABLE_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update tables definition table for entry %s", Name);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                DefinitionEntry->State = CS_STATE_ENABLED;
+                CS_ResetTablesTblResultEntry(CS_AppData.TblResTablesTblPtr);
+                CFE_TBL_Modified(CS_AppData.DefTablesTableHandle);
             }
             else
             {
-                CFE_EVS_SendEvent(CS_ENABLE_TABLES_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Tables enable table command failed, table %s not found", Name);
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CFE_EVS_SendEvent(CS_ENABLE_TABLE_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
+                                  "CS unable to update tables definition table for entry %s", Name);
             }
-        } /* end InProgress if */
+
+            CS_AppData.HkPacket.Payload.CmdCounter++;
+        }
+        else
+        {
+            CFE_EVS_SendEvent(CS_ENABLE_TABLES_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Tables enable table command failed, table %s not found", Name);
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        }
+    }
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #99
  - Moved up the `strncpy` to fill in the `Name` variable before the `if` block, in order to ensure it is filled in for the final error event as well.

Minor changes:
  - Formatting applied to remove incorrect indentation in the files being edited
  - `Baseline` variable in `CS_ReportBaselineAppCmd`, `CS_ReportBaselineEntryIDEepromCmd`, `CS_ReportBaselineEntryIDMemoryCmd` and `CS_ReportBaselineTablesCmd` only used once in these functions - simplifies to use the value directly and avoid the extra variable (happy to separate out these changes into a separate PR if more suitable).
    - In `CS_ReportBaselineEntryIDEepromCmd` & `CS_ReportBaselineEntryIDEepromCmd` two additional simplifications look reasonable:
      - `ResultsEntry` can be removed
      - the assignment of `CS_STATE_UNDEFINED` to `State` can be done at initialization, simplifying the `if`/`else` in the error condition

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
`Name` variable will be filled in in all use-cases.
Unnecessary variables are removed, which simplifies the code and eases maintenance/testing.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt