### PR TITLE
Fix #115, Clean up minor bugs in the CS unit tests

### DIFF
--- a/fsw/src/cs_utils.c
+++ b/fsw/src/cs_utils.c
@@ -105,7 +105,7 @@ void CS_ZeroAppTempValues(void)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Zero out the temp chcksum values ofthe cFE core              */
+/* CS Zero out the temp chcksum values of the cFE core             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_ZeroCfeCoreTempValues(void)

--- a/unit-test/cs_app_cmds_tests.c
+++ b/unit-test/cs_app_cmds_tests.c
@@ -152,8 +152,6 @@ void CS_EnableAppCmd_Test(void)
 
     UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
-
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
@@ -254,8 +252,6 @@ void CS_ReportBaselineAppCmd_Test_NoBaseline(void)
 
     UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
-
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
@@ -315,11 +311,12 @@ void CS_ReportBaselineAppCmd_Test_OneShot(void)
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
-    /* Execute the function being tested */
-    CS_RecomputeBaselineAppCmd(&CmdPacket);
     UT_SetDeferredRetcode(UT_KEY(CS_GetAppResTblEntryByName), 1, true);
     UT_SetHandlerFunction(UT_KEY(CS_GetAppResTblEntryByName), CS_APP_CMDS_TEST_CS_GetAppResTblEntryByNameHandler1,
                           NULL);
+
+    /* Execute the function being tested */
+    CS_RecomputeBaselineAppCmd(&CmdPacket);
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_APP_CHDTASK_ERR_EID);
@@ -374,8 +371,6 @@ void CS_RecomputeBaselineAppCmd_Test_Nominal(void)
     strCmpResult = strncmp(ExpectedEventString, context_CFE_EVS_SendEvent[0].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[0].Spec);
-
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
@@ -487,11 +482,12 @@ void CS_RecomputeBaselineAppCmd_Test_RecomputeInProgress(void)
 
     UT_SetDeferredRetcode(UT_KEY(CS_VerifyCmdLength), 1, true);
 
-    /* Execute the function being tested */
-    CS_RecomputeBaselineAppCmd(&CmdPacket);
     UT_SetDeferredRetcode(UT_KEY(CS_GetAppResTblEntryByName), 1, true);
     UT_SetHandlerFunction(UT_KEY(CS_GetAppResTblEntryByName), CS_APP_CMDS_TEST_CS_GetAppResTblEntryByNameHandler1,
                           NULL);
+
+    /* Execute the function being tested */
+    CS_RecomputeBaselineAppCmd(&CmdPacket);
 
     /* Verify results */
     UtAssert_INT32_EQ(context_CFE_EVS_SendEvent[0].EventID, CS_RECOMPUTE_APP_CHDTASK_ERR_EID);
@@ -549,8 +545,6 @@ void CS_DisableNameAppCmd_Test_Nominal(void)
 
     UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
-
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
@@ -602,8 +596,6 @@ void CS_DisableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
         strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
@@ -711,8 +703,6 @@ void CS_EnableNameAppCmd_Test_Nominal(void)
 
     UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
-
     call_count_CFE_EVS_SendEvent = UT_GetStubCount(UT_KEY(CFE_EVS_SendEvent));
 
     UtAssert_True(call_count_CFE_EVS_SendEvent == 1, "CFE_EVS_SendEvent was called %u time(s), expected 1",
@@ -764,8 +754,6 @@ void CS_EnableNameAppCmd_Test_UpdateAppsDefinitionTableError(void)
         strncmp(ExpectedEventString[1], context_CFE_EVS_SendEvent[1].Spec, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH);
 
     UtAssert_True(strCmpResult == 0, "Event string matched expected result, '%s'", context_CFE_EVS_SendEvent[1].Spec);
-
-    UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 
     UtAssert_True(CS_AppData.HkPacket.Payload.CmdCounter == 1, "CS_AppData.HkPacket.Payload.CmdCounter == 1");
 

--- a/unit-test/cs_app_tests.c
+++ b/unit-test/cs_app_tests.c
@@ -411,9 +411,6 @@ void CS_AppMain_Test_RcvNullBufPtr(void)
     /* Set to make CS_AppPipe return -1 */
     UT_SetDeferredRetcode(UT_KEY(CS_HandleRoutineTableUpdates), 1, -1);
 
-    /* Set to satisfy subsequent condition "BufPtr == NULL" */
-    UT_SetDataBuffer(UT_KEY(CFE_SB_ReceiveBuffer), Packet, sizeof(CS_NoArgsCmd_t), false);
-
     /* Execute the function being tested */
     CS_AppMain();
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #115 
  - fix typos
  - move `UT_Set*` functions to before the test function is called
  - remove duplicate (redundant) asserts

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Tests corrected.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt