### PR TITLE
Fix #138, Remove Dead Functions

### DIFF
--- a/unit-test/cs_cmds_tests.c
+++ b/unit-test/cs_cmds_tests.c
@@ -42,19 +42,6 @@ uint8 call_count_CFE_EVS_SendEvent;
  * Function Definitions
  */
 
-CFE_Status_t CS_CMDS_TEST_CFE_ES_CreateChildTaskHook(uint32                       *TaskIdPtr,
-                                                     const char                   *TaskName,
-                                                     CFE_ES_ChildTaskMainFuncPtr_t FunctionPtr,
-                                                     uint32                       *StackPtr,
-                                                     uint32                        StackSize,
-                                                     uint32                        Priority,
-                                                     uint32                        Flags)
-{
-    *TaskIdPtr = 5;
-
-    return CFE_SUCCESS;
-}
-
 void CS_SendHkCmd_Test_Nominal(void)
 {
     CS_SendHkCmd_t    CmdPacket;

--- a/unit-test/cs_compute_tests.c
+++ b/unit-test/cs_compute_tests.c
@@ -52,18 +52,6 @@ CFE_Status_t CS_COMPUTE_TEST_CFE_TBL_GetAddressHook(void                   *User
     return CFE_TBL_ERR_UNREGISTERED;
 }
 
-CFE_Status_t CS_COMPUTE_TEST_CFE_TBL_GetInfoHook1(void                   *UserObj,
-                                                  int32                   StubRetcode,
-                                                  uint32                  CallCount,
-                                                  const UT_StubContext_t *Context)
-{
-    CFE_TBL_Info_t *TblInfoPtr = (CFE_TBL_Info_t *)Context->ArgPtr[0];
-
-    TblInfoPtr->Size = 5;
-
-    return CFE_TBL_INFO_UPDATED;
-}
-
 void CS_COMPUTE_TEST_CFE_TBL_ShareHandler(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
     CFE_TBL_Handle_t *TblHandlePtr =

--- a/unit-test/cs_table_processing_tests.c
+++ b/unit-test/cs_table_processing_tests.c
@@ -43,31 +43,6 @@ uint8 call_count_CFE_EVS_SendEvent;
  * Function Definitions
  */
 
-void CS_TABLE_PROCESSING_TEST_CFE_ES_GetAppNameHandler1(void                   *UserObj,
-                                                        UT_EntryKey_t           FuncKey,
-                                                        const UT_StubContext_t *Context)
-{
-    char *AppName = (char *)UT_Hook_GetArgValueByName(Context, "AppName", char *);
-
-    strncpy((char *)AppName, "CS", 3);
-}
-
-CFE_Status_t CS_TABLE_PROCESSING_TEST_CFE_TBL_GetAddressHook(void                   *UserObj,
-                                                             int32                   StubRetcode,
-                                                             uint32                  CallCount,
-                                                             const UT_StubContext_t *Context)
-{
-    return CFE_SUCCESS;
-}
-
-CFE_Status_t CS_TABLE_PROCESSING_TEST_CFE_TBL_LoadHook(void                   *UserObj,
-                                                       int32                   StubRetcode,
-                                                       uint32                  CallCount,
-                                                       const UT_StubContext_t *Context)
-{
-    return CFE_SUCCESS;
-}
-
 void Test_CS_ValidateEepromChecksumDefinitionTable(void)
 {
     /* Test case for:


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/HS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #138

**Testing performed**
Ran the native_std commands which includes prep, install, runtest, and lcov. Compared these lcov results against the unchanged cFS bundle and found no changes. Ran the old build commands with unit tests enabled to ensure that the internal static code analysis tool no longer flags these functions. Also ran the bundle with -Wunused flags which only flagged unrelated macros.

**Expected behavior changes**
Removes five dead functions which are 

1. CS_CMDS_TEST_CFE_ES_CreateChildTaskHook
2. CS_COMPUTE_TEST_CFE_TBL_GetInfoHook1
3. CS_TABLE_PROCESSING_TEST_CFE_ES_GetAppNameHandler1
4. CS_TABLE_PROCESSING_TEST_CFE_TBL_GetAddressHook
5. CS_TABLE_PROCESSING_TEST_CFE_TBL_LoadHook


**System(s) tested on**
RedHat, cFS dev

**Additional context**
Lcov bundle results using native_std:
```
Overall coverage rate:
  lines......: 99.2% (30304 of 30537 lines)
  functions..: 99.2% (2428 of 2447 functions)
  branches...: no data found
```
Lcov bundle results using the old build commands:
```
Overall coverage rate:
  lines......: 99.2% (30167 of 30396 lines)
  functions..: 99.2% (2417 of 2436 functions)
  branches...: 98.7% (12931 of 13095 branches)
```

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.
