### PR TITLE
Fix #101, Remove redundant assignments of `RecomputeInProgress`

### DIFF
--- a/fsw/inc/cs_msgdefs.h
+++ b/fsw/inc/cs_msgdefs.h
@@ -1459,7 +1459,7 @@
 /**\}*/
 
 /**
- * \name CS Checkum States
+ * \name CS Checksum States
  * \{
  */
 #define CS_STATE_EMPTY     0x00 /**< \brief Entry unused */

--- a/fsw/src/cs_app.c
+++ b/fsw/src/cs_app.c
@@ -267,8 +267,6 @@ void CS_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
     CFE_SB_MsgId_t MessageID   = CFE_SB_INVALID_MSG_ID;
     uint16         CommandCode = 0;
 
-    CFE_MSG_GetMsgId(&BufPtr->Msg, &MessageID);
-
     CFE_MSG_GetFcnCode(&BufPtr->Msg, &CommandCode);
 
     switch (CommandCode)
@@ -561,6 +559,8 @@ void CS_ProcessCmd(const CFE_SB_Buffer_t *BufPtr)
             break;
 
         default:
+            CFE_MSG_GetMsgId(&BufPtr->Msg, &MessageID);
+
             CFE_EVS_SendEvent(CS_CC_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Invalid ground command code: ID = 0x%08lX, CC = %d",
                               (unsigned long)CFE_SB_MsgIdToValue(MessageID), CommandCode);

--- a/fsw/src/cs_cmds.c
+++ b/fsw/src/cs_cmds.c
@@ -456,7 +456,6 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
             CS_AppData.HkPacket.Payload.OneShotInProgress == false)
         {
             /* There is no child task running right now, we can use it*/
-            CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
             CS_AppData.HkPacket.Payload.OneShotInProgress   = true;
 
             CS_AppData.HkPacket.Payload.LastOneShotAddress = CmdPtr->Payload.Address;
@@ -486,7 +485,7 @@ void CS_OneShotCmd(const CS_OneShotCmd_t *CmdPtr)
             else /* child task creation failed */
             {
                 CFE_EVS_SendEvent(CS_ONESHOT_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "OneShot checkum failed, CFE_ES_CreateChildTask returned: 0x%08X",
+                                  "OneShot checksum failed, CFE_ES_CreateChildTask returned: 0x%08X",
                                   (unsigned int)Status);
 
                 CS_AppData.HkPacket.Payload.CmdErrCounter++;
@@ -531,7 +530,6 @@ void CS_CancelOneShotCmd(const CS_NoArgsCmd_t *CmdPtr)
         if (Status == CFE_SUCCESS)
         {
             CS_AppData.ChildTaskID                          = CFE_ES_TASKID_UNDEFINED;
-            CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
             CS_AppData.HkPacket.Payload.OneShotInProgress   = false;
             CS_AppData.HkPacket.Payload.CmdCounter++;
             CFE_EVS_SendEvent(CS_ONESHOT_CANCELLED_INF_EID, CFE_EVS_EventType_INFORMATION,

--- a/unit-test/cs_cmds_tests.c
+++ b/unit-test/cs_cmds_tests.c
@@ -1275,7 +1275,7 @@ void CS_OneShotCmd_Test_CreateChildTaskError(void)
     memset(&CmdPacket, 0, sizeof(CmdPacket));
 
     snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH,
-             "OneShot checkum failed, CFE_ES_CreateChildTask returned: 0x%%08X");
+             "OneShot checksum failed, CFE_ES_CreateChildTask returned: 0x%%08X");
 
     CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #101 
    - redundant assignments of `CS_AppData.HkPacket.Payload.RecomputeInProgress = false` removed

Minor fix:
	- in `CS_ProcessCmd()`, `MessageID` is only used in the default case event message, so moved the call to `CFE_MSG_GetMsgId` to there, to avoid being called every time for no reason

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt