### PR TITLE
Fix #111, `CS_Enable/Disable/Get_EntryID` functions clean-up

### DIFF
--- a/fsw/src/cs_memory_cmds.c
+++ b/fsw/src/cs_memory_cmds.c
@@ -48,20 +48,20 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_DISABLED;
-            CS_ZeroMemoryTempValues();
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_DISABLED;
+        CS_ZeroMemoryTempValues();
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
+        CS_UpdateCDS();
 #endif
 
-            CFE_EVS_SendEvent(CS_DISABLE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of Memory is Disabled");
+        CFE_EVS_SendEvent(CS_DISABLE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Checksumming of Memory is Disabled");
 
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -71,19 +71,18 @@ void CS_DisableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_ENABLED;
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_ENABLED;
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
+        CS_UpdateCDS();
 #endif
 
-            CFE_EVS_SendEvent(CS_ENABLE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of Memory is Enabled");
+        CFE_EVS_SendEvent(CS_ENABLE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION, "Checksumming of Memory is Enabled");
 
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -94,31 +93,97 @@ void CS_EnableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
 void CS_ReportBaselineEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 {
     /* command verification variables */
-    CS_Res_EepromMemory_Table_Entry_t *ResultsEntry   = NULL;
-    uint32                             Baseline       = 0;
-    uint16                             EntryID        = 0;
-    uint16                             State          = CS_STATE_EMPTY;
+    CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
+    uint32                             Baseline     = 0;
+    uint16                             EntryID      = 0;
+    uint16                             State        = CS_STATE_EMPTY;
 
-        EntryID = CmdPtr->Payload.EntryID;
+    EntryID = CmdPtr->Payload.EntryID;
 
+    if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) && (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
+    {
+        ResultsEntry = &CS_AppData.ResMemoryTblPtr[EntryID];
+
+        if (ResultsEntry->ComputedYet == true)
+        {
+            Baseline = ResultsEntry->ComparisonValue;
+
+            CFE_EVS_SendEvent(CS_BASELINE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Report baseline of Memory Entry %d is 0x%08X", EntryID, (unsigned int)Baseline);
+        }
+        else
+        {
+            CFE_EVS_SendEvent(CS_NO_BASELINE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Report baseline of Memory Entry %d has not been computed yet", EntryID);
+        }
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
+    else
+    {
+        if (EntryID >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
+        {
+            State = CS_STATE_UNDEFINED;
+        }
+        else
+        {
+            State = CS_AppData.ResMemoryTblPtr[EntryID].State;
+        }
+
+        CFE_EVS_SendEvent(CS_BASELINE_INVALID_ENTRY_MEMORY_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Memory report baseline failed, Entry ID invalid: %d, State: %d Max ID: %d", EntryID, State,
+                          (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
+        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CS Recompute the baseline of an entry in the Memory table cmd   */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
+{
+    /* command verification variables */
+    CFE_ES_TaskId_t ChildTaskID = CFE_ES_TASKID_UNDEFINED;
+    CFE_Status_t    Status      = CS_ERROR;
+    uint16          EntryID     = 0;
+    uint16          State       = CS_STATE_EMPTY;
+
+    EntryID = CmdPtr->Payload.EntryID;
+
+    if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false &&
+        CS_AppData.HkPacket.Payload.OneShotInProgress == false)
+    {
+        /* make sure the entry is a valid number and is defined in the table */
         if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
             (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
         {
-            ResultsEntry = &CS_AppData.ResMemoryTblPtr[EntryID];
+            /* There is no child task running right now, we can use it*/
+            CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
 
-            if (ResultsEntry->ComputedYet == true)
-            {
-                Baseline = ResultsEntry->ComparisonValue;
+            /* fill in child task variables */
+            CS_AppData.ChildTaskTable   = CS_MEMORY_TABLE;
+            CS_AppData.ChildTaskEntryID = EntryID;
 
-                CFE_EVS_SendEvent(CS_BASELINE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Report baseline of Memory Entry %d is 0x%08X", EntryID, (unsigned int)Baseline);
-            }
-            else
+            CS_AppData.RecomputeEepromMemoryEntryPtr = &CS_AppData.ResMemoryTblPtr[EntryID];
+
+            Status = CFE_ES_CreateChildTask(&ChildTaskID, CS_RECOMP_MEMORY_TASK_NAME, CS_RecomputeEepromMemoryChildTask,
+                                            NULL, CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
+            if (Status == CFE_SUCCESS)
             {
-                CFE_EVS_SendEvent(CS_NO_BASELINE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Report baseline of Memory Entry %d has not been computed yet", EntryID);
+                CFE_EVS_SendEvent(CS_RECOMPUTE_MEMORY_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
+                                  "Recompute baseline of Memory Entry ID %d started", EntryID);
+                CS_AppData.HkPacket.Payload.CmdCounter++;
             }
-            CS_AppData.HkPacket.Payload.CmdCounter++;
+            else /* child task creation failed */
+            {
+                CFE_EVS_SendEvent(
+                    CS_RECOMPUTE_MEMORY_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
+                    "Recompute baseline of Memory Entry ID %d failed, ES_CreateChildTask returned:  0x%08X", EntryID,
+                    (unsigned int)Status);
+                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
+            }
         }
         else
         {
@@ -131,88 +196,20 @@ void CS_ReportBaselineEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
                 State = CS_AppData.ResMemoryTblPtr[EntryID].State;
             }
 
-            CFE_EVS_SendEvent(CS_BASELINE_INVALID_ENTRY_MEMORY_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Memory report baseline failed, Entry ID invalid: %d, State: %d Max ID: %d", EntryID,
-                              State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
+            CFE_EVS_SendEvent(CS_RECOMPUTE_INVALID_ENTRY_MEMORY_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Memory recompute baseline of entry failed, Entry ID invalid: %d, State: %d, Max ID: %d",
+                              EntryID, State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
+
             CS_AppData.HkPacket.Payload.CmdErrCounter++;
         }
-}
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CS Recompute the baseline of an entry in the Memory table cmd   */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
-{
-    /* command verification variables */
-    CFE_ES_TaskId_t ChildTaskID    = CFE_ES_TASKID_UNDEFINED;
-    CFE_Status_t    Status         = CS_ERROR;
-    uint16          EntryID        = 0;
-    uint16          State          = CS_STATE_EMPTY;
-
-        EntryID = CmdPtr->Payload.EntryID;
-
-        if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false && CS_AppData.HkPacket.Payload.OneShotInProgress == false)
-        {
-            /* make sure the entry is a valid number and is defined in the table */
-            if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
-                (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
-            {
-                /* There is no child task running right now, we can use it*/
-                CS_AppData.HkPacket.Payload.RecomputeInProgress = true;
-
-                /* fill in child task variables */
-                CS_AppData.ChildTaskTable   = CS_MEMORY_TABLE;
-                CS_AppData.ChildTaskEntryID = EntryID;
-
-                CS_AppData.RecomputeEepromMemoryEntryPtr = &CS_AppData.ResMemoryTblPtr[EntryID];
-
-                Status =
-                    CFE_ES_CreateChildTask(&ChildTaskID, CS_RECOMP_MEMORY_TASK_NAME, CS_RecomputeEepromMemoryChildTask,
-                                           NULL, CFE_PLATFORM_ES_DEFAULT_STACK_SIZE, CS_CHILD_TASK_PRIORITY, 0);
-                if (Status == CFE_SUCCESS)
-                {
-                    CFE_EVS_SendEvent(CS_RECOMPUTE_MEMORY_STARTED_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "Recompute baseline of Memory Entry ID %d started", EntryID);
-                    CS_AppData.HkPacket.Payload.CmdCounter++;
-                }
-                else /* child task creation failed */
-                {
-                    CFE_EVS_SendEvent(
-                        CS_RECOMPUTE_MEMORY_CREATE_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
-                        "Recompute baseline of Memory Entry ID %d failed, ES_CreateChildTask returned:  0x%08X",
-                        EntryID, (unsigned int)Status);
-                    CS_AppData.HkPacket.Payload.CmdErrCounter++;
-                    CS_AppData.HkPacket.Payload.RecomputeInProgress = false;
-                }
-            }
-            else
-            {
-                if (EntryID >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
-                {
-                    State = CS_STATE_UNDEFINED;
-                }
-                else
-                {
-                    State = CS_AppData.ResMemoryTblPtr[EntryID].State;
-                }
-
-                CFE_EVS_SendEvent(
-                    CS_RECOMPUTE_INVALID_ENTRY_MEMORY_ERR_EID, CFE_EVS_EventType_ERROR,
-                    "Memory recompute baseline of entry failed, Entry ID invalid: %d, State: %d, Max ID: %d", EntryID,
-                    State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
-
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
-            }
-        }
-        else
-        {
-            /*send event that we can't start another task right now */
-            CFE_EVS_SendEvent(CS_RECOMPUTE_MEMORY_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Recompute baseline of Memory Entry ID %d failed: child task in use", EntryID);
-            CS_AppData.HkPacket.Payload.CmdErrCounter++;
-        }
+    }
+    else
+    {
+        /*send event that we can't start another task right now */
+        CFE_EVS_SendEvent(CS_RECOMPUTE_MEMORY_CHDTASK_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Recompute baseline of Memory Entry ID %d failed: child task in use", EntryID);
+        CS_AppData.HkPacket.Payload.CmdErrCounter++;
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -223,56 +220,49 @@ void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 void CS_EnableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 {
     /* command verification variables */
-    CS_Res_EepromMemory_Table_Entry_t *ResultsEntry   = NULL;
-    uint16                             EntryID        = 0;
-    uint16                             State          = CS_STATE_EMPTY;
+    uint16 EntryID = 0;
+    uint16 State   = CS_STATE_UNDEFINED;
 
-        if (CS_CheckRecomputeOneshot() == false)
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        EntryID = CmdPtr->Payload.EntryID;
+
+        if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
+            (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
         {
-            EntryID = CmdPtr->Payload.EntryID;
+            CS_AppData.ResMemoryTblPtr[EntryID].State = CS_STATE_ENABLED;
 
-            if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
-                (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
+            CFE_EVS_SendEvent(CS_ENABLE_MEMORY_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Checksumming of Memory Entry ID %d is Enabled", EntryID);
+
+            if (CS_AppData.DefMemoryTblPtr[EntryID].State != CS_STATE_EMPTY)
             {
-                ResultsEntry = &CS_AppData.ResMemoryTblPtr[EntryID];
-
-                ResultsEntry->State = CS_STATE_ENABLED;
-
-                CFE_EVS_SendEvent(CS_ENABLE_MEMORY_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of Memory Entry ID %d is Enabled", EntryID);
-
-                if (CS_AppData.DefMemoryTblPtr[EntryID].State != CS_STATE_EMPTY)
-                {
-                    CS_AppData.DefMemoryTblPtr[EntryID].State = CS_STATE_ENABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.MemResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefMemoryTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_ENABLE_MEMORY_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update memory definition table for entry %d, State: %d", EntryID,
-                                      State);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                CS_AppData.DefMemoryTblPtr[EntryID].State = CS_STATE_ENABLED;
+                CS_ResetTablesTblResultEntry(CS_AppData.MemResTablesTblPtr);
+                CFE_TBL_Modified(CS_AppData.DefMemoryTableHandle);
             }
             else
             {
-                if (EntryID >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
-                {
-                    State = CS_STATE_UNDEFINED;
-                }
-                else
-                {
-                    State = CS_AppData.ResMemoryTblPtr[EntryID].State;
-                }
-
-                CFE_EVS_SendEvent(CS_ENABLE_MEMORY_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Enable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
-                                  State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CFE_EVS_SendEvent(CS_ENABLE_MEMORY_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
+                                  "CS unable to update memory definition table for entry %d, State: %d", EntryID,
+                                  CS_AppData.DefMemoryTblPtr[EntryID].State);
             }
-        } /* end InProgress if */
+
+            CS_AppData.HkPacket.Payload.CmdCounter++;
+        }
+        else
+        {
+            if (EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
+            {
+                State = CS_AppData.ResMemoryTblPtr[EntryID].State;
+            }
+
+            CFE_EVS_SendEvent(CS_ENABLE_MEMORY_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Enable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
+                              State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        }
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -283,59 +273,52 @@ void CS_EnableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 void CS_DisableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 {
     /* command verification variables */
-    CS_Res_EepromMemory_Table_Entry_t *ResultsEntry   = NULL;
-    uint16                             EntryID        = 0;
-    uint16                             State          = CS_STATE_EMPTY;
+    uint16 EntryID = 0;
+    uint16 State   = CS_STATE_UNDEFINED;
 
-        if (CS_CheckRecomputeOneshot() == false)
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        EntryID = CmdPtr->Payload.EntryID;
+
+        if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
+            (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
         {
-            EntryID = CmdPtr->Payload.EntryID;
+            CS_AppData.ResMemoryTblPtr[EntryID].State             = CS_STATE_DISABLED;
+            CS_AppData.ResMemoryTblPtr[EntryID].TempChecksumValue = 0;
+            CS_AppData.ResMemoryTblPtr[EntryID].ByteOffset        = 0;
 
-            if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
-                (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
+            CFE_EVS_SendEvent(CS_DISABLE_MEMORY_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Checksumming of Memory Entry ID %d is Disabled", EntryID);
+
+            if (CS_AppData.DefMemoryTblPtr[EntryID].State != CS_STATE_EMPTY)
             {
-                ResultsEntry = &CS_AppData.ResMemoryTblPtr[EntryID];
-
-                ResultsEntry->State             = CS_STATE_DISABLED;
-                ResultsEntry->TempChecksumValue = 0;
-                ResultsEntry->ByteOffset        = 0;
-
-                CFE_EVS_SendEvent(CS_DISABLE_MEMORY_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of Memory Entry ID %d is Disabled", EntryID);
-
-                if (CS_AppData.DefMemoryTblPtr[EntryID].State != CS_STATE_EMPTY)
-                {
-                    CS_AppData.DefMemoryTblPtr[EntryID].State = CS_STATE_DISABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.MemResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefMemoryTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_DISABLE_MEMORY_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update memory definition table for entry %d, State: %d", EntryID,
-                                      State);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+                CS_AppData.DefMemoryTblPtr[EntryID].State = CS_STATE_DISABLED;
+                CS_ResetTablesTblResultEntry(CS_AppData.MemResTablesTblPtr);
+                CFE_TBL_Modified(CS_AppData.DefMemoryTableHandle);
             }
             else
             {
-                if (EntryID >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
-                {
-                    State = CS_STATE_UNDEFINED;
-                }
-                else
-                {
-                    State = CS_AppData.ResMemoryTblPtr[EntryID].State;
-                }
-
-                CFE_EVS_SendEvent(CS_DISABLE_MEMORY_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Disable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
-                                  State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
-
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CFE_EVS_SendEvent(CS_DISABLE_MEMORY_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
+                                  "CS unable to update memory definition table for entry %d, State: %d", EntryID,
+                                  CS_AppData.DefMemoryTblPtr[EntryID].State);
             }
-        } /* end InProgress if */
+
+            CS_AppData.HkPacket.Payload.CmdCounter++;
+        }
+        else
+        {
+            if (EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
+            {
+                State = CS_AppData.ResMemoryTblPtr[EntryID].State;
+            }
+
+            CFE_EVS_SendEvent(CS_DISABLE_MEMORY_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Disable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
+                              State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
+
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        }
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -346,31 +329,26 @@ void CS_DisableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 void CS_GetEntryIDMemoryCmd(const CS_GetEntryIDCmd_t *CmdPtr)
 {
     /* command verification variables */
-    CS_Res_EepromMemory_Table_Entry_t *StartOfResultsTable = NULL;
-    CS_Res_EepromMemory_Table_Entry_t *ResultsEntry        = NULL;
-    uint16                             Loop                = 0;
-    bool                               EntryFound          = false;
+    uint16 i          = 0;
+    bool   EntryFound = false;
 
-        StartOfResultsTable = CS_AppData.ResMemoryTblPtr;
-
-        for (Loop = 0; Loop < CS_MAX_NUM_MEMORY_TABLE_ENTRIES; Loop++)
+    for (i = 0; i < CS_MAX_NUM_MEMORY_TABLE_ENTRIES; i++)
+    {
+        if ((CS_AppData.ResMemoryTblPtr[i].StartAddress <= CmdPtr->Payload.Address) &&
+            CmdPtr->Payload.Address <=
+                (CS_AppData.ResMemoryTblPtr[i].StartAddress + CS_AppData.ResMemoryTblPtr[i].NumBytesToChecksum) &&
+            CS_AppData.ResMemoryTblPtr[i].State != CS_STATE_EMPTY)
         {
-            ResultsEntry = &StartOfResultsTable[Loop];
-
-            if ((ResultsEntry->StartAddress <= CmdPtr->Payload.Address) &&
-                CmdPtr->Payload.Address <= (ResultsEntry->StartAddress + ResultsEntry->NumBytesToChecksum) &&
-                ResultsEntry->State != CS_STATE_EMPTY)
-            {
-                CFE_EVS_SendEvent(CS_GET_ENTRY_ID_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Memory Found Address 0x%08X in Entry ID %d", (unsigned int)(CmdPtr->Payload.Address), Loop);
-                EntryFound = true;
-            }
+            CFE_EVS_SendEvent(CS_GET_ENTRY_ID_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Memory Found Address 0x%08X in Entry ID %d", (unsigned int)(CmdPtr->Payload.Address), i);
+            EntryFound = true;
         }
+    }
 
-        if (EntryFound == false)
-        {
-            CFE_EVS_SendEvent(CS_GET_ENTRY_ID_MEMORY_NOT_FOUND_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Address 0x%08X was not found in Memory table", (unsigned int)(CmdPtr->Payload.Address));
-        }
-        CS_AppData.HkPacket.Payload.CmdCounter++;
+    if (EntryFound == false)
+    {
+        CFE_EVS_SendEvent(CS_GET_ENTRY_ID_MEMORY_NOT_FOUND_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Address 0x%08X was not found in Memory table", (unsigned int)(CmdPtr->Payload.Address));
+    }
+    CS_AppData.HkPacket.Payload.CmdCounter++;
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #111

	`CS_EnableEntryIDMemoryCmd`
	- remove unessesary variable `ResultsEntry`
	- local `State` variable used by mistake in `CS_ENABLE_MEMORY_DEF_EMPTY_DBG_EID` event
	- `State` can be initialized to `CS_STATE_UNDEFINED` instead of `CS_STATE_EMPTY` which simplifies the `if`/`else` block before the `CS_ENABLE_MEMORY_INVALID_ENTRY_ERR_EID` event

	`CS_DisableEntryIDMemoryCmd`
	- remove unnecessary variable `ResultsEntry`
	- local `State` variable used by mistake in `CS_DISABLE_MEMORY_DEF_EMPTY_DBG_EID` event
	- `State` can be initialized to `CS_STATE_UNDEFINED` instead of `CS_STATE_EMPTY` which simplifies the `if`/`else` block before the `CS_DISABLE_MEMORY_INVALID_ENTRY_ERR_EID` event
	
	`CS_GetEntryIDMemoryCmd`
	- remove unnecessary variables `ResultsEntry` and `StartOfResultsTable`


**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Functions are simplified without extraneous intermediate variables, and easier to test.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt