### PR TITLE
Fix #17, consolidate common logic in enable/disable commands

### DIFF
--- a/fsw/inc/cs_events.h
+++ b/fsw/inc/cs_events.h
@@ -513,7 +513,7 @@
  *  \par Cause:
  *
  *  This event message is issued when a report baseline
- *  for the EEPROM entry specifiedcommand has been received
+ *  for the EEPROM entry specified command has been received
  *  and there is a baseline computed to report.
  */
 #define CS_BASELINE_EEPROM_INF_EID 39
@@ -603,7 +603,7 @@
  *
  *  \par Type: INFORMATION
  *
- *  \par Cause:invalid
+ *  \par Cause:
  *
  *  This event message is issued when an enable EEPROM Entry ID
  *  command is accepted.
@@ -712,7 +712,7 @@
  *  \par Cause:
  *
  *  This event message is issued when a report baseline
- *  for the Memory entry specifiedcommand has been received
+ *  for the Memory entry specified command has been received
  *  and there is a baseline computed to report.
  */
 #define CS_BASELINE_MEMORY_INF_EID 54
@@ -912,7 +912,7 @@
  *  \par Cause:
  *
  *  This event message is issued when a report baseline
- *  for the Tables entry specifiedcommand has been received
+ *  for the Tables entry specified command has been received
  *  and there is a baseline computed to report.
  */
 #define CS_BASELINE_TABLES_INF_EID 69
@@ -1458,7 +1458,7 @@
 /***********************************************************************************************/
 
 /**
- * \brief CS Software Buse Create Pipe Failed Event ID
+ * \brief CS Software Bus Create Pipe Failed Event ID
  *
  *  \par Type: ERROR
  *

--- a/fsw/inc/cs_msg.h
+++ b/fsw/inc/cs_msg.h
@@ -45,7 +45,7 @@ typedef struct
     uint8   AppCSState;                  /**< \brief CS App table checksum state */
     uint8   TablesCSState;               /**< \brief CS Tables table checksum state */
     uint8   OSCSState;                   /**< \brief OS code segment checksum state */
-    uint8   CfeCoreCSState;              /**< \brief cFE Core code segment checksum stat e*/
+    uint8   CfeCoreCSState;              /**< \brief cFE Core code segment checksum state*/
     uint8   RecomputeInProgress;         /**< \brief CS "Recompute In Progress" flag */
     uint8   OneShotInProgress;           /**< \brief CS "OneShot In Progress" flag */
     uint8   Filler8;                     /**< \brief 8 bit padding */
@@ -54,12 +54,12 @@ typedef struct
     uint16  AppCSErrCounter;             /**< \brief App miscompare counter */
     uint16  TablesCSErrCounter;          /**< \brief Tables miscompare counter */
     uint16  CfeCoreCSErrCounter;         /**< \brief cFE core miscompare counter */
-    uint16  OSCSErrCounter;              /**< \brief OS code segment miscopmare counter */
+    uint16  OSCSErrCounter;              /**< \brief OS code segment miscompare counter */
     uint16  CurrentCSTable;              /**< \brief Current table being checksummed */
     uint16  CurrentEntryInTable;         /**< \brief Current entry ID in table being checksummed */
     uint32  EepromBaseline;              /**< \brief Baseline checksum for all of EEPROM */
     uint32  OSBaseline;                  /**< \brief Baseline checksum for the OS code segment */
-    uint32  CfeCoreBaseline;             /**< \brief Basline checksum for the cFE core */
+    uint32  CfeCoreBaseline;             /**< \brief Baseline checksum for the cFE core */
     cpuaddr LastOneShotAddress;          /**< \brief Address used in last one shot checksum command */
     uint32  LastOneShotSize;             /**< \brief Size used in the last one shot checksum command */
     uint32  LastOneShotMaxBytesPerCycle; /**< \brief Max bytes per cycle for last one shot checksum command */

--- a/fsw/inc/cs_msgdefs.h
+++ b/fsw/inc/cs_msgdefs.h
@@ -114,7 +114,7 @@
  *       - The #CS_ONESHOT_STARTED_DBG_EID debug event message will be
  *         generated when the command is received
  *       - The CS_ONESHOT_FINISHED_INF_EID informational message will
- *         be generated when the compuation finishes.
+ *         be generated when the computation finishes.
  *       - #CS_HkPacket_Payload_t.LastOneShotChecksum will be updated to the new value
  *
  *  \par Error Conditions
@@ -346,7 +346,7 @@
  * \brief Recompute Baseline checksum of cFE core
  *
  *  \par Description
- *       Recomputesthe baseline checksum of the cFE core
+ *       Recomputes the baseline checksum of the cFE core
  *       and use the new value as the baseline.
  *
  *  \par Command Structure
@@ -485,7 +485,7 @@
  * \brief Recompute Baseline checksum of OS code segment
  *
  *  \par Description
- *       Recomputesthe baseline checksum of the OS code segment
+ *       Recomputes the baseline checksum of the OS code segment
  *       and use the new value as the baseline.
  *
  *  \par Command Structure
@@ -1099,7 +1099,7 @@
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
- *       - The command specified able name is invalid
+ *       - The command specified table name is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
@@ -1317,7 +1317,7 @@
  *  \par Error Conditions
  *       This command may fail for the following reason(s):
  *       - Command packet length not as expected
- *       - The command specified able name is invalid
+ *       - The command specified table name is invalid
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
@@ -1433,13 +1433,13 @@
  *
  *  \par Evidence of failure may be found in the following telemetry:
  *       - #CS_HkPacket_Payload_t.CmdErrCounter will increment
- *       - Error specific event message #CS_DISABLE_APP_NAME_INF_EID
+ *       - Error specific event message #CS_CMD_LEN_ERR_EID
  *       - Error specific event message #CS_DISABLE_APP_UNKNOWN_NAME_ERR_EID
  *
  *  \par Criticality
  *       None
  *
- *  \sa #CS_DISABLE_NAME_APP_CC
+ *  \sa #CS_ENABLE_NAME_APP_CC
  */
 #define CS_DISABLE_NAME_APP_CC 39
 

--- a/fsw/inc/cs_tbldefs.h
+++ b/fsw/inc/cs_tbldefs.h
@@ -85,7 +85,7 @@ typedef struct
     uint32  NumBytesToChecksum; /**< \brief The number of Bytes to Checksum */
     uint32  ComparisonValue;    /**< \brief The Memory Integrity Value */
     uint32  ByteOffset;         /**< \brief Where a previous unfinished calc left off */
-    uint32  TempChecksumValue;  /**< \brief The unfinished caluculation */
+    uint32  TempChecksumValue;  /**< \brief The unfinished calculation */
     uint32  Filler32;           /**< \brief Padding */
 } CS_Res_EepromMemory_Table_Entry_t;
 
@@ -118,7 +118,7 @@ typedef struct
     uint32           NumBytesToChecksum;              /**< \brief The number of Bytes to Checksum */
     uint32           ComparisonValue;                 /**< \brief The Memory Integrity Value */
     uint32           ByteOffset;                      /**< \brief Where a previous unfinished calc left off */
-    uint32           TempChecksumValue;               /**< \brief The unfinished caluculation */
+    uint32           TempChecksumValue;               /**< \brief The unfinished calculation */
     CFE_TBL_Handle_t TblHandle;                       /**< \brief handle recieved from CFE_TBL */
     bool             IsCSOwner;                       /**< \brief Is CS the original owner of this table */
     bool             Filler8;                         /**< \brief Padding */
@@ -136,7 +136,7 @@ typedef struct
     uint32  NumBytesToChecksum;    /**< \brief The number of Bytes to Checksum */
     uint32  ComparisonValue;       /**< \brief The Memory Integrity Value */
     uint32  ByteOffset;            /**< \brief Where a previous unfinished calc left off */
-    uint32  TempChecksumValue;     /**< \brief The unfinished caluculation */
+    uint32  TempChecksumValue;     /**< \brief The unfinished calculation */
     char    Name[OS_MAX_API_NAME]; /**< \brief name of the app */
 } CS_Res_App_Table_Entry_t;
 

