### PR TITLE
Fix #144, remove overwritten checksum variable assignments

### DIFF
--- a/fsw/src/cs_cmds.c
+++ b/fsw/src/cs_cmds.c
@@ -108,8 +108,8 @@ CFE_Status_t CS_ResetCountersCmd(const CS_ResetCountersCmd_t *CmdPtr)
 CFE_Status_t CS_BackgroundCheckCycleCmd(const CS_BackgroundCheckCycleCmd_t *CmdPtr)
 {
     /* command verification variables */
-    bool DoneWithCycle = false;
-    bool EndOfList     = false;
+    bool DoneWithCycle;
+    bool EndOfList;
 
     if (CS_AppData.HkPacket.Payload.ChecksumState == CS_ChecksumState_ENABLED)
     {

--- a/fsw/src/cs_compute.c
+++ b/fsw/src/cs_compute.c
@@ -363,8 +363,6 @@ CS_ComputeEepromMemory(CS_Res_EepromMemory_Table_Entry_t *ResultsEntry, uint32 *
     CFE_Status_t            Status;
     CS_LocalChecksumState_t State;
 
-    Status = CFE_SUCCESS;
-
     memset(&State, 0, sizeof(State));
 
     State.BufferAddr = CFE_ES_MEMADDRESS_TO_PTR(ResultsEntry->StartAddress);
@@ -475,8 +473,6 @@ CFE_Status_t CS_ComputeApp(CS_Res_App_Table_Entry_t *ResultsEntry, uint32 *Compu
 {
     CFE_Status_t            Status;
     CS_LocalChecksumState_t State;
-
-    Status = CFE_SUCCESS;
 
     memset(&State, 0, sizeof(State));
 
@@ -780,7 +776,7 @@ void CS_OneShotChildTask(void)
 {
     uint32  NewChecksumValue        = 0;
     size_t  NumBytesRemainingCycles = 0;
-    size_t  NumBytesThisCycle       = 0;
+    size_t  NumBytesThisCycle;
     cpuaddr FirstAddrThisCycle      = 0;
     size_t  MaxBytesPerCycle        = 0;
 

--- a/fsw/src/cs_compute.c
+++ b/fsw/src/cs_compute.c
@@ -777,8 +777,8 @@ void CS_OneShotChildTask(void)
     uint32  NewChecksumValue        = 0;
     size_t  NumBytesRemainingCycles = 0;
     size_t  NumBytesThisCycle;
-    cpuaddr FirstAddrThisCycle      = 0;
-    size_t  MaxBytesPerCycle        = 0;
+    cpuaddr FirstAddrThisCycle = 0;
+    size_t  MaxBytesPerCycle   = 0;
 
     NewChecksumValue        = 0;
     NumBytesRemainingCycles = CS_AppData.HkPacket.Payload.LastOneShotSize;

--- a/fsw/src/cs_eeprom_cmds.c
+++ b/fsw/src/cs_eeprom_cmds.c
@@ -97,7 +97,7 @@ CFE_Status_t CS_EnableEepromCmd(const CS_EnableEepromCmd_t *CmdPtr)
 CFE_Status_t CS_ReportBaselineEntryIDEepromCmd(const CS_ReportBaselineEntryIDEepromCmd_t *CmdPtr)
 {
     /* command verification variables */
-    uint32                             Baseline     = 0;
+    uint32                             Baseline;
     uint16                             EntryID      = 0;
     CS_ChecksumState_Enum_t            State        = CS_ChecksumState_EMPTY;
     CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
@@ -160,9 +160,9 @@ CFE_Status_t CS_RecomputeBaselineEepromCmd(const CS_RecomputeBaselineEepromCmd_t
 {
     /* command verification variables */
     CFE_ES_TaskId_t                    ChildTaskID  = CFE_ES_TASKID_UNDEFINED;
-    CFE_Status_t                       Status       = CS_ERROR;
+    CFE_Status_t                       Status;
     uint16                             EntryID      = 0;
-    CS_ChecksumState_Enum_t            State        = CS_ChecksumState_EMPTY;
+    CS_ChecksumState_Enum_t            State;
     CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
 
     if (CS_AppData.HkPacket.Payload.RecomputeInProgress == false
@@ -254,8 +254,8 @@ CFE_Status_t CS_EnableEntryIDEepromCmd(const CS_EnableEntryIDEepromCmd_t *CmdPtr
     CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
     CS_Def_EepromMemory_Table_Entry_t *DefEntry     = NULL;
     CS_TableWrapper_t                 *tw           = &CS_AppData.Tbl[CS_ChecksumType_EEPROM_TABLE];
-    uint16                             EntryID      = 0;
-    CS_ChecksumState_Enum_t            State        = CS_ChecksumState_EMPTY;
+    uint16                             EntryID;
+    CS_ChecksumState_Enum_t            State;
 
     if (CS_CheckRecomputeOneshot() == false)
     {
@@ -320,8 +320,8 @@ CFE_Status_t CS_DisableEntryIDEepromCmd(const CS_DisableEntryIDEepromCmd_t *CmdP
     CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
     CS_Def_EepromMemory_Table_Entry_t *DefEntry     = NULL;
     CS_TableWrapper_t                 *tw           = &CS_AppData.Tbl[CS_ChecksumType_EEPROM_TABLE];
-    uint16                             EntryID      = 0;
-    CS_ChecksumState_Enum_t            State        = CS_ChecksumState_EMPTY;
+    uint16                             EntryID;
+    CS_ChecksumState_Enum_t            State;
 
     if (CS_CheckRecomputeOneshot() == false)
     {

--- a/fsw/src/cs_eeprom_cmds.c
+++ b/fsw/src/cs_eeprom_cmds.c
@@ -159,9 +159,9 @@ CFE_Status_t CS_ReportBaselineEntryIDEepromCmd(const CS_ReportBaselineEntryIDEep
 CFE_Status_t CS_RecomputeBaselineEepromCmd(const CS_RecomputeBaselineEepromCmd_t *CmdPtr)
 {
     /* command verification variables */
-    CFE_ES_TaskId_t                    ChildTaskID  = CFE_ES_TASKID_UNDEFINED;
+    CFE_ES_TaskId_t                    ChildTaskID = CFE_ES_TASKID_UNDEFINED;
     CFE_Status_t                       Status;
-    uint16                             EntryID      = 0;
+    uint16                             EntryID = 0;
     CS_ChecksumState_Enum_t            State;
     CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
 

--- a/fsw/src/cs_memory_cmds.c
+++ b/fsw/src/cs_memory_cmds.c
@@ -98,7 +98,7 @@ CFE_Status_t CS_ReportBaselineEntryIDMemoryCmd(const CS_ReportBaselineEntryIDMem
 {
     /* command verification variables */
     CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
-    uint32                             Baseline     = 0;
+    uint32                             Baseline;
     uint16                             EntryID      = 0;
     CS_ChecksumState_Enum_t            State        = CS_ChecksumState_EMPTY;
 
@@ -159,9 +159,9 @@ CFE_Status_t CS_RecomputeBaselineMemoryCmd(const CS_RecomputeBaselineMemoryCmd_t
     /* command verification variables */
     CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
     CFE_ES_TaskId_t                    ChildTaskID  = CFE_ES_TASKID_UNDEFINED;
-    CFE_Status_t                       Status       = CS_ERROR;
+    CFE_Status_t                       Status;
     uint16                             EntryID      = 0;
-    CS_ChecksumState_Enum_t            State        = CS_ChecksumState_EMPTY;
+    CS_ChecksumState_Enum_t            State;
 
     EntryID = CmdPtr->Payload.EntryID;
 
@@ -253,8 +253,8 @@ CFE_Status_t CS_EnableEntryIDMemoryCmd(const CS_EnableEntryIDMemoryCmd_t *CmdPtr
     CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
     CS_Def_EepromMemory_Table_Entry_t *DefEntry     = NULL;
     CS_TableWrapper_t                 *tw           = &CS_AppData.Tbl[CS_ChecksumType_MEMORY_TABLE];
-    uint16                             EntryID      = 0;
-    CS_ChecksumState_Enum_t            State        = CS_ChecksumState_EMPTY;
+    uint16                             EntryID;
+    CS_ChecksumState_Enum_t            State;
 
     if (CS_CheckRecomputeOneshot() == false)
     {
@@ -318,8 +318,8 @@ CFE_Status_t CS_DisableEntryIDMemoryCmd(const CS_DisableEntryIDMemoryCmd_t *CmdP
     CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
     CS_Def_EepromMemory_Table_Entry_t *DefEntry     = NULL;
     CS_TableWrapper_t                 *tw           = &CS_AppData.Tbl[CS_ChecksumType_MEMORY_TABLE];
-    uint16                             EntryID      = 0;
-    CS_ChecksumState_Enum_t            State        = CS_ChecksumState_EMPTY;
+    uint16                             EntryID;
+    CS_ChecksumState_Enum_t            State;
 
     if (CS_CheckRecomputeOneshot() == false)
     {

--- a/fsw/src/cs_memory_cmds.c
+++ b/fsw/src/cs_memory_cmds.c
@@ -99,8 +99,8 @@ CFE_Status_t CS_ReportBaselineEntryIDMemoryCmd(const CS_ReportBaselineEntryIDMem
     /* command verification variables */
     CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
     uint32                             Baseline;
-    uint16                             EntryID      = 0;
-    CS_ChecksumState_Enum_t            State        = CS_ChecksumState_EMPTY;
+    uint16                             EntryID = 0;
+    CS_ChecksumState_Enum_t            State   = CS_ChecksumState_EMPTY;
 
     EntryID      = CmdPtr->Payload.EntryID;
     ResultsEntry = CS_GetMemoryResEntry(EntryID);
@@ -160,7 +160,7 @@ CFE_Status_t CS_RecomputeBaselineMemoryCmd(const CS_RecomputeBaselineMemoryCmd_t
     CS_Res_EepromMemory_Table_Entry_t *ResultsEntry = NULL;
     CFE_ES_TaskId_t                    ChildTaskID  = CFE_ES_TASKID_UNDEFINED;
     CFE_Status_t                       Status;
-    uint16                             EntryID      = 0;
+    uint16                             EntryID = 0;
     CS_ChecksumState_Enum_t            State;
 
     EntryID = CmdPtr->Payload.EntryID;

--- a/fsw/src/cs_table_processing.c
+++ b/fsw/src/cs_table_processing.c
@@ -616,8 +616,8 @@ void CS_ProcessNewTablesDefinitionTable(CS_TableWrapper_t *tw)
     uint16                             NumRegionsInTable = 0;
     CS_ChecksumState_Enum_t            PreviousState     = CS_ChecksumState_EMPTY;
     CFE_ES_AppId_t                     AppID             = CFE_ES_APPID_UNDEFINED;
-    CFE_TBL_Handle_t                   TableHandle       = CFE_TBL_BAD_TABLE_HANDLE;
-    bool                               Owned             = false;
+    CFE_TBL_Handle_t                   TableHandle;
+    bool                               Owned;
     char                               AppName[OS_MAX_API_NAME];
     char                               TableAppName[OS_MAX_API_NAME];
     char                               TableTableName[CFE_MISSION_TBL_MAX_NAME_LENGTH];
@@ -905,7 +905,7 @@ CFE_Status_t CS_HandleTableUpdate(CS_TableWrapper_t *tw)
     CFE_Status_t ManageResult2  = CFE_SUCCESS;
     CFE_Status_t GetResult2     = CFE_SUCCESS;
     CFE_Status_t Result         = CFE_SUCCESS;
-    int32        Loop           = 0;
+    int32        Loop;
 
     CFE_TBL_Handle_t             LocalHandle;
     CS_Res_Tables_Table_Entry_t *ResTablesTblPtr;

--- a/fsw/src/cs_utils.c
+++ b/fsw/src/cs_utils.c
@@ -87,7 +87,7 @@ bool CS_CheckResTableNameMatch(const char *Name, uint16 TableId)
  *-----------------------------------------------------------------*/
 void *CS_GetDefEntryAddr(CS_TableWrapper_t *tw, uint16 EntryId)
 {
-    uint8 *EntryAddr = tw->DefAddr;
+    uint8 *EntryAddr;
 
     if (tw->DefAddr != NULL && EntryId < tw->NumEntries)
     {
@@ -1085,7 +1085,7 @@ void CS_ResetTablesTblResultEntry(CS_Res_Tables_Table_Entry_t *TablesTblResultEn
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 CFE_Status_t CS_HandleRoutineTableUpdates(void)
 {
-    CFE_Status_t       Result = CFE_SUCCESS;
+    CFE_Status_t       Result;
     uint16             TableId;
     CS_TableWrapper_t *tw;
     bool               ShouldProcess;


### PR DESCRIPTION
Fixes #144.

Remove 24 overwritten initializations and assignments across checksum commands, table processing, compute routines, and utilities. Retain initialization required by error paths and checksum accumulation. No API, telemetry, command, or intended runtime behavior changes.

### Validation

Debian 12 arm64, GCC 12.2, native cFE/OSAL configuration with EDS disabled:
- All 11 application coverage targets passed, repeated 20 times: 385 cases and 2,401 assertions per suite run.
- Cppcheck 2.10 redundant/unread-store findings: 24 before, zero after. Other scope/naming style suggestions are outside this change. CodeSonar/Axle were not available locally.
- Clang 14 static analysis reported no diagnostics after the change.
- All 11 optimized flight-source objects are byte-for-byte identical to the baseline with GCC `-O2 -g0 -fno-ident`; the build also enables uninitialized-variable warnings as errors.
- Flight application built; changed lines formatted using the cFS configuration; `git diff --check` passed.

Existing tests are unchanged because this removes dead stores without adding behavior. Full mission/COSMOS and hardware tests were not run.

Contributor: Sylvester Kaczmarek, Personal. No third-party code added. Contributor License Agreement submission status is unverified.