--- a/fsw/src/cs_app.c
+++ b/fsw/src/cs_app.c
@@ -193,7 +193,7 @@ CFE_Status_t CS_AppInit(void)
     {
         CS_InitSegments();
 
-        /* initialize the place to ostart background checksumming */
+        /* initialize the place to start background checksumming */
         CS_AppData.HkPacket.Payload.CurrentCSTable      = 0;
         CS_AppData.HkPacket.Payload.CurrentEntryInTable = 0;
 

--- a/fsw/src/cs_app.h
+++ b/fsw/src/cs_app.h
@@ -138,7 +138,7 @@ typedef struct
     CFE_TBL_Handle_t ResTablesTableHandle; /**< \brief Handle to the Tables results table */
 
     CFE_TBL_Handle_t DefAppTableHandle; /**< \brief Handle to the Apps definition table */
-    CFE_TBL_Handle_t ResAppTableHandle; /**< \brief Hanlde to the Apps results table */
+    CFE_TBL_Handle_t ResAppTableHandle; /**< \brief Handle to the Apps results table */
 
     CS_Def_EepromMemory_Table_Entry_t *DefEepromTblPtr; /**< \brief Pointer to the EEPROM definition table */
     CS_Res_EepromMemory_Table_Entry_t *ResEepromTblPtr; /**< \brief Pointer to the EEPROM results table */

--- a/fsw/src/cs_app_cmds.c
+++ b/fsw/src/cs_app_cmds.c
@@ -41,23 +41,39 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
+/* Common handler for App enable/disable commands                 */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+static void CS_DoEnableDisableAppCmd(const CS_NoArgsCmd_t *CmdPtr, uint16 NewState, uint32 EventID)
+{
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        CS_AppData.HkPacket.Payload.AppCSState = NewState;
+
+        if (NewState == CS_STATE_DISABLED)
+        {
+            CS_ZeroAppTempValues();
+        }
+
+#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
+        CS_UpdateCDS();
+#endif
+
+        CFE_EVS_SendEvent(EventID, CFE_EVS_EventType_INFORMATION,
+                          NewState == CS_STATE_ENABLED ? "Checksumming of App is Enabled"
+                                                       : "Checksumming of App is Disabled");
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
 /* CS Disable background checking of App command                   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableAppCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.AppCSState = CS_STATE_DISABLED;
-            CS_ZeroAppTempValues();
-
-#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
-#endif
-
-            CFE_EVS_SendEvent(CS_DISABLE_APP_INF_EID, CFE_EVS_EventType_INFORMATION, "Checksumming of App is Disabled");
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+    CS_DoEnableDisableAppCmd(CmdPtr, CS_STATE_DISABLED, CS_DISABLE_APP_INF_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -67,17 +83,7 @@ void CS_DisableAppCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableAppCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.AppCSState = CS_STATE_ENABLED;
-
-#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
-#endif
-
-            CFE_EVS_SendEvent(CS_ENABLE_APP_INF_EID, CFE_EVS_EventType_INFORMATION, "Checksumming of App is Enabled");
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+    CS_DoEnableDisableAppCmd(CmdPtr, CS_STATE_ENABLED, CS_ENABLE_APP_INF_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -182,52 +188,69 @@ void CS_RecomputeBaselineAppCmd(const CS_AppNameCmd_t *CmdPtr)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
+/* Common handler for App name-based enable/disable commands      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+static void CS_DoEnableDisableNameAppCmd(const CS_AppNameCmd_t *CmdPtr, uint16 NewState, uint32 EventID,
+                                         uint32 UnknownNameEventID, uint32 DefNotFoundEventID)
+{
+    CS_Res_App_Table_Entry_t *ResultsEntry;
+    CS_Def_App_Table_Entry_t *DefinitionEntry;
+    char                      Name[OS_MAX_API_NAME];
+
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
+        Name[sizeof(Name) - 1] = '\0';
+
+        if (CS_GetAppResTblEntryByName(&ResultsEntry, Name))
+        {
+            ResultsEntry->State = NewState;
+
+            if (NewState == CS_STATE_DISABLED)
+            {
+                ResultsEntry->TempChecksumValue = 0;
+                ResultsEntry->ByteOffset        = 0;
+            }
+
+            CFE_EVS_SendEvent(EventID, CFE_EVS_EventType_INFORMATION,
+                              NewState == CS_STATE_ENABLED ? "Checksumming of app %s is Enabled"
+                                                           : "Checksumming of app %s is Disabled",
+                              Name);
+
+            if (CS_GetAppDefTblEntryByName(&DefinitionEntry, Name))
+            {
+                DefinitionEntry->State = NewState;
+                CS_ResetTablesTblResultEntry(CS_AppData.AppResTablesTblPtr);
+                CFE_TBL_Modified(CS_AppData.DefAppTableHandle);
+            }
+            else
+            {
+                CFE_EVS_SendEvent(DefNotFoundEventID, CFE_EVS_EventType_DEBUG,
+                                  "CS unable to update apps definition table for entry %s", Name);
+            }
+            CS_AppData.HkPacket.Payload.CmdCounter++;
+        }
+        else
+        {
+            CFE_EVS_SendEvent(UnknownNameEventID, CFE_EVS_EventType_ERROR,
+                              NewState == CS_STATE_ENABLED ? "App enable app command failed, app %s not found"
+                                                           : "App disable app command failed, app %s not found",
+                              Name);
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        }
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
 /* CS Disable a specific entry in the App table command            */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableNameAppCmd(const CS_AppNameCmd_t *CmdPtr)
 {
-    /* command verification variables */
-    CS_Res_App_Table_Entry_t *ResultsEntry;
-    CS_Def_App_Table_Entry_t *DefinitionEntry;
-    char                      Name[OS_MAX_API_NAME];
-
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
-            Name[sizeof(Name) - 1] = '\0';
-
-            if (CS_GetAppResTblEntryByName(&ResultsEntry, Name))
-            {
-                ResultsEntry->State             = CS_STATE_DISABLED;
-                ResultsEntry->TempChecksumValue = 0;
-                ResultsEntry->ByteOffset        = 0;
-
-                CFE_EVS_SendEvent(CS_DISABLE_APP_NAME_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of app %s is Disabled", Name);
-
-                if (CS_GetAppDefTblEntryByName(&DefinitionEntry, Name))
-                {
-                    DefinitionEntry->State = CS_STATE_DISABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.AppResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefAppTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_DISABLE_APP_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update apps definition table for entry %s", Name);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
-            }
-
-            else
-            {
-                CFE_EVS_SendEvent(CS_DISABLE_APP_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "App disable app command failed, app %s not found", Name);
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
-            }
-        } /* end InProgress if */
+    CS_DoEnableDisableNameAppCmd(CmdPtr, CS_STATE_DISABLED, CS_DISABLE_APP_NAME_INF_EID,
+                                 CS_DISABLE_APP_UNKNOWN_NAME_ERR_EID, CS_DISABLE_APP_DEF_NOT_FOUND_DBG_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -237,42 +260,6 @@ void CS_DisableNameAppCmd(const CS_AppNameCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableNameAppCmd(const CS_AppNameCmd_t *CmdPtr)
 {
-    /* command verification variables */
-    CS_Res_App_Table_Entry_t *ResultsEntry;
-    CS_Def_App_Table_Entry_t *DefinitionEntry;
-    char                      Name[OS_MAX_API_NAME];
-
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
-            Name[sizeof(Name) - 1] = '\0';
-
-            if (CS_GetAppResTblEntryByName(&ResultsEntry, Name))
-            {
-                ResultsEntry->State = CS_STATE_ENABLED;
-
-                CFE_EVS_SendEvent(CS_ENABLE_APP_NAME_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of app %s is Enabled", Name);
-
-                if (CS_GetAppDefTblEntryByName(&DefinitionEntry, Name))
-                {
-                    DefinitionEntry->State = CS_STATE_ENABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.AppResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefAppTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_ENABLE_APP_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update apps definition table for entry %s", Name);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
-            }
-            else
-            {
-                CFE_EVS_SendEvent(CS_ENABLE_APP_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "App enable app command failed, app %s not found", Name);
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
-            }
-        } /* end InProgress if */
+    CS_DoEnableDisableNameAppCmd(CmdPtr, CS_STATE_ENABLED, CS_ENABLE_APP_NAME_INF_EID,
+                                 CS_ENABLE_APP_UNKNOWN_NAME_ERR_EID, CS_ENABLE_APP_DEF_NOT_FOUND_DBG_EID);
 }

--- a/fsw/src/cs_cmds.c
+++ b/fsw/src/cs_cmds.c
@@ -72,7 +72,7 @@ void CS_ResetCmd(const CS_NoArgsCmd_t *CmdPtr)
     CS_AppData.HkPacket.Payload.OSCSErrCounter      = 0;
     CS_AppData.HkPacket.Payload.PassCounter         = 0;
 
-    CFE_EVS_SendEvent(CS_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command recieved");
+    CFE_EVS_SendEvent(CS_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command received");
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -224,22 +224,36 @@ void CS_EnableAllCSCmd(const CS_NoArgsCmd_t *CmdPtr)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Disable background checking of the cFE core command          */
+/* Common handler for cFE Core enable/disable commands             */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void CS_DisableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
+static void CS_DoEnableDisableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr, uint16 NewState, uint32 EventID)
 {
-    CS_AppData.HkPacket.Payload.CfeCoreCSState = CS_STATE_DISABLED;
-    CS_ZeroCfeCoreTempValues();
+    CS_AppData.HkPacket.Payload.CfeCoreCSState = NewState;
+
+    if (NewState == CS_STATE_DISABLED)
+    {
+        CS_ZeroCfeCoreTempValues();
+    }
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
     CS_UpdateCDS();
 #endif
 
-    CFE_EVS_SendEvent(CS_DISABLE_CFECORE_INF_EID, CFE_EVS_EventType_INFORMATION,
-                      "Checksumming of cFE Core is Disabled");
-
+    CFE_EVS_SendEvent(EventID, CFE_EVS_EventType_INFORMATION,
+                      NewState == CS_STATE_ENABLED ? "Checksumming of cFE Core is Enabled"
+                                                   : "Checksumming of cFE Core is Disabled");
     CS_AppData.HkPacket.Payload.CmdCounter++;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CS Disable background checking of the cFE core command          */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void CS_DisableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
+{
+    CS_DoEnableDisableCfeCoreCmd(CmdPtr, CS_STATE_DISABLED, CS_DISABLE_CFECORE_INF_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -249,14 +263,30 @@ void CS_DisableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-    CS_AppData.HkPacket.Payload.CfeCoreCSState = CS_STATE_ENABLED;
+    CS_DoEnableDisableCfeCoreCmd(CmdPtr, CS_STATE_ENABLED, CS_ENABLE_CFECORE_INF_EID);
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* Common handler for OS enable/disable commands                   */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+static void CS_DoEnableDisableOSCmd(const CS_NoArgsCmd_t *CmdPtr, uint16 NewState, uint32 EventID)
+{
+    CS_AppData.HkPacket.Payload.OSCSState = NewState;
+
+    if (NewState == CS_STATE_DISABLED)
+    {
+        CS_ZeroOSTempValues();
+    }
 
 #if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
     CS_UpdateCDS();
 #endif
 
-    CFE_EVS_SendEvent(CS_ENABLE_CFECORE_INF_EID, CFE_EVS_EventType_INFORMATION, "Checksumming of cFE Core is Enabled");
-
+    CFE_EVS_SendEvent(EventID, CFE_EVS_EventType_INFORMATION,
+                      NewState == CS_STATE_ENABLED ? "Checksumming of OS code segment is Enabled"
+                                                   : "Checksumming of OS code segment is Disabled");
     CS_AppData.HkPacket.Payload.CmdCounter++;
 }
 
@@ -267,17 +297,7 @@ void CS_EnableCfeCoreCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableOSCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-    CS_AppData.HkPacket.Payload.OSCSState = CS_STATE_DISABLED;
-    CS_ZeroOSTempValues();
-
-#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-    CS_UpdateCDS();
-#endif
-
-    CFE_EVS_SendEvent(CS_DISABLE_OS_INF_EID, CFE_EVS_EventType_INFORMATION,
-                      "Checksumming of OS code segment is Disabled");
-
-    CS_AppData.HkPacket.Payload.CmdCounter++;
+    CS_DoEnableDisableOSCmd(CmdPtr, CS_STATE_DISABLED, CS_DISABLE_OS_INF_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -287,16 +307,7 @@ void CS_DisableOSCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableOSCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-    CS_AppData.HkPacket.Payload.OSCSState = CS_STATE_ENABLED;
-
-#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-    CS_UpdateCDS();
-#endif
-
-    CFE_EVS_SendEvent(CS_ENABLE_OS_INF_EID, CFE_EVS_EventType_INFORMATION,
-                      "Checksumming of OS code segment is Enabled");
-
-    CS_AppData.HkPacket.Payload.CmdCounter++;
+    CS_DoEnableDisableOSCmd(CmdPtr, CS_STATE_ENABLED, CS_ENABLE_OS_INF_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/cs_eeprom_cmds.c
+++ b/fsw/src/cs_eeprom_cmds.c
@@ -43,25 +43,39 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
+/* Common handler for EEPROM enable/disable commands               */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+static void CS_DoEnableDisableEepromCmd(const CS_NoArgsCmd_t *CmdPtr, uint16 NewState, uint32 EventID)
+{
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        CS_AppData.HkPacket.Payload.EepromCSState = NewState;
+
+        if (NewState == CS_STATE_DISABLED)
+        {
+            CS_ZeroEepromTempValues();
+        }
+
+#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
+        CS_UpdateCDS();
+#endif
+
+        CFE_EVS_SendEvent(EventID, CFE_EVS_EventType_INFORMATION,
+                          NewState == CS_STATE_ENABLED ? "Checksumming of EEPROM is Enabled"
+                                                       : "Checksumming of EEPROM is Disabled");
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
 /* CS Disable background checking of EEPROM command                */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.EepromCSState = CS_STATE_DISABLED;
-            CS_ZeroEepromTempValues();
-
-#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
-#endif
-
-            CFE_EVS_SendEvent(CS_DISABLE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of EEPROM is Disabled");
-
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+    CS_DoEnableDisableEepromCmd(CmdPtr, CS_STATE_DISABLED, CS_DISABLE_EEPROM_INF_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -71,19 +85,7 @@ void CS_DisableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableEepromCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.EepromCSState = CS_STATE_ENABLED;
-
-#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
-#endif
-
-            CFE_EVS_SendEvent(CS_ENABLE_EEPROM_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of EEPROM is Enabled");
-
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+    CS_DoEnableDisableEepromCmd(CmdPtr, CS_STATE_ENABLED, CS_ENABLE_EEPROM_INF_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -217,62 +219,71 @@ void CS_RecomputeBaselineEepromCmd(const CS_EntryCmd_t *CmdPtr)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Enable a specific entry in the EEPROM table command          */
+/* Common handler for EEPROM EntryID enable/disable commands      */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
+static void CS_DoEnableDisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr, uint16 NewState, uint32 EnableEventID,
+                                               uint32 DefEmptyEventID, uint32 InvalidEntryEventID)
 {
-    /* command verification variables */
     CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
     uint16                             EntryID      = 0;
     uint16                             State        = CS_STATE_EMPTY;
 
-        if (CS_CheckRecomputeOneshot() == false)
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        EntryID = CmdPtr->Payload.EntryID;
+
+        if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
+            (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
         {
-            EntryID = CmdPtr->Payload.EntryID;
+            ResultsEntry = &CS_AppData.ResEepromTblPtr[EntryID];
 
-            if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
-                (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
+            ResultsEntry->State = NewState;
+
+            if (NewState == CS_STATE_DISABLED)
             {
-                ResultsEntry = &CS_AppData.ResEepromTblPtr[EntryID];
+                ResultsEntry->TempChecksumValue = 0;
+                ResultsEntry->ByteOffset        = 0;
+            }
 
-                ResultsEntry->State = CS_STATE_ENABLED;
+            CFE_EVS_SendEvent(EnableEventID, CFE_EVS_EventType_INFORMATION,
+                              NewState == CS_STATE_ENABLED ? "Checksumming of EEPROM Entry ID %d is Enabled"
+                                                           : "Checksumming of EEPROM Entry ID %d is Disabled",
+                              EntryID);
 
-                CFE_EVS_SendEvent(CS_ENABLE_EEPROM_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of EEPROM Entry ID %d is Enabled", EntryID);
-
-                if (CS_AppData.DefEepromTblPtr[EntryID].State != CS_STATE_EMPTY)
-                {
-                    CS_AppData.DefEepromTblPtr[EntryID].State = CS_STATE_ENABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.EepResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefEepromTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_ENABLE_EEPROM_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update EEPROM definition table for entry %d, State: %d", EntryID,
-                                      State);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+            if (CS_AppData.DefEepromTblPtr[EntryID].State != CS_STATE_EMPTY)
+            {
+                CS_AppData.DefEepromTblPtr[EntryID].State = NewState;
+                CS_ResetTablesTblResultEntry(CS_AppData.EepResTablesTblPtr);
+                CFE_TBL_Modified(CS_AppData.DefEepromTableHandle);
             }
             else
             {
-                if (EntryID >= CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
-                {
-                    State = CS_STATE_UNDEFINED;
-                }
-                else
-                {
-                    State = CS_AppData.ResEepromTblPtr[EntryID].State;
-                }
-
-                CFE_EVS_SendEvent(CS_ENABLE_EEPROM_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Enable EEPROM entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
-                                  State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CFE_EVS_SendEvent(DefEmptyEventID, CFE_EVS_EventType_DEBUG,
+                                  "CS unable to update EEPROM definition table for entry %d, State: %d", EntryID,
+                                  State);
             }
-        } /* end InProgress if */
+            CS_AppData.HkPacket.Payload.CmdCounter++;
+        }
+        else
+        {
+            if (EntryID >= CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
+            {
+                State = CS_STATE_UNDEFINED;
+            }
+            else
+            {
+                State = CS_AppData.ResEepromTblPtr[EntryID].State;
+            }
+
+            CFE_EVS_SendEvent(InvalidEntryEventID, CFE_EVS_EventType_ERROR,
+                              NewState == CS_STATE_ENABLED
+                                  ? "Enable EEPROM entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d"
+                                  : "Disable EEPROM entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d",
+                              EntryID, State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        }
+    }
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -282,60 +293,19 @@ void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
 {
-    /* command verification variables */
-    CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
-    uint16                             EntryID      = 0;
-    uint16                             State        = CS_STATE_EMPTY;
+    CS_DoEnableDisableEntryIDEepromCmd(CmdPtr, CS_STATE_DISABLED, CS_DISABLE_EEPROM_ENTRY_INF_EID,
+                                       CS_DISABLE_EEPROM_DEF_EMPTY_DBG_EID, CS_DISABLE_EEPROM_INVALID_ENTRY_ERR_EID);
+}
 
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            EntryID = CmdPtr->Payload.EntryID;
-
-            if ((EntryID < CS_MAX_NUM_EEPROM_TABLE_ENTRIES) &&
-                (CS_AppData.ResEepromTblPtr[EntryID].State != CS_STATE_EMPTY))
-            {
-                ResultsEntry = &CS_AppData.ResEepromTblPtr[EntryID];
-
-                ResultsEntry->State             = CS_STATE_DISABLED;
-                ResultsEntry->TempChecksumValue = 0;
-                ResultsEntry->ByteOffset        = 0;
-
-                CFE_EVS_SendEvent(CS_DISABLE_EEPROM_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of EEPROM Entry ID %d is Disabled", EntryID);
-
-                if (CS_AppData.DefEepromTblPtr[EntryID].State != CS_STATE_EMPTY)
-                {
-                    CS_AppData.DefEepromTblPtr[EntryID].State = CS_STATE_DISABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.EepResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefEepromTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_DISABLE_EEPROM_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update EEPROM definition table for entry %d, State: %d", EntryID,
-                                      State);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
-            }
-            else
-            {
-                if (EntryID >= CS_MAX_NUM_EEPROM_TABLE_ENTRIES)
-                {
-                    State = CS_STATE_UNDEFINED;
-                }
-                else
-                {
-                    State = CS_AppData.ResEepromTblPtr[EntryID].State;
-                }
-
-                CFE_EVS_SendEvent(CS_DISABLE_EEPROM_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Disable EEPROM entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
-                                  State, (CS_MAX_NUM_EEPROM_TABLE_ENTRIES - 1));
-
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
-            }
-        } /* end InProgress if */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CS Enable a specific entry in the EEPROM table command          */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void CS_EnableEntryIDEepromCmd(const CS_EntryCmd_t *CmdPtr)
+{
+    CS_DoEnableDisableEntryIDEepromCmd(CmdPtr, CS_STATE_ENABLED, CS_ENABLE_EEPROM_ENTRY_INF_EID,
+                                       CS_ENABLE_EEPROM_DEF_EMPTY_DBG_EID, CS_ENABLE_EEPROM_INVALID_ENTRY_ERR_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/cs_memory_cmds.c
+++ b/fsw/src/cs_memory_cmds.c
@@ -43,47 +43,49 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
+/* Common handler for Memory enable/disable commands               */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+static void CS_DoEnableDisableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr, uint16 NewState, uint32 EventID)
+{
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        CS_AppData.HkPacket.Payload.MemoryCSState = NewState;
+
+        if (NewState == CS_STATE_DISABLED)
+        {
+            CS_ZeroMemoryTempValues();
+        }
+
+#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
+        CS_UpdateCDS();
+#endif
+
+        CFE_EVS_SendEvent(EventID, CFE_EVS_EventType_INFORMATION,
+                          NewState == CS_STATE_ENABLED ? "Checksumming of Memory is Enabled"
+                                                       : "Checksumming of Memory is Disabled");
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
 /* CS Disable background checking of Memory command                */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_DISABLED;
-            CS_ZeroMemoryTempValues();
-
-#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
-#endif
-
-            CFE_EVS_SendEvent(CS_DISABLE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of Memory is Disabled");
-
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+    CS_DoEnableDisableMemoryCmd(CmdPtr, CS_STATE_DISABLED, CS_DISABLE_MEMORY_INF_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
 /* CS Enable background checking of Memory command                 */
 /*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableMemoryCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.MemoryCSState = CS_STATE_ENABLED;
-
-#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
-#endif
-
-            CFE_EVS_SendEvent(CS_ENABLE_MEMORY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of Memory is Enabled");
-
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+    CS_DoEnableDisableMemoryCmd(CmdPtr, CS_STATE_ENABLED, CS_ENABLE_MEMORY_INF_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -217,62 +219,82 @@ void CS_RecomputeBaselineMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
+/* Common handler for Memory EntryID enable/disable commands      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+static void CS_DoEnableDisableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr, uint16 NewState, uint32 EnableEventID,
+                                               uint32 DefEmptyEventID, uint32 InvalidEntryEventID)
+{
+    CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
+    uint16                             EntryID      = 0;
+    uint16                             State        = CS_STATE_EMPTY;
+
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        EntryID = CmdPtr->Payload.EntryID;
+
+        if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
+            (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
+        {
+            ResultsEntry = &CS_AppData.ResMemoryTblPtr[EntryID];
+
+            ResultsEntry->State = NewState;
+
+            if (NewState == CS_STATE_DISABLED)
+            {
+                ResultsEntry->TempChecksumValue = 0;
+                ResultsEntry->ByteOffset        = 0;
+            }
+
+            CFE_EVS_SendEvent(EnableEventID, CFE_EVS_EventType_INFORMATION,
+                              NewState == CS_STATE_ENABLED ? "Checksumming of Memory Entry ID %d is Enabled"
+                                                           : "Checksumming of Memory Entry ID %d is Disabled",
+                              EntryID);
+
+            if (CS_AppData.DefMemoryTblPtr[EntryID].State != CS_STATE_EMPTY)
+            {
+                CS_AppData.DefMemoryTblPtr[EntryID].State = NewState;
+                CS_ResetTablesTblResultEntry(CS_AppData.MemResTablesTblPtr);
+                CFE_TBL_Modified(CS_AppData.DefMemoryTableHandle);
+            }
+            else
+            {
+                CFE_EVS_SendEvent(DefEmptyEventID, CFE_EVS_EventType_DEBUG,
+                                  "CS unable to update memory definition table for entry %d, State: %d", EntryID,
+                                  State);
+            }
+            CS_AppData.HkPacket.Payload.CmdCounter++;
+        }
+        else
+        {
+            if (EntryID >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
+            {
+                State = CS_STATE_UNDEFINED;
+            }
+            else
+            {
+                State = CS_AppData.ResMemoryTblPtr[EntryID].State;
+            }
+
+            CFE_EVS_SendEvent(InvalidEntryEventID, CFE_EVS_EventType_ERROR,
+                              NewState == CS_STATE_ENABLED
+                                  ? "Enable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d"
+                                  : "Disable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d",
+                              EntryID, State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        }
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
 /* CS Enable a specific entry in the Memory table command          */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 {
-    /* command verification variables */
-    CS_Res_EepromMemory_Table_Entry_t *ResultsEntry   = NULL;
-    uint16                             EntryID        = 0;
-    uint16                             State          = CS_STATE_EMPTY;
-
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            EntryID = CmdPtr->Payload.EntryID;
-
-            if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
-                (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
-            {
-                ResultsEntry = &CS_AppData.ResMemoryTblPtr[EntryID];
-
-                ResultsEntry->State = CS_STATE_ENABLED;
-
-                CFE_EVS_SendEvent(CS_ENABLE_MEMORY_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of Memory Entry ID %d is Enabled", EntryID);
-
-                if (CS_AppData.DefMemoryTblPtr[EntryID].State != CS_STATE_EMPTY)
-                {
-                    CS_AppData.DefMemoryTblPtr[EntryID].State = CS_STATE_ENABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.MemResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefMemoryTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_ENABLE_MEMORY_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update memory definition table for entry %d, State: %d", EntryID,
-                                      State);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
-            }
-            else
-            {
-                if (EntryID >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
-                {
-                    State = CS_STATE_UNDEFINED;
-                }
-                else
-                {
-                    State = CS_AppData.ResMemoryTblPtr[EntryID].State;
-                }
-
-                CFE_EVS_SendEvent(CS_ENABLE_MEMORY_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Enable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
-                                  State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
-            }
-        } /* end InProgress if */
+    CS_DoEnableDisableEntryIDMemoryCmd(CmdPtr, CS_STATE_ENABLED, CS_ENABLE_MEMORY_ENTRY_INF_EID,
+                                       CS_ENABLE_MEMORY_DEF_EMPTY_DBG_EID, CS_ENABLE_MEMORY_INVALID_ENTRY_ERR_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -282,60 +304,8 @@ void CS_EnableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableEntryIDMemoryCmd(const CS_EntryCmd_t *CmdPtr)
 {
-    /* command verification variables */
-    CS_Res_EepromMemory_Table_Entry_t *ResultsEntry   = NULL;
-    uint16                             EntryID        = 0;
-    uint16                             State          = CS_STATE_EMPTY;
-
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            EntryID = CmdPtr->Payload.EntryID;
-
-            if ((EntryID < CS_MAX_NUM_MEMORY_TABLE_ENTRIES) &&
-                (CS_AppData.ResMemoryTblPtr[EntryID].State != CS_STATE_EMPTY))
-            {
-                ResultsEntry = &CS_AppData.ResMemoryTblPtr[EntryID];
-
-                ResultsEntry->State             = CS_STATE_DISABLED;
-                ResultsEntry->TempChecksumValue = 0;
-                ResultsEntry->ByteOffset        = 0;
-
-                CFE_EVS_SendEvent(CS_DISABLE_MEMORY_ENTRY_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of Memory Entry ID %d is Disabled", EntryID);
-
-                if (CS_AppData.DefMemoryTblPtr[EntryID].State != CS_STATE_EMPTY)
-                {
-                    CS_AppData.DefMemoryTblPtr[EntryID].State = CS_STATE_DISABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.MemResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefMemoryTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_DISABLE_MEMORY_DEF_EMPTY_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update memory definition table for entry %d, State: %d", EntryID,
-                                      State);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
-            }
-            else
-            {
-                if (EntryID >= CS_MAX_NUM_MEMORY_TABLE_ENTRIES)
-                {
-                    State = CS_STATE_UNDEFINED;
-                }
-                else
-                {
-                    State = CS_AppData.ResMemoryTblPtr[EntryID].State;
-                }
-
-                CFE_EVS_SendEvent(CS_DISABLE_MEMORY_INVALID_ENTRY_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Disable Memory entry failed, invalid Entry ID:  %d, State: %d, Max ID: %d", EntryID,
-                                  State, (CS_MAX_NUM_MEMORY_TABLE_ENTRIES - 1));
-
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
-            }
-        } /* end InProgress if */
+    CS_DoEnableDisableEntryIDMemoryCmd(CmdPtr, CS_STATE_DISABLED, CS_DISABLE_MEMORY_ENTRY_INF_EID,
+                                       CS_DISABLE_MEMORY_DEF_EMPTY_DBG_EID, CS_DISABLE_MEMORY_INVALID_ENTRY_ERR_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/src/cs_table_cmds.c
+++ b/fsw/src/cs_table_cmds.c
@@ -41,24 +41,39 @@
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
+/* Common handler for Tables enable/disable commands               */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+static void CS_DoEnableDisableTablesCmd(const CS_NoArgsCmd_t *CmdPtr, uint16 NewState, uint32 EventID)
+{
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        CS_AppData.HkPacket.Payload.TablesCSState = NewState;
+
+        if (NewState == CS_STATE_DISABLED)
+        {
+            CS_ZeroTablesTempValues();
+        }
+
+#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
+        CS_UpdateCDS();
+#endif
+
+        CFE_EVS_SendEvent(EventID, CFE_EVS_EventType_INFORMATION,
+                          NewState == CS_STATE_ENABLED ? "Checksumming of Tables is Enabled"
+                                                       : "Checksumming of Tables is Disabled");
+        CS_AppData.HkPacket.Payload.CmdCounter++;
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
 /* CS Disable background checking of Tables command                */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_DisableTablesCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.TablesCSState = CS_STATE_DISABLED;
-            CS_ZeroTablesTempValues();
-
-#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
-#endif
-
-            CFE_EVS_SendEvent(CS_DISABLE_TABLES_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of Tables is Disabled");
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+    CS_DoEnableDisableTablesCmd(CmdPtr, CS_STATE_DISABLED, CS_DISABLE_TABLES_INF_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -68,18 +83,7 @@ void CS_DisableTablesCmd(const CS_NoArgsCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableTablesCmd(const CS_NoArgsCmd_t *CmdPtr)
 {
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            CS_AppData.HkPacket.Payload.TablesCSState = CS_STATE_ENABLED;
-
-#if (CS_PRESERVE_STATES_ON_PROCESSOR_RESET == true)
-            CS_UpdateCDS();
-#endif
-
-            CFE_EVS_SendEvent(CS_ENABLE_TABLES_INF_EID, CFE_EVS_EventType_INFORMATION,
-                              "Checksumming of Tables is Enabled");
-            CS_AppData.HkPacket.Payload.CmdCounter++;
-        }
+    CS_DoEnableDisableTablesCmd(CmdPtr, CS_STATE_ENABLED, CS_ENABLE_TABLES_INF_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -182,50 +186,69 @@ void CS_RecomputeBaselineTablesCmd(const CS_TableNameCmd_t *CmdPtr)
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                 */
-/* CS Disable a specific entry in the Tables table command         */
+/* Common handler for Tables name-based enable/disable commands   */
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void CS_DisableNameTablesCmd(const CS_TableNameCmd_t *CmdPtr)
+static void CS_DoEnableDisableNameTablesCmd(const CS_TableNameCmd_t *CmdPtr, uint16 NewState, uint32 EventID,
+                                            uint32 DefNotFoundEventID, uint32 UnknownNameEventID)
 {
     CS_Res_Tables_Table_Entry_t *ResultsEntry;
     CS_Def_Tables_Table_Entry_t *DefinitionEntry;
     char                         Name[CFE_TBL_MAX_FULL_NAME_LEN];
 
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
-            Name[sizeof(Name) - 1] = '\0';
+    if (CS_CheckRecomputeOneshot() == false)
+    {
+        strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
+        Name[sizeof(Name) - 1] = '\0';
 
-            if (CS_GetTableResTblEntryByName(&ResultsEntry, Name))
+        if (CS_GetTableResTblEntryByName(&ResultsEntry, Name))
+        {
+            ResultsEntry->State = NewState;
+
+            if (NewState == CS_STATE_DISABLED)
             {
-                ResultsEntry->State             = CS_STATE_DISABLED;
                 ResultsEntry->TempChecksumValue = 0;
                 ResultsEntry->ByteOffset        = 0;
+            }
 
-                CFE_EVS_SendEvent(CS_DISABLE_TABLES_NAME_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of table %s is Disabled", Name);
+            CFE_EVS_SendEvent(EventID, CFE_EVS_EventType_INFORMATION,
+                              NewState == CS_STATE_ENABLED ? "Checksumming of table %s is Enabled"
+                                                           : "Checksumming of table %s is Disabled",
+                              Name);
 
-                if (CS_GetTableDefTblEntryByName(&DefinitionEntry, Name))
-                {
-                    DefinitionEntry->State = CS_STATE_DISABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.TblResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefTablesTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_DISABLE_TABLE_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update tables definition table for entry %s", Name);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
+            if (CS_GetTableDefTblEntryByName(&DefinitionEntry, Name))
+            {
+                DefinitionEntry->State = NewState;
+                CS_ResetTablesTblResultEntry(CS_AppData.TblResTablesTblPtr);
+                CFE_TBL_Modified(CS_AppData.DefTablesTableHandle);
             }
             else
             {
-                CFE_EVS_SendEvent(CS_DISABLE_TABLES_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Tables disable table command failed, table %s not found", Name);
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
+                CFE_EVS_SendEvent(DefNotFoundEventID, CFE_EVS_EventType_DEBUG,
+                                  "CS unable to update tables definition table for entry %s", Name);
             }
-        } /* end InProgress if */
+            CS_AppData.HkPacket.Payload.CmdCounter++;
+        }
+        else
+        {
+            CFE_EVS_SendEvent(UnknownNameEventID, CFE_EVS_EventType_ERROR,
+                              NewState == CS_STATE_ENABLED ? "Tables enable table command failed, table %s not found"
+                                                           : "Tables disable table command failed, table %s not found",
+                              Name);
+            CS_AppData.HkPacket.Payload.CmdErrCounter++;
+        }
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CS Disable a specific entry in the Tables table command         */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void CS_DisableNameTablesCmd(const CS_TableNameCmd_t *CmdPtr)
+{
+    CS_DoEnableDisableNameTablesCmd(CmdPtr, CS_STATE_DISABLED, CS_DISABLE_TABLES_NAME_INF_EID,
+                                    CS_DISABLE_TABLE_DEF_NOT_FOUND_DBG_EID, CS_DISABLE_TABLES_UNKNOWN_NAME_ERR_EID);
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -235,41 +258,6 @@ void CS_DisableNameTablesCmd(const CS_TableNameCmd_t *CmdPtr)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void CS_EnableNameTablesCmd(const CS_TableNameCmd_t *CmdPtr)
 {
-    CS_Res_Tables_Table_Entry_t *ResultsEntry;
-    CS_Def_Tables_Table_Entry_t *DefinitionEntry;
-    char                         Name[CFE_TBL_MAX_FULL_NAME_LEN];
-
-        if (CS_CheckRecomputeOneshot() == false)
-        {
-            strncpy(Name, CmdPtr->Payload.Name, sizeof(Name) - 1);
-            Name[sizeof(Name) - 1] = '\0';
-
-            if (CS_GetTableResTblEntryByName(&ResultsEntry, Name))
-            {
-                ResultsEntry->State = CS_STATE_ENABLED;
-
-                CFE_EVS_SendEvent(CS_ENABLE_TABLES_NAME_INF_EID, CFE_EVS_EventType_INFORMATION,
-                                  "Checksumming of table %s is Enabled", Name);
-
-                if (CS_GetTableDefTblEntryByName(&DefinitionEntry, Name))
-                {
-                    DefinitionEntry->State = CS_STATE_ENABLED;
-                    CS_ResetTablesTblResultEntry(CS_AppData.TblResTablesTblPtr);
-                    CFE_TBL_Modified(CS_AppData.DefTablesTableHandle);
-                }
-                else
-                {
-                    CFE_EVS_SendEvent(CS_ENABLE_TABLE_DEF_NOT_FOUND_DBG_EID, CFE_EVS_EventType_DEBUG,
-                                      "CS unable to update tables definition table for entry %s", Name);
-                }
-
-                CS_AppData.HkPacket.Payload.CmdCounter++;
-            }
-            else
-            {
-                CFE_EVS_SendEvent(CS_ENABLE_TABLES_UNKNOWN_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
-                                  "Tables enable table command failed, table %s not found", Name);
-                CS_AppData.HkPacket.Payload.CmdErrCounter++;
-            }
-        } /* end InProgress if */
+    CS_DoEnableDisableNameTablesCmd(CmdPtr, CS_STATE_ENABLED, CS_ENABLE_TABLES_NAME_INF_EID,
+                                    CS_ENABLE_TABLE_DEF_NOT_FOUND_DBG_EID, CS_ENABLE_TABLES_UNKNOWN_NAME_ERR_EID);
 }

--- a/unit-test/cs_cmds_tests.c
+++ b/unit-test/cs_cmds_tests.c
@@ -85,7 +85,7 @@ void CS_ResetCmd_Test(void)
     int32          strCmpResult;
     char           ExpectedEventString[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
 
-    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Reset Counters command recieved");
+    snprintf(ExpectedEventString, CFE_MISSION_EVS_MAX_MESSAGE_LENGTH, "Reset Counters command received");
 
     CS_AppData.HkPacket.Payload.CmdCounter          = 1;
     CS_AppData.HkPacket.Payload.CmdErrCounter       = 2;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #17 
  - Lots of duplicated logic in most of the enable/disable commands. They have been consolidated here to reduce duplication and ease future maintenance.

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).  
100% test coverage is maintained.

**Expected behavior changes**
Behavior is unchanged - the same enable/disable functions exist but call helpers where all common logic is consolidated.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt